### PR TITLE
Stop corrupting identifiers, and fix fence tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ Two packages, split so the drawing half never learns about agents:
 
 **Untrusted text is escaped before it reaches the terminal.** Everything a model, a tool, or a session log produces is untrusted for terminal purposes: an escape sequence in tool output could repaint the live region, and a carriage return could reposition the cursor. Such text passes through `escapeControls` and is shown in caret notation. Styling is a separate function, applied only to strings this frontend composes itself.
 
-**Markdown is rendered, and escaped as it is parsed.** Replies come back as headings, emphasis, inline and fenced code, lists, quotes, rules, and links — a deliberately small subset, hand-rolled in `packages/renderer/src/markdown.ts`, because a parser dependency would cost the property above. The ordering is the security rule: every span is escaped *before* styling is applied, never after. `escapeControls` neutralises the escape character itself, so running it over already-styled output would destroy the styling, and running it over only some spans would let a control sequence through everywhere else. A model can emit one in prose, in a heading, in a link target, or inside a fence, and each is covered.
+**Markdown is rendered, and escaped as it is parsed.** Replies come back as headings, emphasis, inline and fenced code, lists, quotes, rules, and links — a deliberately small subset, hand-rolled in `packages/renderer/src/markdown.ts`, because a parser dependency would cost the property above.
+
+Emphasis follows CommonMark's flanking rules, with one deliberate deviation. A delimiter followed by whitespace cannot open and one preceded by whitespace cannot close, so `2 * 3 * 4` stays arithmetic; underscores may not touch a word, so `snake_case_name` and `file_name.ts` stay intact. The deviation is that `__init__` is left literal rather than read as emphasis: in a reply about code that is a dunder far more often, and corrupting a name the reader may need to type costs more than losing emphasis. Multi-word `__bold text__` and single `_italic_` both still work.
+
+The ordering is the security rule: every span is escaped *before* styling is applied, never after. `escapeControls` neutralises the escape character itself, so running it over already-styled output would destroy the styling, and running it over only some spans would let a control sequence through everywhere else. A model can emit one in prose, in a heading, in a link target, or inside a fence, and each is covered.
 
 **Pasted input is untrusted too.** People paste logs, so a paste is the most likely source of terminal controls in the whole interface. Pasted content is sanitized at the point of insertion rather than at each place it is later measured or drawn: line endings normalize to `\n`, tabs expand to spaces because a tab's rendered width depends on tab stops the arithmetic cannot see, and remaining controls become caret notation. One representation in the buffer means every width, cursor, and draw calculation reads the same text the terminal receives.
 
@@ -223,7 +227,7 @@ Ordered by what most changes daily use, not by what is easiest.
 ```sh
 pnpm install
 pnpm build       # tsc for the renderer; the bundle is transpiled
-pnpm test        # 136 tests, no terminal and no model required
+pnpm test        # 149 tests, no terminal and no model required
 pnpm typecheck   # needs a harness checkout — see below
 ```
 

--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -24,16 +24,53 @@ const BULLETS = ['•', '◦', '‣'] as const
 /** Columns of indent per nesting level. */
 const INDENT = 2
 
-/** Inline patterns, tried in order. Earlier entries win over later ones. */
-const INLINE: readonly { pattern: RegExp; styles: readonly StyleName[]; group: number }[] = [
-  // Code first: its content is literal, so emphasis markers inside it are text.
-  { pattern: /^`([^`]+)`/u, styles: ['cyan'], group: 1 },
-  { pattern: /^\*\*([^*]+)\*\*/u, styles: ['bold'], group: 1 },
-  { pattern: /^__([^_]+)__/u, styles: ['bold'], group: 1 },
-  { pattern: /^\*([^*]+)\*/u, styles: ['italic'], group: 1 },
-  { pattern: /^_([^_]+)_/u, styles: ['italic'], group: 1 },
-  { pattern: /^~~([^~]+)~~/u, styles: ['dim'], group: 1 },
+/**
+ * One emphasis form: its delimiter, the styling it applies, and whether the
+ * delimiter is allowed to sit inside a word.
+ */
+interface Emphasis {
+  readonly delimiter: string
+  readonly styles: readonly StyleName[]
+  /**
+   * Whether the delimiter may open or close with a word character on the outside.
+   *
+   * False for `_` and `__`, following CommonMark: an underscore inside a word is
+   * part of the word. Without this rule `snake_case_name` renders as
+   * `snakecasename`, which silently corrupts identifiers, file paths, and
+   * environment variable names in a reply — and italic is invisible in several
+   * terminals, so the user sees only the damage.
+   */
+  readonly intraword: boolean
+  /**
+   * Whether content that reads as a single identifier vetoes this form.
+   *
+   * True only for `__`, and a deliberate deviation from CommonMark, which reads
+   * `__init__` as strong emphasis. In a reply about code that string is a Python
+   * dunder far more often, and the cost of guessing wrong is asymmetric:
+   * rendering it as `init` corrupts a name the reader may need to type, while
+   * leaving `__bold__` unstyled loses only emphasis. Multi-word `__bold text__`
+   * is unaffected, and single `_italic_` keeps CommonMark behaviour.
+   */
+  readonly vetoIdentifier?: true
+}
+
+/** Emphasis forms, longest delimiter first so `**` wins over `*`. */
+const EMPHASIS: readonly Emphasis[] = [
+  { delimiter: '**', styles: ['bold'], intraword: true },
+  { delimiter: '__', styles: ['bold'], intraword: false, vetoIdentifier: true },
+  { delimiter: '~~', styles: ['dim'], intraword: true },
+  { delimiter: '*', styles: ['italic'], intraword: true },
+  { delimiter: '_', styles: ['italic'], intraword: false },
 ]
+
+/** Inline code, whose content is literal — emphasis markers inside it are text. */
+const CODE_SPAN = /^(`+)([^`]+)\1/u
+
+/** A word character, for the intraword test. */
+const WORD = /[\p{L}\p{N}]/u
+
+/** Content that reads as one identifier rather than a phrase. */
+const IDENTIFIER = /^[\p{L}\p{N}_]+$/u
 
 /** A link, rendered as its text followed by the target. */
 const LINK = /^\[([^\]]+)\]\(([^)\s]+)\)/u
@@ -57,6 +94,9 @@ export function renderInline(source: string): string {
       plain = ''
     }
   }
+  /** The character just before the current position, for the flanking test. */
+  const previous = (): string => (rest.length < source.length ? source[source.length - rest.length - 1] ?? '' : '')
+
   while (rest !== '') {
     const link = LINK.exec(rest)
     if (link !== null && link[1] !== undefined && link[2] !== undefined) {
@@ -65,25 +105,85 @@ export function renderInline(source: string): string {
       rest = rest.slice(link[0].length)
       continue
     }
-    let matched = false
-    for (const { pattern, styles, group } of INLINE) {
-      const found = pattern.exec(rest)
-      const content = found?.[group]
-      if (found === undefined || found === null || content === undefined) continue
+
+    const code = CODE_SPAN.exec(rest)
+    if (code !== null && code[2] !== undefined) {
       flush()
-      // Escaped first, then styled: the escape is what makes the content safe,
-      // and applying it afterwards would strip the styling as well.
-      out += style(escapeControls(content), ...styles)
-      rest = rest.slice(found[0].length)
-      matched = true
-      break
+      out += style(escapeControls(code[2]), 'cyan')
+      rest = rest.slice(code[0].length)
+      continue
     }
-    if (matched) continue
+
+    const emphasis = matchEmphasis(rest, previous())
+    if (emphasis !== undefined) {
+      flush()
+      out += style(escapeControls(emphasis.content), ...emphasis.styles)
+      rest = rest.slice(emphasis.length)
+      continue
+    }
+
     plain += rest[0] ?? ''
     rest = rest.slice(1)
   }
   flush()
   return out
+}
+
+/** A matched emphasis run: what it contains, how it renders, how far it spans. */
+interface EmphasisMatch {
+  readonly content: string
+  readonly styles: readonly StyleName[]
+  readonly length: number
+}
+
+/**
+ * Match an emphasis run at the start of `rest`, or nothing.
+ *
+ * Delimiters must FLANK their content, which is what separates emphasis from
+ * arithmetic and identifiers. An opening run may not be followed by whitespace
+ * and a closing run may not be preceded by it, so `2 * 3 * 4` stays arithmetic;
+ * `_` additionally may not touch a word character on the outside, so
+ * `snake_case_name` stays an identifier.
+ * @param rest - the remaining line, positioned at a candidate delimiter.
+ * @param before - the character immediately before this position, or empty at the
+ *   line start.
+ * @returns the match, or undefined when no form applies here.
+ */
+function matchEmphasis(rest: string, before: string): EmphasisMatch | undefined {
+  for (const { delimiter, styles, intraword, vetoIdentifier } of EMPHASIS) {
+    if (!rest.startsWith(delimiter)) continue
+    // Never match part of a longer delimiter run. Without this, a rejected `__`
+    // lets the single `_` form consume one underscore of the pair and render
+    // `__init__` as `_init_` — mangled differently rather than left alone.
+    const marker = delimiter[0] ?? ''
+    if (before === marker) continue
+    if (rest[delimiter.length] === marker) continue
+    if (!intraword && before !== '' && WORD.test(before)) continue
+    const body = rest.slice(delimiter.length)
+    // An opener followed by whitespace is not an opener.
+    if (body === '' || /^\s/u.test(body)) continue
+    let search = 0
+    while (search >= 0) {
+      const close = body.indexOf(delimiter, search)
+      if (close <= 0) break
+      const content = body.slice(0, close)
+      const after = body[close + delimiter.length] ?? ''
+      // A closer preceded by whitespace is not a closer, and for `_` it may not
+      // touch a word either. Those are structural, so the scan moves on looking
+      // for the next candidate.
+      if (/\s$/u.test(content) || (!intraword && after !== '' && WORD.test(after))) {
+        search = close + 1
+        continue
+      }
+      // The identifier veto is different: this IS the closer CommonMark would
+      // pick, so the form is abandoned rather than searched past — continuing
+      // would find a distant closer and turn `__all__ and __name__` into
+      // `all__ and __name`.
+      if (vetoIdentifier === true && IDENTIFIER.test(content)) break
+      return { content, styles, length: delimiter.length * 2 + content.length }
+    }
+  }
+  return undefined
 }
 
 /** Heading styles by level; deeper headings are quieter. */
@@ -105,18 +205,26 @@ const HEADING_STYLES: readonly (readonly StyleName[])[] = [
  */
 export function renderMarkdown(source: string): string[] {
   const out: string[] = []
+  /** The opening fence run, kept whole so only an equal-or-longer run closes it. */
   let fence: string | undefined
   for (const line of source.split('\n')) {
-    const fenceMatch = /^\s*(`{3,}|~{3,})(.*)$/u.exec(line)
+    // At most three spaces of indent, per CommonMark: a deeper indent inside a
+    // block is content, not a fence.
+    const fenceMatch = /^ {0,3}(`{3,}|~{3,})(.*)$/u.exec(line)
     if (fenceMatch !== null) {
       const marker = fenceMatch[1] ?? ''
+      const info = (fenceMatch[2] ?? '').trim()
       if (fence === undefined) {
-        fence = marker[0]
-        const language = (fenceMatch[2] ?? '').trim()
-        if (language !== '') out.push(style(escapeControls(language), 'gray'))
+        fence = marker
+        if (info !== '') out.push(style(escapeControls(info), 'gray'))
         continue
       }
-      if (marker.startsWith(fence)) {
+      // A closer must use the same character, be at least as long, and carry no
+      // info string. Keeping only the character meant any run closed any block,
+      // so a three-backtick line inside a four-backtick block ended it early and
+      // inverted every block after it — which is exactly the shape a model
+      // produces when it shows fenced examples inside a fenced answer.
+      if (marker[0] === fence[0] && marker.length >= fence.length && info === '') {
         fence = undefined
         continue
       }

--- a/packages/renderer/tests/markdown.spec.ts
+++ b/packages/renderer/tests/markdown.spec.ts
@@ -77,6 +77,89 @@ describe('renderInline()', () => {
   })
 })
 
+describe('delimiter flanking', () => {
+  const inline = (source: string): string => stripAnsi(renderInline(source))
+
+  it('leaves snake_case identifiers intact', () => {
+    // Underscores inside a word are part of the word. Without this the reply
+    // reads "snakecasename" — and italic is invisible in several terminals, so
+    // the user sees only the damage, in a name they may need to type.
+    expect(inline('snake_case_name')).toBe('snake_case_name')
+    expect(inline('MY_CONST_NAME')).toBe('MY_CONST_NAME')
+    expect(inline('a_b_c')).toBe('a_b_c')
+    expect(inline('some_var and other_var')).toBe('some_var and other_var')
+  })
+
+  it('leaves file names intact', () => {
+    expect(inline('file_name.ts')).toBe('file_name.ts')
+    expect(inline('see src/my_module/index_test.py')).toBe('see src/my_module/index_test.py')
+  })
+
+  it('leaves dunder names intact', () => {
+    // A deliberate deviation: CommonMark reads __init__ as strong emphasis, but in
+    // a reply about code it is a Python dunder far more often.
+    expect(inline('__init__')).toBe('__init__')
+    expect(inline('__all__ and __name__')).toBe('__all__ and __name__')
+  })
+
+  it('leaves arithmetic intact', () => {
+    // A delimiter followed by whitespace cannot open emphasis.
+    expect(inline('2 * 3 * 4')).toBe('2 * 3 * 4')
+    expect(inline('5 ** 2')).toBe('5 ** 2')
+    expect(inline('a * b * c')).toBe('a * b * c')
+  })
+
+  it('still renders genuine emphasis', () => {
+    expect(inline('**bold**')).toBe('bold')
+    expect(inline('*italic*')).toBe('italic')
+    expect(inline('_italic_')).toBe('italic')
+    expect(inline('~~struck~~')).toBe('struck')
+    expect(inline('a **b c** d')).toBe('a b c d')
+  })
+
+  it('still renders multi-word double-underscore emphasis', () => {
+    // The dunder rule keys on the absence of whitespace, so real emphasis works.
+    expect(inline('__bold text__')).toBe('bold text')
+  })
+
+  it('allows intraword asterisk emphasis, which CommonMark permits', () => {
+    expect(inline('x*y*z')).toBe('xyz')
+  })
+
+  it('never matches part of a longer delimiter run', () => {
+    // A rejected `__` must not let the single `_` form eat one underscore of the
+    // pair. That produced `_init_` — mangled differently rather than left alone —
+    // so the assertion is that the text survives byte for byte.
+    expect(inline('__init__')).toBe('__init__')
+    expect(inline('***both***')).toBe('***both***')
+    // And nothing was styled, which an equality check on stripped text cannot see.
+    expect(renderInline('__init__')).toBe('__init__')
+  })
+})
+
+describe('fenced blocks', () => {
+  const fence = '```'
+  const longer = '````'
+
+  it('keeps a shorter fence inside a longer one as content', () => {
+    // The shape a model produces when showing fenced examples inside a fenced
+    // answer. Closing on the inner run inverted every block after it.
+    expect(plain([longer + 'md', 'before', fence, 'inside', fence, 'after', longer, 'outside'].join('\n')))
+      .toEqual(['md', '  before', '  ' + fence, '  inside', '  ' + fence, '  after', 'outside'])
+  })
+
+  it('does not let a closing fence carry an info string', () => {
+    expect(plain([fence + 'js', 'code', fence + 'python', 'still code', fence].join('\n')))
+      .toEqual(['js', '  code', '  ' + fence + 'python', '  still code'])
+  })
+
+  it('treats a deeply indented fence inside a block as content', () => {
+    // CommonMark allows at most three spaces of indent for a fence.
+    expect(plain([fence, '        ' + fence, 'still inside', fence].join('\n')))
+      .toEqual(['          ' + fence, '  still inside'])
+  })
+})
+
 describe('untrusted content', () => {
   it('neutralizes an escape sequence in prose', () => {
     // A model can emit a control sequence anywhere, not only inside code spans.

--- a/packages/renderer/tests/rendered.spec.ts
+++ b/packages/renderer/tests/rendered.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { box, Composer, displayWidth, escapeControls, Screen, style } from '../src/index.ts'
+import { box, Composer, displayWidth, escapeControls, renderMarkdown, Screen, style } from '../src/index.ts'
 import { createEmulator } from './emulator.ts'
 
 /**
@@ -193,6 +193,38 @@ describe('rendered output', () => {
     // unsanitized do reach the terminal and do clear it.
     screen.setLive(['\u001b[2J after'])
     expect(await emulator.screen()).not.toContain('before')
+    emulator.dispose()
+  })
+
+  it('renders a multi-line markdown reply with styling that survives the terminal', async () => {
+    const emulator = createEmulator(40)
+    const screen = new Screen(emulator.target)
+    const reply = ['# Setup', '', 'Run **build** then `test`.', '', '- first', '- second'].join('\n')
+    screen.commit(renderMarkdown(reply))
+    expect(await emulator.screen()).toEqual([
+      'Setup',
+      '',
+      'Run build then test.',
+      '',
+      '• first',
+      '• second',
+    ])
+    // Structure alone would pass with every attribute lost, so the heading's
+    // weight and the bullet glyph's colour are read from the cells.
+    expect(await emulator.cell(0, 0)).toEqual({ chars: 'S', fg: 6, bold: true })
+    expect((await emulator.cell(4, 2))?.bold).toBe(true)
+    expect((await emulator.cell(0, 4))?.fg).toBe(8)
+    // And prose between them carries no styling of its own.
+    expect(await emulator.cell(0, 2)).toEqual({ chars: 'R', fg: undefined, bold: false })
+    emulator.dispose()
+  })
+
+  it('keeps an identifier in a reply intact through the terminal', async () => {
+    const emulator = createEmulator(40)
+    const screen = new Screen(emulator.target)
+    screen.commit(renderMarkdown('Edit snake_case_name in file_name.ts'))
+    // The end-to-end form of the flanking rule: what the user can read and copy.
+    expect(await emulator.screen()).toEqual(['Edit snake_case_name in file_name.ts'])
     emulator.dispose()
   })
 

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -208,7 +208,12 @@ async function run(ctx: Context): Promise<void> {
     }
     // The assembled message is the committed form; clearing first keeps the
     // streamed copy from being drawn beneath the text it duplicates.
-    if (event.type === 'assistant/message') streaming = ''
+    //
+    // `turn/end` clears it too, and must: an aborted turn never reaches an
+    // `assistant/message` — the loop throws on the abort signal before appending
+    // one — so a reply interrupted with ctrl-c used to stay pinned above the
+    // composer for the rest of the session.
+    if (event.type === 'assistant/message' || event.type === 'turn/end') streaming = ''
     commit(projectEvent(event, terminal.columns()))
     draw()
   }), 'dsh-tui: transcript projection')


### PR DESCRIPTION
Step 1 of the roadmap. Three correctness defects, one severe for a coding tool. No new features.

## Emphasis destroyed identifiers

Verified by executing the built renderer before the fix:

```
snake_case_name → snakecasename        MY_CONST_NAME → MYCONSTNAME
file_name.ts    → filename.ts          __init__      → init
2 * 3 * 4       → 2  3  4
```

Every inline pattern was anchored and retried at each offset with no flanking rules, so an underscore inside a word opened emphasis and **both delimiters were deleted**. Italic is invisible in several terminals, so a reader saw only the damage — in names they may need to type. For a tool whose whole job is discussing code, this was the worst defect in the repo.

Emphasis now follows CommonMark flanking: a delimiter followed by whitespace cannot open, one preceded by whitespace cannot close, and `_`/`__` may not touch a word character. The roadmap named only the underscore case; the asterisk case was broken too but differently — CommonMark *permits* intraword `*` (so `x*y*z` is correct) while forbidding space-flanked delimiters, which is why `2 * 3 * 4` was wrong. One mechanism covers both.

A delimiter run is also never matched in part. Without that, a rejected `__` let the single `_` form eat one underscore of the pair and render `__init__` as `_init_` — mangled differently rather than left alone.

**One deliberate deviation from CommonMark**, documented in the code and README: `__init__` stays literal rather than becoming strong emphasis. In a reply about code that is a Python dunder far more often than emphasis, and the costs are asymmetric — corrupting a name the reader may need to type is worse than losing emphasis. Multi-word `__bold text__` and single `_italic_` are unaffected.

That veto had to *abandon* the form rather than search past the closer. My first attempt continued the scan, which found a distant closer and turned `__all__ and __name__` into `all__ and __name` — worse than the bug it replaced.

## Fences closed early and inverted everything after

`fence` stored only the first character of the opening run, so any run of three or more closed any block:

```
````md / before / ``` / inside / ``` / after / ```` / outside
→ ["md", "  before", "inside", "  after", "outside"]
```

`inside` escaped the block and was parsed as prose, the second inner fence re-opened, and prose after the block rendered as code. This is exactly the shape a model produces when showing fenced examples inside a fenced answer.

The full run is kept now, a closer must be at least as long, carry no info string, and fence indent is capped at three spaces — all per CommonMark. (A four-backtick run legitimately closing a three-backtick block is spec-correct and stays.)

## An interrupted reply stayed on screen forever

Not on the roadmap. `streaming` was cleared only on `assistant/message`, which an aborted turn never reaches — the loop throws on the abort signal before appending one. So after `ctrl-c` mid-reply, the orphaned partial text stayed pinned above the composer for the rest of the session. `turn/end` clears it too.

## Verification

149 tests, up from 136. The new ones cover identifiers, file names, dunders, arithmetic, genuine emphasis still working, delimiter runs, nested fences, closing-fence info strings, and fence indent.

Two are end-to-end through `@xterm/headless`, including one that asserts a rendered reply's **cell attributes** — heading weight and bullet colour — because structure alone would pass with every attribute lost. That is the markdown frame test the roadmap asked for.

Checked live in a pseudo-terminal: `Edit snake_case_name in file_name.ts` survives a rendered reply intact, and the live region comes back clean after an interrupt.