### PR TITLE
A context-pressure bar, and a status line that degrades instead of truncating

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Two packages, split so the drawing half never learns about agents:
 
 `ctrl-o` cycles how much of a card is drawn: `compact`, `full`, `hidden`. `hidden` still draws the call, and still shows a non-zero exit, because a transcript that omitted them would lie about what ran.
 
+**The status line degrades instead of truncating.** Context pressure shows as a bar beside the reading — `██████░░ 6.2k/8.0k` — but only once a cell would actually fill. A DeepSeek window is a million tokens, so a linear bar reads as empty for every session anyone really has, and an always-empty bar spends columns to say nothing; a non-linear one would fill sooner and lie about proportion. As the terminal narrows, hints drop whole rather than being cut in half, and the model name goes before the pressure reading does, because the model does not change during a session and the reading does.
+
 **Reasoning is shown while it happens.** Reasoning models emit `reasoning-delta` chunks for as long as they think, which can be most of a turn. Those are rendered quietly above the answer, dimmed and italic, so the screen shows the model working rather than a spinner over an empty region.
 
 **The screen appends and redraws one region.** A chat transcript only grows, so the renderer owns no full-screen buffer. Finished output is written into the terminal's scroll buffer and never touched again; only the bottom live region — a streaming reply, a prompt, the composer — is redrawn in place. Scroll position is therefore never modelled and never reflowed on resize. The invariant that makes it correct: the live region is the last thing on screen, so every write goes through `Screen`.
@@ -240,7 +242,7 @@ Run the same gates locally with `pnpm run security`. Report a vulnerability priv
 ```sh
 pnpm install
 pnpm build       # tsc -b for both packages
-pnpm test        # 274 tests, no terminal and no model required
+pnpm test        # 293 tests, no terminal and no model required
 pnpm typecheck   # tsc -b, same graph
 pnpm security    # the advisory and workflow gates CI runs
 ```

--- a/packages/tui/src/views.ts
+++ b/packages/tui/src/views.ts
@@ -64,6 +64,13 @@ const MAX_COLUMNS = 100
 const COMPOSER_ROWS = 10
 
 
+/** Cells in the context-pressure bar. */
+const BAR_CELLS = 8
+
+/** Glyphs the bar is drawn from. */
+const BAR_FULL = '█'
+const BAR_EMPTY = '░'
+
 /** Context fill at which the pressure reading warns. */
 const PRESSURE_WARN = 0.7
 
@@ -206,6 +213,30 @@ function pressureStyle(tokens: number, window: number | undefined): StyleName {
 }
 
 /**
+ * A bar for context pressure, or nothing when a bar would say nothing.
+ *
+ * Withheld below one cell of fill, and that threshold is the whole design. A
+ * DeepSeek model's window is a million tokens, so a linear bar reads as completely
+ * empty for every session anyone actually has — 45k tokens is 4.5%, which rounds to
+ * no cells — and an always-empty bar spends columns to tell the reader nothing. It
+ * appears once there is something to see, which is also when a reader starts caring.
+ *
+ * A non-linear scale would fill it sooner and would be a lie about proportion, so
+ * the bar stays linear and stays absent instead.
+ * @param tokens - current pressure.
+ * @param window - the model's context window, when known.
+ * @returns the styled bar, or undefined when it would carry no information.
+ */
+function pressureBar(tokens: number, window: number | undefined): string | undefined {
+  if (window === undefined || window <= 0) return undefined
+  // Floored, not rounded: a bar that shows full at 94% overstates the one thing it
+  // exists to report.
+  const filled = Math.min(BAR_CELLS, Math.floor((tokens / window) * BAR_CELLS))
+  if (filled < 1) return undefined
+  return style(`${BAR_FULL.repeat(filled)}${BAR_EMPTY.repeat(BAR_CELLS - filled)}`, pressureStyle(tokens, window))
+}
+
+/**
  * The status line under the composer.
  * @param state - a getter for the current values, read at render time.
  * @returns the slot view.
@@ -214,26 +245,52 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
   return {
     render(columns) {
       const current = state()
-      const parts: string[] = []
+      const budget = Math.max(10, columns - 2)
+      const separator = style(' · ', 'gray')
+
+      // Facts first, in the order they matter. These are never dropped: a status
+      // line that hid whether a turn was running would be worse than a short one.
+      const facts: string[] = []
       if (current.busy) {
         const elapsed = current.elapsedMs === undefined ? '' : ` ${formatElapsed(current.elapsedMs)}`
-        parts.push(style(`${spinnerFrame(current.tick)} working${elapsed}`, 'yellow'))
+        facts.push(style(`${spinnerFrame(current.tick)} working${elapsed}`, 'yellow'))
       } else {
-        parts.push(`${style('●', 'green')}${style(' ready', 'dim')}`)
+        facts.push(`${style('●', 'green')}${style(' ready', 'dim')}`)
       }
-      if (current.model !== undefined) parts.push(style(current.model, 'dim'))
+      // Held apart from the other facts because it is the one that can be dropped.
+      const model = current.model === undefined ? undefined : style(current.model, 'dim')
       if (current.tokens !== undefined) {
         const window = current.contextWindow === undefined ? '' : `/${formatTokens(current.contextWindow)}`
-        parts.push(style(
+        const reading = style(
           `${formatTokens(current.tokens)}${window}`,
           pressureStyle(current.tokens, current.contextWindow),
-        ))
+        )
+        const bar = pressureBar(current.tokens, current.contextWindow)
+        facts.push(bar === undefined ? reading : `${bar} ${reading}`)
       }
-      // Only the non-default levels are reported: naming the default on every
-      // frame spends a column on a fact the user did not ask about.
-      if (current.detail !== 'compact') parts.push(style(`tools ${current.detail}`, 'yellow'))
-      parts.push(style(current.busy ? 'ctrl-c interrupt' : 'alt-enter newline · ctrl-o tool output · /model · ctrl-d quit', 'gray'))
-      return [`  ${truncateToWidth(parts.join(style(' · ', 'gray')), Math.max(10, columns - 2))}`]
+      // Only the non-default levels are reported: naming the default on every frame
+      // spends a column on a fact the user did not ask about.
+      if (current.detail !== 'compact') facts.push(style(`tools ${current.detail}`, 'yellow'))
+
+      // Hints are dropped WHOLE when the width runs out. Truncating the joined line
+      // instead cut one in half — `ctrl-d qui` — which reads as a rendering fault
+      // rather than as a hint. `/model` is absent because a slash command announces
+      // itself the moment one is typed.
+      const hints = current.busy
+        ? ['ctrl-c interrupt']
+        : ['alt-enter newline', 'ctrl-o output', 'ctrl-d quit']
+      // The model name is the longest fact and the least urgent: it does not change
+      // during a session, where the pressure reading does. Dropping it is what keeps
+      // the reading on a narrow terminal, which is where the reading matters most.
+      const withModel = [facts[0] ?? '', ...model === undefined ? [] : [model], ...facts.slice(1)]
+      let line = withModel.join(separator)
+      if (displayWidth(line) > budget) line = facts.join(separator)
+      for (const hint of hints) {
+        const extended = `${line}${separator}${style(hint, 'gray')}`
+        if (displayWidth(extended) > budget) break
+        line = extended
+      }
+      return [`  ${truncateToWidth(line, budget)}`]
     },
   }
 }

--- a/packages/tui/tests/views.spec.ts
+++ b/packages/tui/tests/views.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { Composer, displayWidth, Screen, stripAnsi } from '@riesbri/dsh-tui-renderer'
 import { createEmulator } from '../../../tests/emulator.ts'
-import { createComposerView } from '../src/views.ts'
+import type { StatusState } from '../src/views.ts'
+import { createComposerView, createStatusView } from '../src/views.ts'
 
 /** A terminal width whose inner content area is a round number of columns. */
 const COLUMNS = 40
@@ -181,5 +182,95 @@ describe('a composer taller than the terminal', () => {
     expect(rows.join('\n')).toContain('one')
     expect(rows.join('\n')).toContain('three')
     expect(rows[1]).not.toContain('rows')
+  })
+})
+
+describe('the status line', () => {
+  /**
+   * Render the status line and strip its styling.
+   * @param overrides - values to override on the default state.
+   * @param columns - the terminal width.
+   * @returns the line a person would see.
+   */
+  function status(overrides: Partial<StatusState> = {}, columns = 120): string {
+    const view = createStatusView(() => ({
+      busy: false,
+      tick: 0,
+      elapsedMs: undefined,
+      model: 'deepseek-v4-flash',
+      tokens: undefined,
+      contextWindow: undefined,
+      detail: 'compact',
+      ...overrides,
+    }))
+    return stripAnsi(view.render(columns)[0] ?? '')
+  }
+
+  it('draws a bar beside the reading once there is something to see', () => {
+    expect(status({ tokens: 6_200, contextWindow: 8_000 })).toContain('██████░░ 6.2k/8.0k')
+  })
+
+  it('withholds the bar when it would read as empty', () => {
+    // A DeepSeek window is a million tokens, so a linear bar is empty for every
+    // session anyone actually has: 45k is 4.5%, which is no cells at all. An
+    // always-empty bar spends columns to say nothing.
+    expect(status({ tokens: 45_000, contextWindow: 1_000_000 })).not.toContain('░')
+    expect(status({ tokens: 45_000, contextWindow: 1_000_000 })).toContain('45k/1.0M')
+  })
+
+  it('shows the bar once a cell would fill', () => {
+    expect(status({ tokens: 130_000, contextWindow: 1_000_000 })).toContain('█░░░░░░░')
+  })
+
+  it('floors the fill rather than rounding it', () => {
+    // A bar reading full at 94% overstates the one thing it exists to report.
+    expect(status({ tokens: 940_000, contextWindow: 1_000_000 })).toContain('███████░')
+    expect(status({ tokens: 1_000_000, contextWindow: 1_000_000 })).toContain('████████')
+  })
+
+  it('draws no bar when the window is unknown', () => {
+    expect(status({ tokens: 45_000 })).toContain('45k')
+    expect(status({ tokens: 45_000 })).not.toContain('░')
+  })
+
+  it('never exceeds the terminal, at any width', () => {
+    for (const columns of [20, 30, 40, 60, 80, 96, 120, 200]) {
+      const line = status({ tokens: 130_000, contextWindow: 1_000_000 }, columns)
+      expect(line.length, `${String(columns)} columns`).toBeLessThanOrEqual(columns)
+    }
+  })
+
+  it('drops a hint whole rather than cutting one in half', () => {
+    // Truncating the joined line produced `ctrl-d qui`, which reads as a rendering
+    // fault rather than as a hint.
+    const hints = ['alt-enter newline', 'ctrl-o output', 'ctrl-d quit']
+    for (const columns of [20, 30, 40, 60, 80, 96, 120]) {
+      const line = status({ tokens: 130_000, contextWindow: 1_000_000 }, columns)
+      // The last segment is where a cut would land, and it must be a whole hint or
+      // not a hint at all — never the beginning of one.
+      const last = line.split(' · ').at(-1) ?? ''
+      const partial = hints.find(hint => hint.startsWith(last) && hint !== last)
+      expect(partial, `${String(columns)} columns ended on ${JSON.stringify(last)}`).toBeUndefined()
+    }
+  })
+
+  it('keeps the pressure reading on a narrow terminal by dropping the model', () => {
+    // The model does not change during a session; the reading does.
+    const narrow = status({ tokens: 130_000, contextWindow: 1_000_000 }, 30)
+    expect(narrow).toContain('130k/1.0M')
+    expect(narrow).not.toContain('deepseek-v4-flash')
+  })
+
+  it('says a turn is running, and offers the key that stops it', () => {
+    const busy = status({ busy: true, elapsedMs: 4_000 })
+    expect(busy).toContain('working')
+    expect(busy).toContain('ctrl-c interrupt')
+    expect(busy).not.toContain('ctrl-d quit')
+  })
+
+  it('names a non-default card level and stays quiet about the default', () => {
+    expect(status({ detail: 'full' })).toContain('tools full')
+    expect(status({ detail: 'hidden' })).toContain('tools hidden')
+    expect(status()).not.toContain('tools')
   })
 })


### PR DESCRIPTION
The cheap, high-impact one from your list — with one correction that changed the design.

## The bar

```
● ready · deepseek-v4-flash · ██████░░ 6.2k/8.0k · alt-enter newline · ctrl-o output · ctrl-d quit
```

Exactly your example. But a linear 8-cell bar against DeepSeek's **1M** window reads as empty for every session anyone really has:

| tokens | fill | bar |
| --- | --- | --- |
| 13k | 1.3% | `░░░░░░░░` |
| 45k | 4.5% | `░░░░░░░░` |
| 120k | 12% | `█░░░░░░░` |
| 900k | 90% | `███████░` |

So it appears only once a cell would actually fill, which is also when a reader starts caring. A non-linear scale would fill it sooner and would be a lie about proportion, so the bar stays linear and stays absent instead. The fill is floored, because a bar reading full at 94% overstates the one thing it exists to report.

## Which exposed a truncation bug

Adding the bar pushed the line past 96 columns, and the cut landed mid-hint:

```
● ready · deepseek-v4-flash · █░░░░░░░ 130k/1.0M · alt-enter newline · ctrl-o output · ctrl-d qui
```

`ctrl-d qui` reads as a rendering fault, not a hint. The line now **assembles** rather than being cut: hints are appended only while they fit and dropped whole, and the model name goes before the pressure reading does, because the model does not change during a session and the reading does.

```
 30  ● ready · █░░░░░░░ 130k/1.0M
 50  ● ready · deepseek-v4-flash · █░░░░░░░ 130k/1.0M
 80  ● ready · deepseek-v4-flash · █░░░░░░░ 130k/1.0M · alt-enter newline
120  ● ready · deepseek-v4-flash · █░░░░░░░ 130k/1.0M · alt-enter newline · ctrl-o output · ctrl-d quit
```

`/model` is dropped from the hints: a slash command announces itself the moment one is typed, and a hint is for the keys that cannot be discovered by trying.

## Verification

- 293 tests. `views.ts` gained a status-line suite alongside the composer one added in #12.
- Measured at 20, 30, 40, 60, 80, 96, 120 and 200 columns: the line never exceeds the terminal and never ends on a partial hint.
- Three mutations — truncate instead of drop, always draw the bar, round instead of floor — each confirmed to fail a test that names the behaviour.
- Confirmed in a real pseudo-terminal against the live API.