### PR TITLE
Assert what these tests claim to assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Ordered by what most changes daily use, not by what is easiest.
 ```sh
 pnpm install
 pnpm build       # tsc for the renderer; the bundle is transpiled
-pnpm test        # 105 tests, no terminal and no model required
+pnpm test        # 115 tests, no terminal and no model required
 pnpm typecheck   # needs a harness checkout — see below
 ```
 
@@ -251,7 +251,9 @@ CI runs the build and the full suite on Node 22 and 24. The `typecheck against t
 
 Rendered layout is verified against a real terminal. `packages/renderer/tests/rendered.spec.ts` feeds the renderer's output to `@xterm/headless` and asserts the rows a person actually sees — borders landing in one column for ASCII and CJK, a live region leaving no tail behind when it shrinks, styling surviving a wrapped row, and an escape sequence in tool output being shown rather than obeyed. Stripping escape sequences out of the byte stream cannot reconstruct a frame, because the redraw uses cursor positioning, which is why an emulator is the reference.
 
-These tests are hermetic — no pseudo-terminal, no harness, no model — so `pnpm test` runs them and CI covers layout without a separate job. Reading emulator output takes one piece of care: a wide character occupies two cells and `translateToString` skips the second, so rows are measured in columns rather than by string length.
+These tests are hermetic — no pseudo-terminal, no harness, no model — so `pnpm test` runs them and CI covers layout without a separate job.
+
+Reading emulator output takes care in two places. A wide character occupies two cells and `translateToString` skips the second, so rows are measured in columns rather than by string length. And text output carries neither cursor position nor cell attributes, so anything about the cursor is asserted through `emulator.cursor()` and anything about colour through `emulator.cell()` — a frame with a misplaced cursor or a colourless continuation row reads identically as text.
 
 ## License
 

--- a/packages/renderer/tests/emulator.ts
+++ b/packages/renderer/tests/emulator.ts
@@ -19,12 +19,45 @@ import type { ScreenTarget } from '../src/index.ts'
 // The package ships CommonJS, so ESM interop puts its exports on `default`.
 const { Terminal } = headless as unknown as { Terminal: new (options: object) => XtermLike }
 
+/** One rendered cell's content and attributes. */
+interface XtermCell {
+  getChars(): string
+  getFgColor(): number
+  isFgPalette(): boolean
+  isBold(): number
+}
+
 /** The slice of xterm's API these tests use. */
 interface XtermLike {
   readonly rows: number
-  readonly buffer: { active: { getLine(y: number): { translateToString(trim: boolean): string; isWrapped: boolean } | undefined } }
+  readonly buffer: {
+    active: {
+      readonly cursorX: number
+      readonly cursorY: number
+      getLine(y: number): {
+        translateToString(trim: boolean): string
+        getCell(x: number): XtermCell | undefined
+      } | undefined
+    }
+  }
   write(data: string, callback: () => void): void
   dispose(): void
+}
+
+/** Where the terminal left its cursor, in zero-based cells. */
+export interface CursorAt {
+  column: number
+  row: number
+}
+
+/** What a cell holds, for asserting styling rather than only characters. */
+export interface CellAt {
+  /** The character, or an empty string for the second half of a wide one. */
+  chars: string
+  /** Palette index when the cell carries a palette colour, or undefined. */
+  fg: number | undefined
+  /** Whether the cell is bold. */
+  bold: boolean
 }
 
 /** A terminal under test, plus the target the renderer writes through. */
@@ -35,6 +68,19 @@ export interface Emulator {
   flush(): Promise<void>
   /** Visible rows, trailing blank lines removed. */
   screen(): Promise<string[]>
+  /**
+   * Where the terminal put its cursor. Reading the buffer as text cannot show
+   * this, so a frame with a misplaced cursor looks identical to a correct one.
+   */
+  cursor(): Promise<CursorAt>
+  /**
+   * One cell's content and attributes. Text output carries no styling, so this is
+   * the only way to assert that a colour survived a wrap.
+   * @param column - zero-based cell column.
+   * @param row - zero-based cell row.
+   * @returns the cell, or undefined when the row or column does not exist.
+   */
+  cell(column: number, row: number): Promise<CellAt | undefined>
   /** Release the emulator. */
   dispose(): void
 }
@@ -72,6 +118,22 @@ export function createEmulator(columns: number, rows = 24): Emulator {
       }
       while (lines.length > 0 && lines.at(-1) === '') lines.pop()
       return lines
+    },
+    cursor: async () => {
+      await flush()
+      return { column: term.buffer.active.cursorX, row: term.buffer.active.cursorY }
+    },
+    cell: async (column, row) => {
+      await flush()
+      const cell = term.buffer.active.getLine(row)?.getCell(column)
+      if (cell === undefined) return undefined
+      return {
+        chars: cell.getChars(),
+        // A default foreground reports as not-a-palette-colour, which is a
+        // different fact from "some colour whose index happens to be zero".
+        fg: cell.isFgPalette() ? cell.getFgColor() : undefined,
+        bold: cell.isBold() !== 0,
+      }
     },
     dispose: () => { term.dispose() },
   }

--- a/packages/renderer/tests/rendered.spec.ts
+++ b/packages/renderer/tests/rendered.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { box, Composer, displayWidth, Screen, style } from '../src/index.ts'
+import { box, Composer, displayWidth, escapeControls, Screen, style } from '../src/index.ts'
 import { createEmulator } from './emulator.ts'
 
 /**
@@ -105,20 +105,52 @@ describe('rendered output', () => {
     const screen = new Screen(emulator.target)
     screen.setLive([style('aaaa bbbb', 'red')])
     expect(await emulator.screen()).toEqual(['aaaa', 'bbbb'])
+    // Read from cell attributes, not text: translateToString carries no styling,
+    // so a continuation row that lost its colour would look identical.
+    expect(await emulator.cell(0, 0)).toEqual({ chars: 'a', fg: 1, bold: false })
+    expect(await emulator.cell(0, 1)).toEqual({ chars: 'b', fg: 1, bold: false })
     emulator.dispose()
   })
 
-  it('places the cursor where the composer says it is', async () => {
+  it('leaves an unstyled row with no colour of its own', async () => {
+    const emulator = createEmulator(10)
+    const screen = new Screen(emulator.target)
+    screen.setLive(['plain'])
+    // The companion to the assertion above: without this, a helper that reported
+    // red for every cell would satisfy both.
+    expect(await emulator.cell(0, 0)).toEqual({ chars: 'p', fg: undefined, bold: false })
+    emulator.dispose()
+  })
+
+  it('places the terminal cursor over CJK by columns, not characters', async () => {
     const emulator = createEmulator(40)
     const screen = new Screen(emulator.target)
     const composer = new Composer()
     composer.set('标准模式')
     composer.handle({ kind: 'key', name: 'left' })
-    // Six columns of CJK precede the cursor, plus a two-column prompt.
-    screen.setLive([`› ${composer.value}`], { row: 0, column: 2 + composer.cursorColumn })
-    await emulator.flush()
+    // Three ideographs precede the cursor, so six columns, plus a two-column
+    // prompt: the terminal cursor must land at column 8, not at 5 characters.
     expect(composer.cursorColumn).toBe(6)
+    screen.setLive([`› ${composer.value}`], { row: 0, column: 2 + composer.cursorColumn })
     expect(await emulator.screen()).toEqual(['› 标准模式'])
+    expect(await emulator.cursor()).toEqual({ column: 8, row: 0 })
+    emulator.dispose()
+  })
+
+  it('places the cursor on the row the caller asked for', async () => {
+    const emulator = createEmulator(20)
+    const screen = new Screen(emulator.target)
+    screen.setLive(['first', 'second', 'third'], { row: 1, column: 3 })
+    expect(await emulator.cursor()).toEqual({ column: 3, row: 1 })
+    emulator.dispose()
+  })
+
+  it('leaves the cursor clear of the region when none is requested', async () => {
+    const emulator = createEmulator(20)
+    const screen = new Screen(emulator.target)
+    screen.setLive(['one', 'two'])
+    // No placement means the cursor ends where drawing stopped, on the last row.
+    expect(await emulator.cursor()).toEqual({ column: 3, row: 1 })
     emulator.dispose()
   })
 
@@ -142,12 +174,25 @@ describe('rendered output', () => {
     const emulator = createEmulator(40)
     const screen = new Screen(emulator.target)
     screen.commit(['before'])
-    // Untrusted text is escaped by the caller; this asserts the consequence —
-    // a clear-screen sequence in tool output leaves earlier rows intact.
-    screen.setLive(['^[[2J after'])
+    // A REAL clear-screen sequence, run through the production sanitizer, so the
+    // test fails if that sanitizing is ever removed. Writing the caret form
+    // directly would assert nothing.
+    const hostile = '\u001b[2J after'
+    screen.setLive([escapeControls(hostile)])
     const rows = await emulator.screen()
     expect(rows[0]).toBe('before')
-    expect(rows[1]).toContain('^[[2J after')
+    expect(rows[1]).toBe('^[[2J after')
+    emulator.dispose()
+  })
+
+  it('would lose earlier rows if that sanitizing were skipped', async () => {
+    const emulator = createEmulator(40)
+    const screen = new Screen(emulator.target)
+    screen.commit(['before'])
+    // The counter-case that gives the assertion above its meaning: the same bytes
+    // unsanitized do reach the terminal and do clear it.
+    screen.setLive(['\u001b[2J after'])
+    expect(await emulator.screen()).not.toContain('before')
     emulator.dispose()
   })
 

--- a/packages/renderer/tests/terminal.spec.ts
+++ b/packages/renderer/tests/terminal.spec.ts
@@ -35,6 +35,56 @@ describe('acquireTerminal()', () => {
     expect(() => acquireTerminal(streams(false, true))).toThrow(/requires a terminal/u)
   })
 
+  /** A fake stdin that records mode changes and starts in `initiallyRaw`. */
+  function fakeStreams(initiallyRaw: boolean) {
+    const log: string[] = []
+    let raw = initiallyRaw
+    const listeners = new Map<string, unknown>()
+    const input = {
+      isTTY: true,
+      get isRaw() { return raw },
+      setRawMode(value: boolean) {
+        raw = value
+        log.push(`raw:${String(value)}`)
+      },
+      setEncoding() { log.push('encoding') },
+      resume() { log.push('resume') },
+      pause() { log.push('pause') },
+      on(event: string, listener: unknown) { listeners.set(event, listener) },
+      off(event: string) { listeners.delete(event) },
+    } as unknown as NodeJS.ReadStream
+    const written: string[] = []
+    const output = {
+      isTTY: true,
+      columns: 80,
+      write(chunk: string) { written.push(chunk); return true },
+      on() {}, off() {},
+    } as unknown as NodeJS.WriteStream
+    return { input, output, log, listeners, written, isRaw: () => raw }
+  }
+
+  it('restores raw mode to TRUE when it was already raw before acquisition', () => {
+    // The case that matters and that a `setRawMode(false)` teardown gets wrong:
+    // this frontend may not be the first thing to have put the stream in raw mode,
+    // and clearing it would break whatever did.
+    const fake = fakeStreams(true)
+    const terminal = acquireTerminal({ input: fake.input, output: fake.output })
+    expect(fake.isRaw()).toBe(true)
+    terminal.close()
+    expect(fake.isRaw()).toBe(true)
+    expect(fake.log.filter(entry => entry === 'raw:false')).toEqual([])
+  })
+
+  it('enables bracketed paste and disables it again on close', () => {
+    // Without it a pasted newline is indistinguishable from a pressed one; leaving
+    // it enabled after exit changes how the user's shell behaves.
+    const fake = fakeStreams(false)
+    const terminal = acquireTerminal({ input: fake.input, output: fake.output })
+    expect(fake.written).toContain('\u001b[?2004h')
+    terminal.close()
+    expect(fake.written).toContain('\u001b[?2004l')
+  })
+
   it('restores the previous raw mode and releases the stream on close', () => {
     const log: string[] = []
     let raw = false

--- a/tools/link-harness.mjs
+++ b/tools/link-harness.mjs
@@ -44,9 +44,33 @@ if (argument === undefined || argument === '--help') {
 
 const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
 
+/**
+ * The declaration file a linked package must have emitted.
+ *
+ * A present `package.json` proves only that the directory is there. Typechecking
+ * reads declarations, and the harness emits those into `lib/types` during its own
+ * build — so an unbuilt checkout has every manifest and no types, which is
+ * exactly the state that made the old success message a lie.
+ * @param target - the resolved package directory.
+ * @returns the declaration path the package advertises, or undefined when it
+ *   advertises none.
+ */
+async function declarationOf(target) {
+  let manifestText
+  try {
+    manifestText = await readFile(join(target, 'package.json'), 'utf8')
+  } catch {
+    return undefined
+  }
+  const packaged = JSON.parse(manifestText)
+  const declared = packaged.types ?? packaged.exports?.['.']?.types
+  return typeof declared === 'string' ? join(target, declared) : undefined
+}
+
 if (argument === '--check') {
   const unlinked = []
-  const unresolved = []
+  const missing = []
+  const unbuilt = []
   const roots = new Set()
   for (const [name, subpath] of Object.entries(HARNESS_PATHS)) {
     const spec = manifest.devDependencies?.[name]
@@ -57,24 +81,34 @@ if (argument === '--check') {
     // A link: spec is relative to the package that declares it.
     const target = resolve(bundleDir, spec.slice('link:'.length))
     roots.add(target.slice(0, target.length - subpath.length - 1))
+    const declaration = await declarationOf(target)
+    if (declaration === undefined) {
+      missing.push(subpath)
+      continue
+    }
     try {
-      await access(join(target, 'package.json'))
+      await access(declaration)
     } catch {
-      unresolved.push(subpath)
+      unbuilt.push(subpath)
     }
   }
-  if (unlinked.length === 0 && unresolved.length === 0) {
-    process.stdout.write('harness links resolve; `pnpm typecheck` will work\n')
+  if (unlinked.length === 0 && missing.length === 0 && unbuilt.length === 0) {
+    process.stdout.write('harness links resolve and its declarations are built; `pnpm typecheck` will work\n')
     process.exit(0)
   }
   // Every entry normally shares one root, so report that once rather than
   // repeating the same directory ten times.
   for (const root of roots) process.stdout.write(`harness expected at ${root}\n`)
-  if (unresolved.length > 0) {
-    process.stdout.write(`  ${String(unresolved.length)} of ${String(Object.keys(HARNESS_PATHS).length)} packages missing there, starting with ${unresolved[0]}\n`)
+  const total = String(Object.keys(HARNESS_PATHS).length)
+  if (missing.length > 0) {
+    process.stdout.write(`  ${String(missing.length)} of ${total} packages are not there, starting with ${missing[0]}\n`)
+    process.stdout.write('  fix with: node tools/link-harness.mjs <path-to-deepseek-harness>\n')
+  }
+  if (unbuilt.length > 0) {
+    process.stdout.write(`  ${String(unbuilt.length)} of ${total} packages are present but unbuilt, starting with ${unbuilt[0]}\n`)
+    process.stdout.write('  fix by building the harness: pnpm install && pnpm run build, in that checkout\n')
   }
   for (const name of unlinked) process.stdout.write(`  ${name} is not linked at all\n`)
-  process.stdout.write('\nfix with: node tools/link-harness.mjs <path-to-deepseek-harness>\n')
   process.exit(1)
 }
 


### PR DESCRIPTION
Addresses the four Codex findings on #1. Every one was correct: the tests passed without proving their titles.

Each fix is **mutation-checked** — break the behaviour deliberately, confirm the test fails, restore. A test that cannot fail is worse than no test, because it reports safety that isn't there.

## Cursor placement was never asserted

`translateToString` does not expose the cursor, so a frame with the cursor in the wrong column read identically to a correct one; the test only validated the composer's arithmetic and unchanged row contents.

The emulator now reports cursor coordinates, and the CJK case asserts the terminal cursor lands at **column 8** — three ideographs plus a two-column prompt — rather than at 5 characters. Two more cases cover an explicit row and the no-placement default.

*Mutation:* shifting the emitted column by one fails three tests.

## Continuation-row styling was never asserted

Text output carries no cell attributes, so the row passing was fully compatible with it having lost its colour.

The emulator now reports a cell's foreground and weight. Added a companion assertion that an unstyled row has **no** colour of its own — without it, a helper that reported red for every cell would satisfy both.

*Mutation:* dropping the style reopening in `wrapToWidth` fails the cell assertion.

## The escape test fed a printable string

It passed `^[[2J` — the caret form, not an escape byte — so no control sequence ever reached the path under test, and the test would have passed with sanitizing removed entirely.

It now starts from a real escape byte and runs it through `escapeControls`, plus a counter-case proving the same bytes **unsanitized** do clear the screen. That counter-case is what gives the first assertion meaning.

## Teardown was only tested from a non-raw start

An implementation hardcoding `setRawMode(false)` passed, despite the test being titled after restoring the previous mode. The case that matters is acquisition while `input.isRaw` is already true — this frontend may not be the first thing to have put the stream in raw mode.

Added it, and bracketed-paste enable/disable while there.

*Mutation:* hardcoding `setRawMode(false)` fails the new case.

## `--check` lied about an unbuilt harness

It reported that `pnpm typecheck` would work whenever each linked directory held a `package.json` — which an unbuilt checkout does: every manifest, no declarations.

It now resolves the declaration each package advertises (`types` / `exports['.'].types`) and distinguishes **absent** from **present but unbuilt**, because the remedies differ — relink versus build that checkout:

```
harness expected at /path/to/deepseek-harness
  10 of 10 packages are present but unbuilt, starting with vendor/cordis
  fix by building the harness: pnpm install && pnpm run build, in that checkout
```

Verified against a staged checkout containing manifests and no `lib/`.

## Result

115 tests, build and typecheck clean. No production behaviour changes in this PR — it is entirely about the tests being able to fail.