### PR TITLE
Stop quoting an exact test count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ That split is not just tidiness. **The renderer must never import from the harne
 ```sh
 pnpm install
 pnpm build       # tsc -b for both packages
-pnpm test        # 347 tests, no terminal and no model required
+pnpm test        # the full suite, no terminal and no model required
 pnpm typecheck   # tsc -b, same project graph
 pnpm security    # the dependency and workflow checks CI runs
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Press the key that misbehaves. Each line shows the raw bytes and the key this pr
 ```sh
 pnpm install
 pnpm build        # also required before testing by hand; see AGENTS.md
-pnpm test         # 347 tests, no terminal and no model needed
+pnpm test         # the full suite, no terminal and no model needed
 pnpm typecheck
 pnpm security     # the dependency and workflow checks that CI runs
 ```

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Releases are built and published by GitHub Actions from a tag, never from a lapt
 
 ```sh
 pnpm install
-pnpm build && pnpm test      # 347 tests; no terminal and no model needed
+pnpm build && pnpm test      # the full suite; no terminal and no model needed
 ```
 
 Nothing outside this repository is required. Bug reports are especially useful right now — this is alpha software and the author cannot test every terminal. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md), and read [`AGENTS.md`](AGENTS.md) before changing code.


### PR DESCRIPTION
Three pages said `347 tests`; the suite is at 351 and will drift again with the next change. They now say "the full suite", keeping the part of the promise that stays true — no terminal and no model needed to run it.

Documentation only.