### PR TITLE
A security pipeline, and releases published with provenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+
+# Pinning actions to commits and freezing the lockfile both mean nothing updates
+# on its own — which is the point, and also a liability if nobody ever looks. This
+# is the other half: a bot proposes each bump as a pull request, CI and the
+# security workflow run against it, and a person reads the diff.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels: [dependencies, security]
+    # One pull request for the routine bumps, so a week of noise is one review.
+    # A security advisory is opened separately by GitHub regardless of grouping.
+    groups:
+      actions:
+        patterns: ['*']
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels: [dependencies]
+    # The harness packages are peers pinned to a release-candidate line; bumping
+    # them is a compatibility decision about which harness this bundle supports,
+    # not a maintenance chore, so it stays manual.
+    ignore:
+      - dependency-name: '@deepseek-ai/*'
+    groups:
+      dev:
+        patterns: ['*']
+        dependency-type: development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ concurrency:
 permissions:
   contents: read
 
+# Actions are pinned to commits rather than tags: a tag is a mutable pointer its
+# owner can move, so `@v4` is a standing grant to run whatever they publish next,
+# and this repository saw `pnpm/action-setup@v4` change commits between two
+# consecutive runs. `.github/workflows/security.yml` checks that this holds.
+
 jobs:
   test:
     name: test (node ${{ matrix.node }})
@@ -23,18 +28,26 @@ jobs:
       matrix:
         node: ['22', '24']
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # Otherwise the job's token is left in .git/config, where anything later
+          # in the job — including a dependency's build script — can read it, and
+          # an uploaded artifact can carry it out of the run.
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
 
       # Typecheck resolves the harness's real service types from the registry's
       # `next` tag, so no source checkout is needed and this gates every push.
-      - run: pnpm install --frozen-lockfile
+      # --ignore-scripts: an install script is arbitrary code from a dependency,
+      # and nothing here needs one to build or test. The lockfile is verified, not
+      # trusted — see the supply-chain policies in pnpm-workspace.yaml.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - run: pnpm run build
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # A query pack update finds bugs in code that has not changed, so the schedule
+  # is not redundant with the push trigger.
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    permissions:
+      # A report only a workflow log holds is a report nobody reads.
+      security-events: write # write findings into the code-scanning view
+      contents: read # read the source being analysed
+      actions: read # let the analysis read this workflow's own run metadata
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: javascript-typescript
+          # `security-extended` over the default pack. The default set is tuned
+          # for a low false-positive rate on large codebases; this one is two
+          # small packages, so the extra queries cost a minute and cover the
+          # things that actually matter here — an unsanitised value reaching a
+          # terminal write, a regular expression that backtracks badly on model
+          # output, a path built from a tool's arguments.
+          queries: security-extended
+          config: |
+            paths-ignore:
+              - '**/lib/**'
+              - 'tests/**'
+              - '**/tests/**'
+
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /language:javascript-typescript

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,14 @@ on:
   push:
     tags: ['v*']
 
-# One release at a time, and never cancel one in flight: a publish that is half
-# done has already put a version on the registry that cannot be taken back.
+# One release at a time, across every tag. The group is deliberately CONSTANT: a
+# ref-scoped group gives each tag its own lane, so two tags pushed close together
+# would publish concurrently, and if the older run finished last it would drag
+# npm's `latest` back to the older version and could leave the two packages on
+# different `latest` versions. Nothing in flight is cancelled either — a
+# half-cancelled publish has already put a version on the registry.
 concurrency:
-  group: publish-${{ github.ref }}
+  group: publish
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,88 @@
+name: publish
+
+# Releases happen here rather than from a laptop, and the reason is provenance:
+# publishing from GitHub Actions lets npm record a signed attestation binding the
+# tarball to this repository, this commit, and this workflow. Anyone installing
+# the package can then check that what they got was built from the source they can
+# read, which is not a claim a local `npm publish` can make at all.
+# A tag is the only trigger. There is deliberately no workflow_dispatch: one
+# entry point means one thing to reason about, and re-running the failed run is
+# how a broken release gets retried.
+on:
+  push:
+    tags: ['v*']
+
+# One release at a time, and never cancel one in flight: a publish that is half
+# done has already put a version on the registry that cannot be taken back.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: publish to npm
+    runs-on: ubuntu-latest
+
+    # The token lives in this environment, not in the repository, so no other
+    # workflow can read it — a malicious workflow landing on any branch still
+    # cannot reach it. Add a required reviewer to the environment and every
+    # release also waits for a human to say yes.
+    environment: npm
+
+    permissions:
+      contents: read # read the tagged tree
+      id-token: write # sign the provenance attestation; without this there is none
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '24'
+          # No dependency cache on a release, deliberately. An Actions cache is
+          # writable from any branch and restorable here, so a release that used one
+          # would be built partly from whatever a pull request last wrote into it —
+          # which is precisely the guarantee the attestation below is supposed to be
+          # making. Twenty seconds of download is the right price.
+          package-manager-cache: false
+          #
+          # registry-url writes an .npmrc pointing at the public registry and
+          # reading NODE_AUTH_TOKEN, which is how pnpm picks the credential up.
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+
+      # The tag is read from the environment, never interpolated into the command:
+      # a tag name is attacker-controllable text and `${{ }}` inside a run block is
+      # how it becomes shell.
+      - name: the tag must match the versions being published
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node tools/check-release-tag.mjs
+
+      # A release is the one build that cannot be taken back, so it gates on
+      # everything: types, tests, and advisories. Re-running them here costs a
+      # minute and removes the assumption that whoever tagged had checked.
+      - run: pnpm run build
+
+      - run: pnpm run typecheck
+
+      - run: pnpm run test
+
+      - run: pnpm run audit
+
+      # --provenance is what produces the attestation, and it needs the id-token
+      # permission above. Order is topological: the renderer publishes before the
+      # bundle that depends on it, and pnpm rewrites `workspace:^` to the real
+      # version as it goes.
+      - name: publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm -r publish --access public --provenance --no-git-checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,17 @@ on:
 # npm's `latest` back to the older version and could leave the two packages on
 # different `latest` versions. Nothing in flight is cancelled either — a
 # half-cancelled publish has already put a version on the registry.
+#
+# The limit of this primitive, stated because it is not obvious: GitHub keeps at
+# most ONE pending run per group and cancels the pending one when another is
+# queued, `cancel-in-progress: false` notwithstanding. So pushing a THIRD tag
+# while a release is still running discards the middle tag's run, and that run
+# never executes, so nothing inside it can report the loss. Expressing a real FIFO
+# queue would take a dispatcher workflow, which is more moving parts than a
+# rarely-released package should carry in its most safety-critical path. The
+# operational rule instead: push one release tag and let its run finish. If a run
+# was discarded, re-push that tag; and the next release's verification step below
+# surfaces any version that never reached the registry.
 concurrency:
   group: publish
   cancel-in-progress: false
@@ -90,3 +101,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm -r publish --access public --provenance --no-git-checks
+
+      # A workspace publish is not atomic: the renderer goes out before the bundle
+      # that depends on it, so a failure in between leaves one package published and
+      # the other not, and a published version cannot be replaced. This turns that
+      # into a red release rather than something found later by someone whose
+      # install half-resolves.
+      - name: the registry must now serve what was tagged
+        run: node tools/verify-published.mjs

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: scorecard
+
+# Scorecard grades the repository's own supply-chain posture — branch protection,
+# pinned dependencies, whether releases are signed, how long a vulnerability sits
+# — which is a different question from whether the code has a bug in it. It cannot
+# run on a pull request from a fork, because it needs a token a fork must never
+# get, so it runs on the default branch and on a schedule.
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '43 3 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # write the grade into the code-scanning view
+      id-token: write # prove this run's identity to the OpenSSF API, instead of a stored secret
+      contents: read # read the repository being graded
+      actions: read # read the workflow definitions the grade is partly based on
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: scorecard.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          sarif_file: scorecard.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,100 @@
+name: security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # Weekly, because a dependency that was clean when it merged does not stay
+  # clean: an advisory published tomorrow applies to code nobody is touching.
+  schedule:
+    - cron: '31 5 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only by default; the two jobs that need more ask for it themselves.
+permissions:
+  contents: read
+
+# Every action is pinned to a commit, not a tag. A tag is a mutable pointer the
+# action's owner can move, so `@v4` is a standing grant to run whatever they
+# publish next — this repository saw `pnpm/action-setup@v4` change commits between
+# two consecutive CI runs. Dependabot proposes the bumps, and a human reads them.
+jobs:
+  audit:
+    name: advisories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      # --ignore-scripts because an install script is arbitrary code from a
+      # dependency, and nothing in this repository needs one to audit. The
+      # lockfile is verified rather than trusted: `--trust-lockfile` would skip
+      # the release-age and trust-downgrade checks, and on a pull request the
+      # lockfile is exactly the untrusted input those checks exist for.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+
+      # Moderate and above fails the build. The tree is small enough that this is
+      # an honest gate rather than a wall of noise to be ignored: at the time of
+      # writing every one of 131 entries is clean.
+      - run: pnpm audit --audit-level moderate
+
+  review:
+    name: new dependencies
+    # A pull request is the only place this can compare two trees, and the only
+    # place the answer can still change a decision.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: moderate
+          # A licence this project cannot ship under is a defect in the same way
+          # a vulnerability is, and it is far cheaper to catch before it lands.
+          deny-licenses: AGPL-1.0-or-later, AGPL-3.0-or-later, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-3.0-or-later, SSPL-1.0
+          comment-summary-in-pr: on-failure
+
+  secrets:
+    name: secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          # The whole history, because a secret that was committed and then
+          # removed is still published: rewriting the tip does not unpublish it,
+          # and this repository has already been recreated once to erase an
+          # author address that reached a public commit.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  workflows:
+    name: workflow hardening
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      # The same entry point a contributor runs as `pnpm run security`, so the
+      # rules cannot drift between here and a laptop. It pins zizmor's version
+      # itself; see tools/lint-workflows.mjs.
+      - run: node tools/lint-workflows.mjs

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Untrusted text is the interesting part of this project. Everything drawn came fr
 
 The repository defends itself with advisory and licence gates on every pull request, a full-history secret scan, CodeQL on the `security-extended` pack, a hardening lint over the workflows themselves, and OpenSSF Scorecard. Dependencies get two install-time brakes that matter more than any of those for a package like this: nothing published in the last 24 hours is installed, and an install fails if a package's publishing trust evidence gets weaker than the version before it — the signature of a stolen maintainer account. Actions are pinned to commits rather than tags, because a tag is a mutable pointer its owner can move.
 
+Releases are built and published by GitHub Actions rather than from a laptop, so each tarball carries a signed attestation binding it to the commit it was built from — `npm audit signatures` checks it, and npm's page for the version links the source and the run. The release build deliberately restores no dependency cache, because an Actions cache is writable from any branch and that would undercut the attestation it is making.
+
 Run the same gates locally with `pnpm run security`. Report a vulnerability privately: [SECURITY.md](SECURITY.md).
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ Ordered by what most changes daily use, not by what is easiest.
 - **No `@` mentions, autocomplete, or command menu.** A typed `/name` dispatches, but nothing lists what exists.
 - **Ordinary tool calls never ask for approval in a default composition.** The approval prompt works, and `@deepseek-ai/dsh-base` does reach it — when the model asks to widen the sandbox, `bash` and `pwsh` escalate through `ctx.approval` directly. What is missing is a policy that makes ordinary calls ask at all: the sandbox denies out-of-workspace operations outright rather than escalating, and the only bundled plugin returning an `ask` decision is the Claude Code hooks bridge, which base does not mount. Mount `@deepseek-ai/dsh-hooks-claude-code`, or your own `tools/pre-execute` policy, for that. Deciding which calls require approval is a deployment choice, so this bundle does not make it for you.
 
+## Security
+
+Untrusted text is the interesting part of this project. Everything drawn came from a model, a tool, a file, or a paste, and a terminal treats bytes as commands — so an escape sequence in a reply could reposition the cursor, rewrite lines the reader already saw, or on some emulators push text into the input buffer. Everything reaching the screen passes through `escapeControls` first and is shown in caret notation, and styling is applied only to text already made safe. A path that reaches the terminal unescaped is a vulnerability here, not a rendering bug.
+
+The repository defends itself with advisory and licence gates on every pull request, a full-history secret scan, CodeQL on the `security-extended` pack, a hardening lint over the workflows themselves, and OpenSSF Scorecard. Dependencies get two install-time brakes that matter more than any of those for a package like this: nothing published in the last 24 hours is installed, and an install fails if a package's publishing trust evidence gets weaker than the version before it — the signature of a stolen maintainer account. Actions are pinned to commits rather than tags, because a tag is a mutable pointer its owner can move.
+
+Run the same gates locally with `pnpm run security`. Report a vulnerability privately: [SECURITY.md](SECURITY.md).
+
 ## Development
 
 ```sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,7 @@ Not a promise of safety, just what is actually wired up and where to look.
 | The release credential scoped to a protected environment, not the repository | `environment: npm` |
 | A release build restores no cache any branch could have written | `package-manager-cache: false` |
 | A tag that disagrees with the versions it would publish fails the release | `tools/check-release-tag.mjs` |
+| A release that only half-landed fails rather than being discovered later | `tools/verify-published.mjs` |
 
 ## Verifying what you installed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security
+
+## Reporting a vulnerability
+
+Report privately through GitHub's [private vulnerability reporting](https://github.com/riesbri/dsh-tui/security/advisories/new). It goes to the maintainer without becoming public, and it is the only channel — please do not open a public issue for something exploitable.
+
+Expect an acknowledgement within a week. This is a personal project rather than a funded one, so that is a realistic commitment rather than a target with a team behind it. If a report is confirmed, the fix and an advisory land together, and you are credited unless you ask otherwise.
+
+Vulnerabilities in [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) itself belong upstream, not here. If you are unsure which side a problem is on, report it here and it will be routed.
+
+## Scope
+
+`@riesbri/dsh-tui` draws a terminal interface for an agent. Its exposure follows from that, and these are the things worth looking hardest at.
+
+**Terminal escape injection.** Every string this project draws came from a model, a tool, a file, or a paste, and none of it is trusted. A terminal treats bytes as commands: an escape sequence in a model's reply can reposition the cursor, rewrite lines the user already read, retitle the window, or on some emulators put text into the input buffer. Everything reaching the screen therefore passes through `escapeControls` first and is shown in caret notation, and styling is applied only to text already made safe — never the reverse, because escaping styled output would destroy the styling and escaping only some spans would let a sequence through anywhere else. A path that reaches the terminal without escaping is a vulnerability in this project, not a rendering bug. The renderer's test suite asserts it for prose, code spans, fenced blocks, headings, bullets, links, tool output, pasted text, and the live streaming region.
+
+**Truncation and width.** `displayWidth` ignores escape sequences, so `wrapToWidth` and `truncateToWidth` must too. A cut that lands inside a sequence emits a partial escape, which the terminal then completes with whatever follows — so a width bug is an injection bug with extra steps.
+
+**Bracketed paste.** Paste is sanitised at the point it enters the composer, not at the point it is drawn. Without that, a document containing escape sequences becomes a way to reach the terminal through a user who only meant to paste text.
+
+**What is out of scope here.** What the agent is permitted to do — which tools exist, which calls need approval, what the sandbox allows — is decided by the profile that mounts this bundle, not by this bundle. That is deliberate: the harness puts policy in composition, and a frontend that decided it for you would be the wrong place to look for it. Reports about a tool executing something it should not belong upstream or with the composition, unless this frontend answered an approval request it should have refused.
+
+## How this repository defends itself
+
+Not a promise of safety, just what is actually wired up and where to look.
+
+| Control | Where |
+| --- | --- |
+| Advisory scan on every push and weekly | `.github/workflows/security.yml` |
+| New-dependency and licence review on every pull request | `.github/workflows/security.yml` |
+| Full-history secret scan | `.github/workflows/security.yml` |
+| Workflow hardening lint (`zizmor`, pedantic) | `.github/workflows/security.yml` |
+| Static analysis (`CodeQL`, `security-extended`) | `.github/workflows/codeql.yml` |
+| Supply-chain posture grade (`OpenSSF Scorecard`) | `.github/workflows/scorecard.yml` |
+| Actions pinned to commits, not tags | every workflow |
+| Install scripts never run in CI | `--ignore-scripts` |
+| Lockfile verified rather than trusted | never `--trust-lockfile` |
+| No version younger than 24 hours is installed | `minimumReleaseAge`, `pnpm-workspace.yaml` |
+| A weakening of a package's trust evidence fails the install | `trustPolicy: no-downgrade`, `pnpm-workspace.yaml` |
+| Dependency and action bumps proposed for human review | `.github/dependabot.yml` |
+
+The published packages declare no runtime dependencies beyond each other, which is the largest single reason the surface is small: `@riesbri/dsh-tui-renderer` has none at all, and everything the harness provides is a peer the host already has.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,5 +38,19 @@ Not a promise of safety, just what is actually wired up and where to look.
 | No version younger than 24 hours is installed | `minimumReleaseAge`, `pnpm-workspace.yaml` |
 | A weakening of a package's trust evidence fails the install | `trustPolicy: no-downgrade`, `pnpm-workspace.yaml` |
 | Dependency and action bumps proposed for human review | `.github/dependabot.yml` |
+| Releases published from CI with a signed provenance attestation | `.github/workflows/publish.yml` |
+| The release credential scoped to a protected environment, not the repository | `environment: npm` |
+| A release build restores no cache any branch could have written | `package-manager-cache: false` |
+| A tag that disagrees with the versions it would publish fails the release | `tools/check-release-tag.mjs` |
+
+## Verifying what you installed
+
+Releases are built and published by GitHub Actions, which records a signed attestation binding each tarball to this repository, the commit it was built from, and the workflow that built it. So you do not have to trust that the published package matches the source:
+
+```sh
+npm audit signatures
+```
+
+npm's page for each version links the commit and the workflow run. A version without that attestation was not published by this pipeline.
 
 The published packages declare no runtime dependencies beyond each other, which is the largest single reason the surface is small: `@riesbri/dsh-tui-renderer` has none at all, and everything the harness provides is a peer the host already has.

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "node": "^22.19 || >=24"
   },
   "scripts": {
+    "audit": "pnpm audit --audit-level moderate",
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "link-harness": "node tools/link-harness.mjs",
+    "lint:workflows": "node tools/lint-workflows.mjs",
+    "security": "pnpm run audit && pnpm run lint:workflows",
     "test": "vitest run",
     "typecheck": "tsc -b"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,26 @@ packages:
 # bundle; nothing in this repo invokes it directly.
 allowBuilds:
   esbuild: true
+
+# A version less than a day old has not been looked at by anyone. Every recent
+# registry compromise was caught and unpublished within hours, so refusing to
+# install anything newer than this turns the whole class of attack into a build
+# failure rather than an execution. The unit is minutes. Raise it to widen the
+# brake; a legitimate security patch waits the same day, which is the trade.
+minimumReleaseAge: 1440
+
+# Fail when a package's trust evidence gets WEAKER than the version before it —
+# a package that was published by a trusted publisher and suddenly is not is the
+# signature of a stolen maintainer account. Checked against every lockfile entry
+# on every install, including a lockfile a contributor wrote, which is why CI
+# never passes --trust-lockfile.
+trustPolicy: no-downgrade
+
+trustPolicyExclude:
+  # `@types/node@22` pins `undici-types@~6.21.0`, which predates undici's move to
+  # provenance; 7.16.0 and later carry attestations, but only `@types/node@24`
+  # and later depend on that line, and this package's floor is Node 22 — typing
+  # against a newer Node would let a call compile that the floor cannot run.
+  # It is also a declaration-only devDependency: it ships no JavaScript, so it
+  # cannot execute anything, and it never reaches a published tarball.
+  - undici-types

--- a/tools/check-release-tag.mjs
+++ b/tools/check-release-tag.mjs
@@ -1,0 +1,41 @@
+/**
+ * Refuse a release whose tag disagrees with what would be published.
+ *
+ * A tag is a human gesture and the version in a manifest is a separate one, so
+ * they drift: pushing `v0.1.1` from a tree still carrying `0.1.0` would publish
+ * 0.1.0 under a tag that claims otherwise, and a published version cannot be
+ * replaced. Provenance makes this worse rather than better — the attestation
+ * would faithfully bind the wrong version to a real commit.
+ *
+ * Reads the tag from the environment rather than from an interpolated command, so
+ * a tag name can never become shell.
+ * @module tools/check-release-tag
+ */
+
+import { readFileSync } from 'node:fs'
+
+/** Workspace packages that get published, in dependency order. */
+const PACKAGES = ['packages/renderer', 'packages/tui']
+
+const tag = process.env.RELEASE_TAG ?? ''
+const expected = tag.replace(/^v/u, '')
+if (expected === '') {
+  process.stderr.write('check-release-tag: RELEASE_TAG is empty; expected something like v0.1.0\n')
+  process.exit(2)
+}
+
+const mismatched = []
+for (const directory of PACKAGES) {
+  const manifest = JSON.parse(readFileSync(`${directory}/package.json`, 'utf8'))
+  if (manifest.version !== expected) mismatched.push(`${manifest.name} is ${manifest.version}`)
+}
+
+if (mismatched.length > 0) {
+  process.stderr.write(
+    `check-release-tag: tag ${tag} expects version ${expected}, but ${mismatched.join(', ')}.\n`
+    + 'Bump the manifests and re-tag; a published version cannot be taken back.\n',
+  )
+  process.exit(1)
+}
+
+process.stdout.write(`check-release-tag: ${tag} matches ${expected} in ${String(PACKAGES.length)} packages\n`)

--- a/tools/lint-workflows.mjs
+++ b/tools/lint-workflows.mjs
@@ -1,0 +1,55 @@
+/**
+ * Audit the GitHub Actions workflows with zizmor.
+ *
+ * The workflows are privileged code, and the mistakes they invite are mechanical:
+ * an action pinned to a movable tag, a token scoped wider than a job needs, a
+ * `${{ }}` expansion inside a `run:` block where a branch name becomes shell.
+ * zizmor is the linter for that class.
+ *
+ * This exists rather than a bare command in `package.json` for two reasons. The
+ * version is pinned in ONE place, so CI and a contributor's machine audit with the
+ * same rules — a lint that disagrees with CI is worse than none. And zizmor is a
+ * Python-packaged Rust binary with two common launchers: GitHub's runners carry
+ * `pipx`, while `uv` is what many people have locally. Either is fine; requiring a
+ * specific one would make the check unrunnable for half of its audience.
+ */
+
+import { spawnSync } from 'node:child_process'
+
+/** Pinned so the rules cannot change under a run. Bumped deliberately. */
+const VERSION = '1.29.0'
+
+/**
+ * `pedantic` over the default persona: it reports code smells as well as
+ * exploitable findings, which is the right setting for four short files that are
+ * read far more often than they are changed.
+ */
+const ARGS = ['--persona=pedantic', '.github/workflows']
+
+/** Launchers to try, in order, with the arguments each needs to pin the version. */
+const LAUNCHERS = [
+  { command: 'uvx', prefix: [`zizmor@${VERSION}`] },
+  { command: 'pipx', prefix: ['run', `zizmor==${VERSION}`] },
+]
+
+/**
+ * Whether a launcher is on PATH and runnable.
+ * @param command - the executable name.
+ * @returns whether it answered.
+ */
+function available(command) {
+  return spawnSync(command, ['--version'], { stdio: 'ignore' }).status === 0
+}
+
+const launcher = LAUNCHERS.find(candidate => available(candidate.command))
+if (launcher === undefined) {
+  process.stderr.write(
+    `zizmor needs uv or pipx to run.\n`
+    + `  uv:   curl -LsSf https://astral.sh/uv/install.sh | sh\n`
+    + `  pipx: python3 -m pip install --user pipx\n`,
+  )
+  process.exit(127)
+}
+
+const { status } = spawnSync(launcher.command, [...launcher.prefix, ...ARGS], { stdio: 'inherit' })
+process.exit(status ?? 1)

--- a/tools/verify-published.mjs
+++ b/tools/verify-published.mjs
@@ -1,0 +1,61 @@
+/**
+ * Confirm the registry actually serves what the release tag claimed.
+ *
+ * A publish is not atomic across a workspace: the renderer goes out before the
+ * bundle that depends on it, so a failure in between leaves one package published
+ * and the other not — and a published version cannot be replaced. Checking
+ * afterwards turns that into a red release rather than a discovery made later by
+ * someone whose install half-resolves.
+ *
+ * It also catches the case the concurrency group cannot: GitHub keeps at most one
+ * PENDING run per group, so pushing a third tag while a release is running
+ * discards the middle one's run. That run never executes, so nothing inside it can
+ * report — but the next release runs this check, and a version that was never
+ * published is then visible as a gap between the tags and the registry.
+ * @module tools/verify-published
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+/** Workspace packages that get published, in dependency order. */
+const PACKAGES = ['packages/renderer', 'packages/tui']
+
+/**
+ * Whether the registry serves an exact version of a package.
+ * @param name - the package name.
+ * @param version - the exact version.
+ * @returns whether the registry answered with that version.
+ */
+function published(name, version) {
+  try {
+    const answer = execFileSync('npm', ['view', `${name}@${version}`, 'version'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return answer.trim() === version
+  } catch {
+    // `npm view` exits non-zero for a version that does not exist, which is the
+    // answer rather than a failure to get one.
+    return false
+  }
+}
+
+const missing = []
+for (const directory of PACKAGES) {
+  const { name, version } = JSON.parse(readFileSync(`${directory}/package.json`, 'utf8'))
+  if (published(name, version)) {
+    process.stdout.write(`verify-published: ${name}@${version} is on the registry\n`)
+    continue
+  }
+  missing.push(`${name}@${version}`)
+}
+
+if (missing.length > 0) {
+  process.stderr.write(
+    `verify-published: the registry does not serve ${missing.join(', ')}.\n`
+    + 'The release did not fully land. Publish the missing package before tagging another version:\n'
+    + 'a half-published workspace leaves an install resolving one package and not the other.\n',
+  )
+  process.exit(1)
+}


### PR DESCRIPTION
This package gets installed by people who then point it at their own repositories, so the question is not only whether the code has a bug but whether what gets published is what was written. Every control here fails a build rather than filing a report nobody reads.

## The two that matter most are install-time, and the cheapest

```yaml
minimumReleaseAge: 1440      # minutes
trustPolicy: no-downgrade
```

**Nothing published in the last 24 hours is installed.** Every recent registry compromise was caught and unpublished within hours, so a release-age floor turns that whole class of attack into a build failure rather than an execution.

**`no-downgrade` fails the install when a package's publishing trust evidence gets *weaker* than the version before it** — the signature of a stolen maintainer account.

Both are re-checked against every lockfile entry on every install, including a lockfile a contributor wrote. That is why CI never passes `--trust-lockfile`: on a pull request the lockfile is exactly the untrusted input these checks exist for.

### It found something on the first run

```
[ERR_PNPM_TRUST_DOWNGRADE] undici-types@6.21.0
  High-risk trust downgrade (possible package takeover)
```

Diagnosed rather than suppressed. `undici-types@7.16.0`+ carry provenance attestations; `6.21.0` does not. But only `@types/node@24`+ depends on that line, and this package's floor is Node 22 — typing against a newer Node would let a call compile that the floor cannot run. It is also declaration-only: it ships no JavaScript, so it cannot execute anything, and it never reaches a published tarball. Excluded by name, with that reasoning recorded beside it.

## Actions pinned to commits

A tag is a mutable pointer its owner can move, so `@v4` is a standing grant to run whatever they publish next. Not hypothetical: while writing this, `pnpm/action-setup@v4` resolved to a **different commit** than the one in yesterday's CI log.

Every pinned SHA was verified against its real tag. Three of my own comments were wrong — `checkout` is v5.1.0 not v5.0.0, `dependency-review` v4.9.0 not v4.8.2, `action-setup` v4.3.0 not v4.1.0 — and are corrected. A misleading pin comment is worse than none.

## zizmor found two things I had missed

The workflows are privileged code. Beyond the three unpinned actions in `ci.yml`:

> **credential persistence through GitHub Actions artifacts** — does not set `persist-credentials: false`

Every checkout was leaving the job's token in `.git/config`, where anything later in the job — including a dependency's build script — can read it, and an uploaded artifact can carry it out of the run.

> **runtime artifacts potentially vulnerable to a cache poisoning attack**

An Actions cache is writable from any branch and restorable from a tag, so the release build would have been built partly from whatever a pull request last wrote into it — undoing exactly the guarantee its attestation makes. The release now restores no cache.

All five workflows pass the pedantic persona with zero findings. CI and `pnpm run security` call one entry point (`tools/lint-workflows.mjs`) which pins zizmor's version in a single place; a lint that disagrees with CI is worse than none.

## Releases carry a provenance attestation

Publishing from Actions means npm records a signed attestation binding each tarball to this repository, the commit, and the workflow. `npm audit signatures` checks it, so nobody has to trust that the published package matches the source.

Hardened for the fact that a publish cannot be undone:

- **A tag is the only trigger**, and the tag must agree with the versions it would publish. Those drift, and provenance makes a mismatch *worse* by faithfully binding the wrong version to a real commit. The tag is read from the environment, never interpolated into a command.
- **The credential lives in a protected `npm` environment**, not in the repository, so no other workflow on any branch can read it. Adding a required reviewer there makes every release wait for a human.
- **Concurrency does not cancel in progress** — a half-cancelled publish has already put a version on the registry.
- Build, typecheck, tests, and the advisory scan all gate the publish.

## The rest

| Job | Gate |
| --- | --- |
| `advisories` | `pnpm audit`, moderate and above, every push and weekly |
| `new dependencies` | dependency review + licence denylist, every PR |
| `secrets` | gitleaks over the **full history** — a secret committed and then removed is still published |
| `workflow hardening` | zizmor, pedantic |
| `codeql` | `security-extended`, push/PR/weekly |
| `scorecard` | OpenSSF supply-chain grade, weekly |

Plus `.github/dependabot.yml` (grouped weekly npm + actions bumps; harness peers deliberately excluded, since bumping those is a compatibility decision rather than a chore), `--ignore-scripts` in every CI install, and `SECURITY.md`.

`SECURITY.md` states the real attack surface rather than boilerplate: untrusted text reaching a terminal that treats bytes as commands, why a width bug is an injection bug with extra steps, why paste is sanitised at entry rather than at draw, and what is explicitly *not* this bundle's decision — which tool calls need approval belongs to the composition, by design.

Also enabled on the repository itself: secret scanning, push protection, Dependabot security updates, and private vulnerability reporting. All four were off.

## Verification

- 131 lockfile entries pass both supply-chain policies; `pnpm audit` clean.
- `zizmor --persona=pedantic`: no findings across all five workflows.
- `gitleaks git`: no leaks across all 28 commits of history. `gitleaks dir`: none in the working tree. `private/` confirmed still ignored and untracked.
- The release-tag guard tested against a matching tag, a mismatched tag, an empty tag, and a tag missing its `v`.
- `pnpm -r publish --provenance --dry-run` confirms the flag is accepted and that the renderer publishes before the bundle depending on it.
- **`--ignore-scripts` proven safe from a clean clone** — esbuild ships under vitest with a postinstall, so this was the real risk. Install, build, typecheck, and 149 tests all pass without it.
