### PR TITLE
Make the context bar visible, and explain the launcher error

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -70,6 +70,40 @@ Inside the session, type `/` to list the commands your profile provides, then pr
 
 If a keyboard shortcut does nothing, run `node tools/keyprobe.mjs` from a checkout of this repository. It shows what your terminal sends and how this project reads it, which is what a bug report needs.
 
+## Troubleshooting
+
+### `Command "dsh" not found`
+
+```
+$ pnpm dsh --profile tui
+[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "dsh" not found
+```
+
+`pnpm dsh` is a script belonging to the **harness** repository, so it only exists when you run it from inside a harness checkout. Run it from anywhere else — including a clone of this repository — and pnpm reports that there is no such command. Three ways to fix it:
+
+```sh
+# 1. Install the harness command globally, then it works from any folder.
+npm install -g @deepseek-ai/dsh
+dsh --profile tui
+
+# 2. Run it from the harness folder, and point the session elsewhere with -C.
+cd ~/path/to/deepseek-harness
+pnpm dsh --profile tui -C ~/code/my-project
+
+# 3. Wrap option 2 in a shell function, so you can start it from any folder.
+dsh-tui() { (cd ~/path/to/deepseek-harness && pnpm dsh --profile tui -C "${1:-$PWD}"); }
+```
+
+With the function in your shell profile, `dsh-tui` opens the folder you are standing in, and `dsh-tui ~/code/api` opens another one.
+
+### It exits immediately with a message about needing a terminal
+
+That is the frontend refusing to start without a real terminal, which happens when its input or output is redirected. Run the launcher directly rather than through a wrapper that does not pass a terminal through, or use `--profile headless` for scripted runs.
+
+### A keyboard shortcut does nothing
+
+Run `node tools/keyprobe.mjs` from a checkout of this repository and press the key. It prints the bytes your terminal sends and the key this project decodes them into; an empty result is a bug worth reporting.
+
 ## Uninstalling
 
 This removes both the package and the profile's reference to it:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,8 +18,14 @@ Reopening a session with `--resume` keeps the folder that session was created in
 If you usually want the folder you are standing in, an alias is worth setting up:
 
 ```sh
+# With the harness installed globally:
 alias dsh-tui='dsh --profile tui -C "$PWD"'
+
+# Running the harness from a source checkout instead:
+dsh-tui() { (cd ~/path/to/deepseek-harness && pnpm dsh --profile tui -C "${1:-$PWD}"); }
 ```
+
+The second form matters because `pnpm dsh` is the harness repository's own script: from any other folder it fails with `Command "dsh" not found`. See [Install → Troubleshooting](install.md#command-dsh-not-found).
 
 ## Keys
 

--- a/packages/tui/src/views.ts
+++ b/packages/tui/src/views.ts
@@ -71,6 +71,20 @@ const BAR_CELLS = 8
 const BAR_FULL = '█'
 const BAR_EMPTY = '░'
 
+/**
+ * Partial cells, one eighth to seven eighths.
+ *
+ * These are what make the bar usable at all on a million-token window. Whole cells
+ * alone need 12.5% of the window before the first one appears — 125k tokens, which
+ * almost no session reaches — so the bar a reader was promised was never drawn. At
+ * an eighth of a cell each, the same eight columns carry 64 steps, and the first is
+ * visible at 1.6%.
+ */
+const BAR_PARTIAL: readonly string[] = ['\u258f', '\u258e', '\u258d', '\u258c', '\u258b', '\u258a', '\u2589']
+
+/** Steps per cell: the partial glyphs plus the full one. */
+const BAR_STEPS = BAR_PARTIAL.length + 1
+
 /** Context fill at which the pressure reading warns. */
 const PRESSURE_WARN = 0.7
 
@@ -217,27 +231,38 @@ function pressureStyle(tokens: number, window: number | undefined): StyleName {
 }
 
 /**
- * A bar for context pressure, or nothing when a bar would say nothing.
+ * A bar for context pressure, or nothing when there is nothing to report.
  *
- * Withheld below one cell of fill, and that threshold is the whole design. A
- * DeepSeek model's window is a million tokens, so a linear bar reads as completely
- * empty for every session anyone actually has — 45k tokens is 4.5%, which rounds to
- * no cells — and an always-empty bar spends columns to tell the reader nothing. It
- * appears once there is something to see, which is also when a reader starts caring.
+ * Measured in eighths of a cell rather than whole cells, which is what makes it
+ * appear at all. A DeepSeek window is a million tokens: in whole cells the first one
+ * fills at 12.5%, so a bar drawn that way stayed invisible through every session
+ * anyone really has — and a feature nobody ever sees is indistinguishable from one
+ * that is broken. In eighths the same eight columns resolve to 64 steps.
  *
- * A non-linear scale would fill it sooner and would be a lie about proportion, so
- * the bar stays linear and stays absent instead.
+ * The scale stays strictly linear — a curve would fill sooner and would misreport
+ * proportion — with one rule at each end, both of the same kind: never show a state
+ * the reader has not reached. Any use at all rounds UP to the first visible mark,
+ * because a bar reading empty while the window is in use is the failure this
+ * function exists to avoid. The fill is otherwise rounded DOWN, so the bar is not
+ * full until the window is.
+ *
+ * Nothing is drawn before the first token, when there is genuinely nothing to see.
  * @param tokens - current pressure.
  * @param window - the model's context window, when known.
  * @returns the styled bar, or undefined when it would carry no information.
  */
 function pressureBar(tokens: number, window: number | undefined): string | undefined {
-  if (window === undefined || window <= 0) return undefined
-  // Floored, not rounded: a bar that shows full at 94% overstates the one thing it
-  // exists to report.
-  const filled = Math.min(BAR_CELLS, Math.floor((tokens / window) * BAR_CELLS))
-  if (filled < 1) return undefined
-  return style(`${BAR_FULL.repeat(filled)}${BAR_EMPTY.repeat(BAR_CELLS - filled)}`, pressureStyle(tokens, window))
+  if (window === undefined || window <= 0 || tokens <= 0) return undefined
+  const steps = BAR_CELLS * BAR_STEPS
+  const filled = Math.min(steps, Math.max(1, Math.floor((tokens / window) * steps)))
+  const whole = Math.floor(filled / BAR_STEPS)
+  const remainder = filled % BAR_STEPS
+  const partial = remainder === 0 ? '' : BAR_PARTIAL[remainder - 1] ?? ''
+  const empty = BAR_CELLS - whole - (partial === '' ? 0 : 1)
+  return style(
+    `${BAR_FULL.repeat(whole)}${partial}${BAR_EMPTY.repeat(Math.max(0, empty))}`,
+    pressureStyle(tokens, window),
+  )
 }
 
 /**
@@ -263,18 +288,20 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
       }
       // Held apart from the other facts because it is the one that can be dropped.
       const model = current.model === undefined ? undefined : style(current.model, 'dim')
+      let reading: string | undefined
+      let readingWithBar: string | undefined
       if (current.tokens !== undefined) {
         const window = current.contextWindow === undefined ? '' : `/${formatTokens(current.contextWindow)}`
-        const reading = style(
+        reading = style(
           `${formatTokens(current.tokens)}${window}`,
           pressureStyle(current.tokens, current.contextWindow),
         )
         const bar = pressureBar(current.tokens, current.contextWindow)
-        facts.push(bar === undefined ? reading : `${bar} ${reading}`)
+        readingWithBar = bar === undefined ? reading : `${bar} ${reading}`
       }
       // Only the non-default levels are reported: naming the default on every frame
       // spends a column on a fact the user did not ask about.
-      if (current.detail !== 'compact') facts.push(style(`tools ${current.detail}`, 'yellow'))
+      const detail = current.detail === 'compact' ? undefined : style(`tools ${current.detail}`, 'yellow')
 
       // Hints are dropped WHOLE when the width runs out. Truncating the joined line
       // instead cut one in half — `ctrl-d qui` — which reads as a rendering fault
@@ -283,12 +310,34 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
       const hints = current.busy
         ? ['ctrl-c interrupt']
         : ['alt-enter newline', 'ctrl-o output', 'ctrl-d quit']
-      // The model name is the longest fact and the least urgent: it does not change
-      // during a session, where the pressure reading does. Dropping it is what keeps
-      // the reading on a narrow terminal, which is where the reading matters most.
-      const withModel = [facts[0] ?? '', ...model === undefined ? [] : [model], ...facts.slice(1)]
-      let line = withModel.join(separator)
-      if (displayWidth(line) > budget) line = facts.join(separator)
+      // Three lines, richest first, and the first that fits wins. Each step gives up
+      // something the one below it keeps, in order of how little it costs:
+      //
+      // The BAR goes first. It is a picture of the numbers printed beside it, so it
+      // is the only thing here whose loss costs no information at all.
+      //
+      // The MODEL NAME goes next. It is the longest fact and the least urgent: it
+      // does not change during a session, where the pressure reading does.
+      //
+      // The reading itself is never given up, and neither is whether a turn is
+      // running. Dropping whole parts rather than truncating the joined line is the
+      // same rule the hints follow — a reading cut to `14k/1.0` reads as a rendering
+      // fault, not as a number.
+      const tail = detail === undefined ? [] : [detail]
+      const status = facts[0] ?? ''
+      const rungs = [
+        [status, ...model === undefined ? [] : [model], ...readingWithBar === undefined ? [] : [readingWithBar], ...tail],
+        [status, ...model === undefined ? [] : [model], ...reading === undefined ? [] : [reading], ...tail],
+        [status, ...reading === undefined ? [] : [reading], ...tail],
+      ]
+      let line = (rungs[rungs.length - 1] ?? []).join(separator)
+      for (const rung of rungs) {
+        const joined = rung.join(separator)
+        if (displayWidth(joined) <= budget) {
+          line = joined
+          break
+        }
+      }
       for (const hint of hints) {
         const extended = `${line}${separator}${style(hint, 'gray')}`
         if (displayWidth(extended) > budget) break

--- a/packages/tui/tests/views.spec.ts
+++ b/packages/tui/tests/views.spec.ts
@@ -206,31 +206,62 @@ describe('the status line', () => {
     return stripAnsi(view.render(columns)[0] ?? '')
   }
 
-  it('draws a bar beside the reading once there is something to see', () => {
-    expect(status({ tokens: 6_200, contextWindow: 8_000 })).toContain('██████░░ 6.2k/8.0k')
+  it('draws a bar beside the reading', () => {
+    expect(status({ tokens: 6_200, contextWindow: 8_000 })).toContain('\u2588\u2588\u2588\u2588\u2588\u2588\u258f\u2591 6.2k/8.0k')
   })
 
-  it('withholds the bar when it would read as empty', () => {
-    // A DeepSeek window is a million tokens, so a linear bar is empty for every
-    // session anyone actually has: 45k is 4.5%, which is no cells at all. An
-    // always-empty bar spends columns to say nothing.
-    expect(status({ tokens: 45_000, contextWindow: 1_000_000 })).not.toContain('░')
+  it('draws a visible bar on a million-token window, where whole cells could not', () => {
+    // The failure this replaces: in whole cells the first one fills at 12.5%, so on
+    // a DeepSeek window the bar stayed invisible through every session anyone really
+    // has — 45k is 4.5%, which was no cells at all. A feature nobody ever sees is
+    // indistinguishable from one that is broken, so the bar resolves in eighths.
+    expect(status({ tokens: 45_000, contextWindow: 1_000_000 })).toContain('\u258e\u2591\u2591\u2591\u2591\u2591\u2591\u2591')
     expect(status({ tokens: 45_000, contextWindow: 1_000_000 })).toContain('45k/1.0M')
   })
 
-  it('shows the bar once a cell would fill', () => {
-    expect(status({ tokens: 130_000, contextWindow: 1_000_000 })).toContain('█░░░░░░░')
+  it('rounds any use at all up to the first visible mark', () => {
+    // 0.1% of the window is a fortieth of one eighth. Rounding it down would draw an
+    // empty bar while the window is in use, which is the case this exists to avoid.
+    expect(status({ tokens: 1_000, contextWindow: 1_000_000 })).toContain('\u258f\u2591\u2591\u2591\u2591\u2591\u2591\u2591')
+  })
+
+  it('draws nothing before the first token, when there is nothing to see', () => {
+    expect(status({ tokens: 0, contextWindow: 1_000_000 })).not.toContain('\u2591')
+    expect(status({ tokens: 0, contextWindow: 1_000_000 })).toContain('0/1.0M')
+  })
+
+  it('fills whole cells as the window fills', () => {
+    expect(status({ tokens: 125_000, contextWindow: 1_000_000 })).toContain('\u2588\u2591\u2591\u2591\u2591\u2591\u2591\u2591')
+    expect(status({ tokens: 500_000, contextWindow: 1_000_000 })).toContain('\u2588\u2588\u2588\u2588\u2591\u2591\u2591\u2591')
   })
 
   it('floors the fill rather than rounding it', () => {
     // A bar reading full at 94% overstates the one thing it exists to report.
-    expect(status({ tokens: 940_000, contextWindow: 1_000_000 })).toContain('███████░')
-    expect(status({ tokens: 1_000_000, contextWindow: 1_000_000 })).toContain('████████')
+    expect(status({ tokens: 940_000, contextWindow: 1_000_000 })).toContain('\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258c')
+    expect(status({ tokens: 1_000_000, contextWindow: 1_000_000 })).toContain('\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588')
   })
 
   it('draws no bar when the window is unknown', () => {
     expect(status({ tokens: 45_000 })).toContain('45k')
-    expect(status({ tokens: 45_000 })).not.toContain('░')
+    expect(status({ tokens: 45_000 })).not.toContain('\u2591')
+  })
+
+  it('gives up the bar before the reading when the width runs out', () => {
+    // The bar is a picture of the numbers beside it, so it is the only part whose
+    // loss costs no information. The reading is never given up, and never cut.
+    const wide = status({ tokens: 14_000, contextWindow: 1_000_000 }, 60)
+    expect(wide).toContain('\u258f\u2591\u2591\u2591\u2591\u2591\u2591\u2591')
+    expect(wide).toContain('deepseek-v4-flash')
+
+    const narrow = status({ tokens: 14_000, contextWindow: 1_000_000 }, 46)
+    expect(narrow).not.toContain('\u2591')
+    expect(narrow).toContain('deepseek-v4-flash')
+    expect(narrow).toContain('14k/1.0M')
+
+    const narrowest = status({ tokens: 14_000, contextWindow: 1_000_000 }, 24)
+    expect(narrowest).not.toContain('\u2591')
+    expect(narrowest).not.toContain('deepseek-v4-flash')
+    expect(narrowest).toContain('14k/1.0M')
   })
 
   it('never exceeds the terminal, at any width', () => {


### PR DESCRIPTION
Two things reported from manual testing.

## The context bar never rendered

It was correct and invisible. The bar filled in **whole cells**, so the first one appeared at 12.5% of the window — and a DeepSeek window is a million tokens, putting that first mark at 125k. No ordinary session gets there, so the status line showed `14k/1.0M` with nothing beside it, every time, for everyone.

The earlier reasoning was right about what to reject and wrong about what to do instead. A curved scale would fill sooner and misreport proportion, so refusing that was correct — but the conclusion drawn was to withhold the bar below one cell, which threw away the feature rather than the lie. **The resolution was the problem, not the scale.**

Eight columns now carry sixty-four steps, using the eighth-block glyphs, all of which measure one column. The scale stays strictly linear, with one rule at each end — never show a state the reader has not reached:

| tokens | of 1.0M | bar |
| --- | --- | --- |
| 0 | 0% | *(none — nothing to show yet)* |
| 1k | 0.1% | `▏░░░░░░░` |
| 45k | 4.5% | `▎░░░░░░░` |
| 125k | 12.5% | `█░░░░░░░` |
| 500k | 50% | `████░░░░` |
| 940k | 94% | `███████▌` |
| 1.0M | 100% | `████████` |

Verified live, in the real interface: after one turn the status line now reads `▏░░░░░░░ 8.1k/1.0M`, where before it read `8.1k/1.0M` with nothing beside it.

Making it always visible cost columns, which had to be given back. At 24 columns the bar pushed the reading into the truncation and produced `14k/1.0` — the same class of fault the hints already avoid by dropping whole. So the line now degrades in three rungs, each giving up the cheapest thing left:

```
80c   ● ready · deepseek-v4-flash · ▏░░░░░░░ 14k/1.0M · alt-enter newline
46c   ● ready · deepseek-v4-flash · 14k/1.0M          ← bar dropped: it duplicates the numbers
24c   ● ready · 14k/1.0M                              ← model dropped, as before
```

The reading itself is never given up and never cut. Measured at 24, 34, 46, 60 and 80 columns.

## `Command "dsh" not found`

```
$ pnpm dsh --profile tui          # run from a clone of THIS repository
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "dsh" not found
```

`pnpm dsh` is the harness repository's own script, so it exists only inside a harness checkout. The install page said to run it from there, but said it in passing — and pnpm's error names neither the cause nor the fix. There is now a troubleshooting section that quotes the error and gives three ways out: install the harness globally, run it from the harness folder with `-C` pointing at the folder you want, or wrap that in a shell function. The usage page's alias grew the same second form, because the one-line alias silently assumed a global `dsh`.

All four launch paths were checked in a pseudo-terminal:

| | |
| --- | --- |
| `pnpm dsh` from this repository | fails — the reported error |
| `pnpm dsh` from the harness checkout | works |
| `node --import tsx/esm apps/cli/src/bin.ts` from the harness | works |
| the same, with `-C` pointing elsewhere | works |