### PR TITLE
A dshtui command, so starting a session is one word

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,12 @@ Read [`docs/design.md`](docs/design.md) before changing anything about drawing, 
 A terminal interface for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). It runs as a plugin inside the agent's own process, rather than as a client connecting over a network. There are two packages:
 
 ```
-packages/renderer   @riesbri/dsh-tui-renderer   widths, keys, input line, boxes, screen — knows nothing about agents
-packages/tui        @riesbri/dsh-tui            the plugin: session loop, transcript, harness integration, view registry
+packages/renderer       @riesbri/dsh-tui-renderer   widths, keys, input line, boxes, screen — knows nothing about agents
+packages/tui            @riesbri/dsh-tui            the plugin: session loop, transcript, harness integration, view registry
+packages/tui/bin        dshtui                      a launcher wrapper, and deliberately nothing more
 ```
+
+`bin/dshtui.mjs` exists so that using this does not require remembering two things (`dsh`, `--profile tui`). It finds the harness launcher, adds the profile and the working folder, and hands over the terminal with `stdio: 'inherit'`. It must never grow session logic: one implementation of the frontend is the point, and a wrapper that started doing its own work would be a second one.
 
 That split is not just tidiness. **The renderer must never import from the harness, and must never gain a dependency or a peer dependency.** Having no dependencies is what lets this plugin add nothing to a user's setup, and it is why every rule below about widths, cutting, and escaping can be tested without a terminal and without a model.
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,10 @@ If you are changing this repository rather than using it, start at [`AGENTS.md`]
 Type `/` to see the commands your agent actually has. `/model` and `/exit` are handled by this interface. `/compact`, `/plan`, `/goal`, `/permission` and `/feedback` come from the harness, so which ones appear depends on your setup. Every command prints its result. A name that matches nothing is reported as unknown instead of being sent to the model as a question.
 
 ```sh
-dsh --profile tui -C ~/code/api      # open a different folder
-dsh --profile tui "run the tests"    # send a first message on startup
-dsh --profile tui --resume           # reopen one of your recent sessions
+dshtui                    # open the folder you are standing in
+dshtui -C ~/code/api      # open a different folder
+dshtui "run the tests"    # send a first message on startup
+dshtui --resume           # reopen one of your recent sessions
 ```
 
 Text-editing keys, the `shift-enter` caveat, a warning about `/goal`, and the permission presets are all in [`docs/usage.md`](docs/usage.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,6 +11,16 @@
 - **A working [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) installation** with a model configured. If `dsh web` starts and answers a prompt, you are ready.
 - **A real terminal.** This interface needs a terminal for both input and output. If either is redirected, it exits with an error instead of waiting with nothing on screen. For scripts, use `--profile headless` instead.
 
+## The short version
+
+```sh
+npm install -g @deepseek-ai/dsh @riesbri/dsh-tui   # the harness, and this interface
+dshtui --setup                                     # once, to create the profile
+dshtui                                             # from any folder, on any machine
+```
+
+The rest of this page explains each step, and what to do when one of them does not apply to you.
+
 ## 1. Make sure you have a `dsh` command
 
 This plugin is started by the harness's own command-line program, so you need a way to run it. Either option works.
@@ -58,12 +68,36 @@ pnpm dsh --profile tui
 
 Installing directly from a Git URL is not supported. `dsh plugin add github:riesbri/dsh-tui` would install the repository root, which is a workspace containing two packages rather than the plugin itself. Use the npm package name, or a path to `packages/tui`.
 
-## 3. Confirm it worked
+## 3. Get a one-word command
+
+Installing this package globally puts a `dshtui` command on your PATH:
 
 ```sh
-dsh --profile tui --dump-config      # look for a "# == @riesbri/dsh-tui" section
-dsh --profile tui --help             # the flags this interface adds
-dsh --profile tui                    # a banner, an input line, and a "ready" status line
+npm install -g @riesbri/dsh-tui
+dshtui --setup     # the same as: dsh plugin --profile tui add @riesbri/dsh-tui
+dshtui             # the same as: dsh --profile tui --cwd "$PWD"
+```
+
+It is a small wrapper around the harness's launcher, and nothing more: it finds `dsh`, adds `--profile tui` unless you asked for another profile, pins the session to the folder you ran it from, and passes everything else through. So `dshtui --resume`, `dshtui "run the tests"` and `dshtui --help` all reach the real launcher.
+
+Two things it needs to find:
+
+- **The launcher.** It looks at `$DSH_BIN` first, then for `dsh` on your PATH, then for the `@deepseek-ai/dsh` package next to its own — which is why installing both globally in one command is enough. If your harness is a source checkout with no global command, set the variable once in your shell profile:
+
+  ```sh
+  export DSH_BIN=~/path/to/deepseek-harness/node_modules/.bin/dsh
+  ```
+
+- **The profile.** `dshtui --setup` creates it. Run `dshtui` before that and it says so rather than failing obscurely. To install from a checkout instead of the registry, give `--setup` the path: `dshtui --setup ./packages/tui`.
+
+`dshtui` claims only that one command name. The unscoped `dsh-tui` package on npm is a different interface, so this package deliberately does not install a `dsh-tui` command that would shadow it.
+
+## 4. Confirm it worked
+
+```sh
+dshtui --dump-config      # look for a "# == @riesbri/dsh-tui" section
+dshtui --help             # the flags this interface adds
+dshtui                    # a banner, an input line, and a "ready" status line
 ```
 
 Inside the session, type `/` to list the commands your profile provides, then press `ctrl-d` to leave.
@@ -82,19 +116,19 @@ $ pnpm dsh --profile tui
 `pnpm dsh` is a script belonging to the **harness** repository, so it only exists when you run it from inside a harness checkout. Run it from anywhere else — including a clone of this repository — and pnpm reports that there is no such command. Three ways to fix it:
 
 ```sh
-# 1. Install the harness command globally, then it works from any folder.
-npm install -g @deepseek-ai/dsh
-dsh --profile tui
+# 1. Install both globally and use the one-word command from anywhere.
+npm install -g @deepseek-ai/dsh @riesbri/dsh-tui
+dshtui --setup
+dshtui
 
-# 2. Run it from the harness folder, and point the session elsewhere with -C.
+# 2. Keep your source checkout, and tell dshtui where its launcher is.
+export DSH_BIN=~/path/to/deepseek-harness/node_modules/.bin/dsh
+dshtui
+
+# 3. Run it from the harness folder, pointing the session elsewhere with -C.
 cd ~/path/to/deepseek-harness
 pnpm dsh --profile tui -C ~/code/my-project
-
-# 3. Wrap option 2 in a shell function, so you can start it from any folder.
-dsh-tui() { (cd ~/path/to/deepseek-harness && pnpm dsh --profile tui -C "${1:-$PWD}"); }
 ```
-
-With the function in your shell profile, `dsh-tui` opens the folder you are standing in, and `dsh-tui ~/code/api` opens another one.
 
 ### It exits immediately with a message about needing a terminal
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,28 +4,29 @@
 
 | | |
 | --- | --- |
-| `dsh --profile tui` | Start in the current folder |
-| `dsh --profile tui -C ~/code/api` | Start in a different folder |
-| `dsh --profile tui "run the tests"` | Send a first message on startup |
-| `dsh --profile tui --resume` | Choose from your twenty most recent sessions |
-| `dsh --profile tui --resume <id>` | Reopen a session you know the id of |
-| `dsh --profile tui --help` | All flags this interface adds |
+| `dshtui` | Start in the current folder |
+| `dshtui -C ~/code/api` | Start in a different folder |
+| `dshtui "run the tests"` | Send a first message on startup |
+| `dshtui --resume` | Choose from your twenty most recent sessions |
+| `dshtui --resume <id>` | Reopen a session you know the id of |
+| `dshtui --help` | All flags this interface adds |
+| `dshtui --setup` | Create the `tui` profile, once, before the first run |
+
+`dshtui` is a small wrapper around the harness's own launcher: it finds `dsh`, adds `--profile tui`, and pins the session to the folder you ran it from. Everything else is passed through, so `dshtui <anything>` and `dsh --profile tui <anything>` behave the same. Use whichever you prefer.
 
 `-C` (or `--cwd`) sets the folder the *session* works in. It does not change where the command itself runs from.
 
 Reopening a session with `--resume` keeps the folder that session was created in, because that folder is recorded in the session file. `-C` is therefore ignored when resuming, rather than quietly moving an old conversation to a new folder.
 
-If you usually want the folder you are standing in, an alias is worth setting up:
+`dshtui` already opens the folder you are standing in, so no alias is needed for that.
+
+If your harness is a source checkout with no global `dsh` command, give `dshtui` its launcher once:
 
 ```sh
-# With the harness installed globally:
-alias dsh-tui='dsh --profile tui -C "$PWD"'
-
-# Running the harness from a source checkout instead:
-dsh-tui() { (cd ~/path/to/deepseek-harness && pnpm dsh --profile tui -C "${1:-$PWD}"); }
+export DSH_BIN=~/path/to/deepseek-harness/node_modules/.bin/dsh
 ```
 
-The second form matters because `pnpm dsh` is the harness repository's own script: from any other folder it fails with `Command "dsh" not found`. See [Install → Troubleshooting](install.md#command-dsh-not-found).
+Without a global `dsh` and without that variable, `pnpm dsh` still works — but only from inside the harness folder, because that script belongs to the harness repository. See [Install → Troubleshooting](install.md#command-dsh-not-found).
 
 ## Keys
 

--- a/packages/tui/bin/dshtui.mjs
+++ b/packages/tui/bin/dshtui.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * `dshtui` — start a terminal session in the current folder.
+ *
+ * This frontend is a plugin, so it is started by the harness's own launcher with
+ * `dsh --profile tui`. That is two decisions to remember (which launcher, which
+ * profile) before anything happens, and on a server it is the difference between
+ * using this and not bothering. This wrapper makes the whole thing one word.
+ *
+ * It finds the launcher, adds `--profile tui` unless another profile was asked for,
+ * pins the session to the folder you ran it from, and hands over the terminal. Every
+ * other argument is passed through untouched, so `dshtui --resume`, `dshtui "run the
+ * tests"` and `dshtui --help` all reach the real launcher.
+ *
+ * Deliberately a launcher and nothing else: it starts no session logic of its own,
+ * so there is only ever one implementation of the frontend to reason about.
+ * @module @riesbri/dsh-tui/bin/dshtui
+ */
+
+import { spawn } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { homedir } from 'node:os'
+import { delimiter, dirname, join } from 'node:path'
+
+/** The profile this wrapper starts, and installs into with `--setup`. */
+const PROFILE = 'tui'
+
+/** This package, as `dsh plugin add` names it. */
+const PACKAGE = '@riesbri/dsh-tui'
+
+/** The harness's launcher package, resolved when no `dsh` is on PATH. */
+const LAUNCHER_PACKAGE = '@deepseek-ai/dsh'
+
+/**
+ * How to run the harness launcher: a command and any arguments that must precede
+ * the ones this wrapper passes.
+ * @typedef {{ command: string, prefix: string[], describe: string }} Launcher
+ */
+
+/**
+ * Whether a command exists on PATH.
+ *
+ * Looked up rather than probed by running it. Running `dsh --version` to find out
+ * whether `dsh` exists would put a whole Node startup in front of every launch, for
+ * an answer the filesystem already has. The Windows extensions are tried because a
+ * launcher installed by npm there is a `.cmd` shim rather than the name itself.
+ * @param name - the command to look for.
+ * @returns whether a matching file was found.
+ */
+function onPath(name) {
+  const candidates = process.platform === 'win32' ? [`${name}.cmd`, `${name}.exe`, `${name}.bat`, name] : [name]
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    if (directory === '') continue
+    for (const candidate of candidates) {
+      if (existsSync(join(directory, candidate))) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Find the harness launcher.
+ *
+ * Three ways, in the order that respects what the user has already decided:
+ * `DSH_BIN` when they have pointed at one explicitly, then `dsh` on PATH for the
+ * ordinary global install, then the launcher package resolved from this one — which
+ * is what makes `npm i -g @deepseek-ai/dsh @riesbri/dsh-tui` enough, since a global
+ * install puts the two side by side.
+ * @returns the launcher, or undefined when none can be found.
+ */
+function findLauncher() {
+  const configured = process.env.DSH_BIN
+  if (configured !== undefined && configured !== '') {
+    return { command: configured, prefix: [], describe: `$DSH_BIN (${configured})` }
+  }
+  if (onPath('dsh')) return { command: 'dsh', prefix: [], describe: 'dsh on your PATH' }
+  try {
+    const require = createRequire(import.meta.url)
+    const manifestPath = require.resolve(`${LAUNCHER_PACKAGE}/package.json`)
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+    const entry = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.dsh
+    if (typeof entry !== 'string') return undefined
+    const script = join(dirname(manifestPath), entry)
+    if (!existsSync(script)) return undefined
+    // Run through this Node rather than the script's own shebang, so it does not
+    // matter whether the file is executable in the install that provided it.
+    return { command: process.execPath, prefix: [script], describe: `${LAUNCHER_PACKAGE} (${script})` }
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Where the harness keeps this profile.
+ *
+ * Resolved the same way the harness resolves it — `$DSH_HOME` when set, `~/.dsh`
+ * otherwise, with a leading `~` expanded — because a wrapper that guessed
+ * differently would announce a missing profile that is really there.
+ * @returns the absolute profile directory.
+ */
+function profileDirectory() {
+  const configured = (process.env.DSH_HOME ?? '').trim()
+  const home = configured === ''
+    ? join(homedir(), '.dsh')
+    : configured === '~'
+      ? homedir()
+      : configured.startsWith('~/') || configured.startsWith('~\\')
+        ? join(homedir(), configured.slice(2))
+        : configured
+  return join(home, 'profiles', PROFILE)
+}
+
+/**
+ * Whether an argument list already chooses a profile, in either accepted form.
+ * @param args - the arguments this wrapper was given.
+ * @returns whether `--profile` is present.
+ */
+function choosesProfile(args) {
+  return args.some(argument => argument === '--profile' || argument.startsWith('--profile='))
+}
+
+/**
+ * Whether an argument list already chooses a working folder.
+ * @param args - the arguments this wrapper was given.
+ * @returns whether a cwd flag is present.
+ */
+function choosesCwd(args) {
+  return args.some(argument => argument === '-C' || argument === '--cwd' || argument.startsWith('--cwd='))
+}
+
+/**
+ * Run the launcher and exit with its status.
+ *
+ * `stdio: 'inherit'` is the whole point: the frontend refuses to start without a
+ * real terminal, so the child must be given this process's own. SIGINT is ignored
+ * here for the same reason — `ctrl-c` is a keystroke the frontend decides the
+ * meaning of, and a wrapper that died on it would tear down the session mid-turn.
+ * @param launcher - how to run the launcher.
+ * @param args - the arguments to pass.
+ */
+function handOver(launcher, args) {
+  process.on('SIGINT', () => {})
+  const child = spawn(launcher.command, [...launcher.prefix, ...args], { stdio: 'inherit' })
+  child.on('error', (error) => {
+    process.stderr.write(`dshtui: could not start ${launcher.describe}: ${error.message}\n`)
+    process.exit(127)
+  })
+  child.on('exit', (code, signal) => {
+    if (signal !== null) {
+      process.kill(process.pid, signal)
+      return
+    }
+    process.exit(code ?? 0)
+  })
+}
+
+const args = process.argv.slice(2)
+
+if (args[0] === '--setup') {
+  const launcher = findLauncher()
+  if (launcher === undefined) {
+    process.stderr.write(missingLauncherMessage())
+    process.exit(127)
+  }
+  // A source may be given instead of the published package — `dshtui --setup
+  // ./packages/tui` is how someone testing a checkout installs it, and it is the
+  // same argument `dsh plugin add` takes, so it is passed through rather than
+  // reinvented. Anything further goes to the launcher untouched.
+  const source = args.length > 1 ? args.slice(1) : [PACKAGE]
+  process.stdout.write(`dshtui: installing ${source[0] ?? PACKAGE} into the "${PROFILE}" profile\n`)
+  handOver(launcher, ['plugin', '--profile', PROFILE, 'add', ...source])
+} else {
+  const launcher = findLauncher()
+  if (launcher === undefined) {
+    process.stderr.write(missingLauncherMessage())
+    process.exit(127)
+  }
+  if (!existsSync(profileDirectory())) {
+    process.stderr.write(`dshtui: the "${PROFILE}" profile does not exist yet. Create it once with:\n\n  dshtui --setup\n\n`)
+    process.exit(1)
+  }
+  // Added BEFORE the caller's arguments, never after. A first task is a positional
+  // argument — `dshtui "run the tests"` — and appending a flag behind positionals
+  // leaves the parser deciding whether `--cwd` belongs to the option or to the task.
+  const added = []
+  if (!choosesProfile(args)) added.push('--profile', PROFILE)
+  // The folder is pinned explicitly rather than left to the launcher's own default,
+  // because the launcher may be reached through something that changed folder on the
+  // way — a shell function that enters a harness checkout first, for instance.
+  // `--resume` ignores it by design and keeps the folder its session was created in.
+  if (!choosesCwd(args)) added.push('--cwd', process.cwd())
+  handOver(launcher, [...added, ...args])
+}
+
+/**
+ * What to print when no launcher can be found.
+ * @returns the message, ending in a newline.
+ */
+function missingLauncherMessage() {
+  return [
+    'dshtui: cannot find the DeepSeek Harness launcher.',
+    '',
+    'This is a plugin for the harness, so the harness has to be installed too:',
+    '',
+    `  npm install -g ${LAUNCHER_PACKAGE}`,
+    '  dshtui --setup',
+    '',
+    'If you run the harness from a source checkout, point this at its launcher:',
+    '',
+    '  export DSH_BIN=~/path/to/deepseek-harness/node_modules/.bin/dsh',
+    '',
+  ].join('\n')
+}

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -15,6 +15,7 @@
     }
   },
   "files": [
+    "bin",
     "lib",
     "src",
     "cordis.patch.yml"
@@ -83,5 +84,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "Ricardo (riesbri)"
+  "author": "Ricardo (riesbri)",
+  "bin": {
+    "dshtui": "./bin/dshtui.mjs"
+  }
 }


### PR DESCRIPTION
Reported: launching this on a server is awkward, because it takes two things you have to remember first — which launcher (`dsh`) and which profile (`--profile tui`).

Installing the package globally now puts a `dshtui` command on the PATH:

```sh
npm install -g @deepseek-ai/dsh @riesbri/dsh-tui   # the harness, and this interface
dshtui --setup                                     # once, to create the profile
dshtui                                             # from any folder, on any machine
```

It is a launcher and deliberately nothing else — it starts no session logic of its own, so there is still one implementation of the frontend. It finds the harness launcher, adds `--profile tui` unless another profile was asked for, pins the session to the folder you ran it from, and passes everything else through:

```
dshtui                          →  dsh --profile tui --cwd $PWD
dshtui --resume                 →  dsh --profile tui --cwd $PWD --resume
dshtui "run the tests"          →  dsh --profile tui --cwd $PWD run the tests
dshtui --profile other          →  dsh --profile other --cwd $PWD
dshtui -C /somewhere run this   →  dsh --profile tui -C /somewhere run this
dshtui --setup                  →  dsh plugin --profile tui add @riesbri/dsh-tui
dshtui --setup ./packages/tui   →  dsh plugin --profile tui add ./packages/tui
```

### Decisions worth reviewing

- **Finding the launcher**, in the order the user has already decided things: `$DSH_BIN`, then `dsh` on PATH, then `@deepseek-ai/dsh` resolved from this package — which is what makes installing both in one command enough. PATH is read from the filesystem rather than probed by running `dsh --version`, which would put a Node startup in front of every launch.
- **The folder is passed explicitly**, not left to the launcher's default, because the launcher may be reached through something that changed directory on the way — a shell function entering a harness checkout is exactly how a source install runs.
- **Added flags go before the caller's arguments.** A first task is positional, and appending a flag behind positionals leaves the parser deciding who `--cwd` belongs to.
- **`stdio: 'inherit'`, and SIGINT ignored in the wrapper.** The frontend refuses to start without a real terminal, and `ctrl-c` is a keystroke it decides the meaning of — a wrapper dying on it would tear down the session mid-turn. A signal that does kill the child is re-raised, so a caller sees what really happened.
- **Only `dshtui` is claimed.** The unscoped `dsh-tui` package on npm is a different frontend; installing a `dsh-tui` command here would silently shadow it.
- **Both failure paths say what to do**, not what went wrong: no launcher prints the install commands and the `DSH_BIN` alternative, a missing profile prints `dshtui --setup`. Both exit non-zero.

### Verification

In a pseudo-terminal, driving the real assembled profile through the wrapper:

| | |
| --- | --- |
| run from an unrelated nested folder | opens **that** folder, not the harness — banner and composer both confirm |
| `dshtui "reply with exactly: banana"` | task passed through as one message, answered |
| `dshtui --help` | reaches the real launcher's help |
| `ctrl-d` | exits 0 through both processes |
| no launcher on PATH | exit 127 with install instructions |
| no profile | exit 1 with `dshtui --setup` |

Argument construction checked for all seven forms in the table above. Docs updated: the README quickstart, the usage tables, and a new install section; the troubleshooting entry for `Command "dsh" not found` now leads with this.