### PR TITLE
Let dshtui find a harness source checkout

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -82,11 +82,15 @@ It is a small wrapper around the harness's launcher, and nothing more: it finds 
 
 Two things it needs to find:
 
-- **The launcher.** It looks at `$DSH_BIN` first, then for `dsh` on your PATH, then for the `@deepseek-ai/dsh` package next to its own — which is why installing both globally in one command is enough. If your harness is a source checkout with no global command, set the variable once in your shell profile:
+- **The launcher**, looked for in four places, in the order in which you have already made a decision: `$DSH_BIN`, then `$DSH_HARNESS`, then `dsh` on your PATH, then the `@deepseek-ai/dsh` package sitting next to its own — which is why installing both globally in one command is enough.
+
+  For a **source checkout**, set `DSH_HARNESS` to the checkout itself:
 
   ```sh
-  export DSH_BIN=~/path/to/deepseek-harness/node_modules/.bin/dsh
+  export DSH_HARNESS=~/path/to/deepseek-harness
   ```
+
+  A checkout has no `dsh` executable to point `DSH_BIN` at: its launcher is a TypeScript entry run through a loader, written down in the checkout's own `package.json` as a `dsh` script. `dshtui` reads that script and runs it from the checkout, so it keeps working if the harness moves its own files. `DSH_BIN` is for a real executable — a global install, or a `node_modules/.bin/dsh` from installing the harness as a dependency.
 
 - **The profile.** `dshtui --setup` creates it. Run `dshtui` before that and it says so rather than failing obscurely. To install from a checkout instead of the registry, give `--setup` the path: `dshtui --setup ./packages/tui`.
 
@@ -121,14 +125,30 @@ npm install -g @deepseek-ai/dsh @riesbri/dsh-tui
 dshtui --setup
 dshtui
 
-# 2. Keep your source checkout, and tell dshtui where its launcher is.
-export DSH_BIN=~/path/to/deepseek-harness/node_modules/.bin/dsh
+# 2. Keep your source checkout, and name it.
+export DSH_HARNESS=~/path/to/deepseek-harness
 dshtui
 
 # 3. Run it from the harness folder, pointing the session elsewhere with -C.
 cd ~/path/to/deepseek-harness
 pnpm dsh --profile tui -C ~/code/my-project
 ```
+
+### `$DSH_BIN points at … which does not exist`
+
+```
+$ export DSH_BIN=~/path/to/deepseek-harness/node_modules/.bin/dsh
+$ dshtui
+dshtui: $DSH_BIN points at …/node_modules/.bin/dsh, which does not exist.
+```
+
+A harness **source checkout does not contain that file**, and nothing builds it: the launcher there is a script in the checkout's `package.json`, which is why `pnpm dsh` works from inside the checkout and a path to a binary does not. Name the checkout instead:
+
+```sh
+export DSH_HARNESS=~/path/to/deepseek-harness
+```
+
+`DSH_BIN` is only for a real executable, such as the one `npm install -g @deepseek-ai/dsh` puts on your PATH.
 
 ### It exits immediately with a message about needing a terminal
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,11 +20,13 @@ Reopening a session with `--resume` keeps the folder that session was created in
 
 `dshtui` already opens the folder you are standing in, so no alias is needed for that.
 
-If your harness is a source checkout with no global `dsh` command, give `dshtui` its launcher once:
+If your harness is a source checkout rather than a global install, name the checkout once:
 
 ```sh
-export DSH_BIN=~/path/to/deepseek-harness/node_modules/.bin/dsh
+export DSH_HARNESS=~/path/to/deepseek-harness
 ```
+
+A checkout has no `dsh` executable to point at — its launcher is a script — so this names the folder and lets `dshtui` read that script from it. See [Install → Troubleshooting](install.md#dsh_bin-points-at--which-does-not-exist).
 
 Without a global `dsh` and without that variable, `pnpm dsh` still works — but only from inside the harness folder, because that script belongs to the harness repository. See [Install → Troubleshooting](install.md#command-dsh-not-found).
 

--- a/packages/tui/bin/dshtui.mjs
+++ b/packages/tui/bin/dshtui.mjs
@@ -33,6 +33,16 @@ const PACKAGE = '@riesbri/dsh-tui'
 const LAUNCHER_PACKAGE = '@deepseek-ai/dsh'
 
 /**
+ * The script a harness source checkout uses to launch itself.
+ *
+ * A checkout has no `dsh` executable at all — the launcher is a TypeScript entry run
+ * through a loader, and the checkout's own `package.json` is where that command is
+ * written down. Reading it from there rather than hardcoding the path means this
+ * keeps working when the harness moves its own files.
+ */
+const HARNESS_SCRIPT = 'dsh'
+
+/**
  * How to run the harness launcher: a command and any arguments that must precede
  * the ones this wrapper passes.
  * @typedef {{ command: string, prefix: string[], describe: string }} Launcher
@@ -70,9 +80,41 @@ function onPath(name) {
  * @returns the launcher, or undefined when none can be found.
  */
 function findLauncher() {
-  const configured = process.env.DSH_BIN
-  if (configured !== undefined && configured !== '') {
+  const configured = (process.env.DSH_BIN ?? '').trim()
+  if (configured !== '') {
+    // Checked rather than handed to spawn, so a wrong path is a sentence instead of
+    // an ENOENT naming a file the reader already believed was there.
+    if (!existsSync(configured)) {
+      return { error: `$DSH_BIN points at ${configured}, which does not exist.${sourceCheckoutHint(configured)}` }
+    }
     return { command: configured, prefix: [], describe: `$DSH_BIN (${configured})` }
+  }
+  const checkout = (process.env.DSH_HARNESS ?? '').trim()
+  if (checkout !== '') {
+    const expanded = checkout.startsWith('~/') ? join(homedir(), checkout.slice(2)) : checkout
+    const manifestPath = join(expanded, 'package.json')
+    if (!existsSync(manifestPath)) {
+      return { error: `$DSH_HARNESS points at ${expanded}, which is not a harness checkout (no package.json).` }
+    }
+    let command
+    try {
+      command = JSON.parse(readFileSync(manifestPath, 'utf8')).scripts?.[HARNESS_SCRIPT]
+    } catch {
+      command = undefined
+    }
+    if (typeof command !== 'string' || command.trim() === '') {
+      return { error: `${manifestPath} has no "${HARNESS_SCRIPT}" script, so this does not look like a harness checkout.` }
+    }
+    // The script is a plain command line — `node --import tsx/esm apps/cli/src/bin.ts`
+    // — with paths relative to the checkout, so it runs from there. Split on
+    // whitespace because that is what the value is; nothing here quotes arguments.
+    const [program, ...rest] = command.trim().split(/\s+/u)
+    return {
+      command: program ?? 'node',
+      prefix: rest,
+      cwd: expanded,
+      describe: `$DSH_HARNESS (${expanded}: ${command})`,
+    }
   }
   if (onPath('dsh')) return { command: 'dsh', prefix: [], describe: 'dsh on your PATH' }
   try {
@@ -141,7 +183,13 @@ function choosesCwd(args) {
  */
 function handOver(launcher, args) {
   process.on('SIGINT', () => {})
-  const child = spawn(launcher.command, [...launcher.prefix, ...args], { stdio: 'inherit' })
+  const child = spawn(launcher.command, [...launcher.prefix, ...args], {
+    stdio: 'inherit',
+    // A source checkout's launcher is a relative path inside it, and its loader
+    // resolves from there too, so that launcher only runs with the checkout as the
+    // working directory. The session's own folder is passed as an argument instead.
+    ...launcher.cwd === undefined ? {} : { cwd: launcher.cwd },
+  })
   child.on('error', (error) => {
     process.stderr.write(`dshtui: could not start ${launcher.describe}: ${error.message}\n`)
     process.exit(127)
@@ -157,12 +205,25 @@ function handOver(launcher, args) {
 
 const args = process.argv.slice(2)
 
-if (args[0] === '--setup') {
-  const launcher = findLauncher()
-  if (launcher === undefined) {
+/**
+ * Resolve the launcher or leave, having said why.
+ * @returns the launcher, once it is known to be usable.
+ */
+function launcherOrExit() {
+  const found = findLauncher()
+  if (found === undefined) {
     process.stderr.write(missingLauncherMessage())
     process.exit(127)
   }
+  if (found.error !== undefined) {
+    process.stderr.write(`dshtui: ${found.error}\n`)
+    process.exit(127)
+  }
+  return found
+}
+
+if (args[0] === '--setup') {
+  const launcher = launcherOrExit()
   // A source may be given instead of the published package — `dshtui --setup
   // ./packages/tui` is how someone testing a checkout installs it, and it is the
   // same argument `dsh plugin add` takes, so it is passed through rather than
@@ -171,11 +232,7 @@ if (args[0] === '--setup') {
   process.stdout.write(`dshtui: installing ${source[0] ?? PACKAGE} into the "${PROFILE}" profile\n`)
   handOver(launcher, ['plugin', '--profile', PROFILE, 'add', ...source])
 } else {
-  const launcher = findLauncher()
-  if (launcher === undefined) {
-    process.stderr.write(missingLauncherMessage())
-    process.exit(127)
-  }
+  const launcher = launcherOrExit()
   if (!existsSync(profileDirectory())) {
     process.stderr.write(`dshtui: the "${PROFILE}" profile does not exist yet. Create it once with:\n\n  dshtui --setup\n\n`)
     process.exit(1)
@@ -194,6 +251,22 @@ if (args[0] === '--setup') {
 }
 
 /**
+ * The likely correction when `$DSH_BIN` names something that is not there.
+ *
+ * A source checkout has no `dsh` executable to point at — the launcher is a
+ * TypeScript entry run through a loader — so this is the mistake a reader is most
+ * likely to have made, and `$DSH_HARNESS` is the answer to it.
+ * @param configured - the path that did not exist.
+ * @returns a sentence beginning with a space, or an empty string.
+ */
+function sourceCheckoutHint(configured) {
+  if (!/node_modules[\\/]\.bin[\\/]dsh$/u.test(configured)) return ''
+  const checkout = configured.replace(/[\\/]node_modules[\\/]\.bin[\\/]dsh$/u, '')
+  return ` A harness SOURCE CHECKOUT has no such executable — its launcher is a script.`
+    + ` Point at the checkout itself instead:\n\n  export DSH_HARNESS=${checkout}\n`
+}
+
+/**
  * What to print when no launcher can be found.
  * @returns the message, ending in a newline.
  */
@@ -206,9 +279,14 @@ function missingLauncherMessage() {
     `  npm install -g ${LAUNCHER_PACKAGE}`,
     '  dshtui --setup',
     '',
-    'If you run the harness from a source checkout, point this at its launcher:',
+    'If you run the harness from a SOURCE CHECKOUT, name the checkout — not a',
+    'binary, because a checkout does not build one:',
     '',
-    '  export DSH_BIN=~/path/to/deepseek-harness/node_modules/.bin/dsh',
+    '  export DSH_HARNESS=~/path/to/deepseek-harness',
+    '',
+    'Or name an executable directly, if you have one:',
+    '',
+    '  export DSH_BIN=/path/to/dsh',
     '',
   ].join('\n')
 }


### PR DESCRIPTION
Reported straight after #19, and the documentation was at fault before the code was:

```
$ export DSH_BIN=~/deepseek/deepseek-harness/node_modules/.bin/dsh
$ dshtui
dshtui: could not start $DSH_BIN (…/node_modules/.bin/dsh): spawn … ENOENT
```

That path was in the README and the install page, and **it never existed**. A harness source checkout builds no `dsh` executable: its launcher is a TypeScript entry run through a loader, declared in the checkout's own `package.json` as a `dsh` script. That is why `pnpm dsh` works from inside the checkout, and why no path to a binary works from outside it. `DSH_BIN` was the wrong instrument and the advice to use it that way was wrong.

## `DSH_HARNESS` names the checkout

```sh
export DSH_HARNESS=~/path/to/deepseek-harness
dshtui
```

What runs is the checkout's own `dsh` script, **read from its manifest rather than hardcoded here**, with the checkout as the working directory — both the entry path and its loader resolve from there. So this keeps working if the harness moves its own files, and the session still opens the folder `dshtui` was called from, because that was already passed as an argument rather than inherited.

## `DSH_BIN` keeps its real job

A real executable: a global install, or a `node_modules/.bin/dsh` from installing the harness as a dependency. It is now checked before being handed to spawn, so a wrong path is a sentence rather than an ENOENT naming a file the reader believed was there — and when the path looks like the mistake above, the message names the variable to use instead:

```
dshtui: $DSH_BIN points at …/node_modules/.bin/dsh, which does not exist.
A harness SOURCE CHECKOUT has no such executable — its launcher is a script.
Point at the checkout itself instead:

  export DSH_HARNESS=/home/…/deepseek-harness
```

Resolution order is now `$DSH_BIN`, `$DSH_HARNESS`, `dsh` on PATH, then the launcher package beside this one — what the user said explicitly, before what happens to be around.

## Verification

In a pseudo-terminal against the real checkout, with `DSH_HARNESS` set and nothing else — no `DSH_BIN`, no global `dsh`:

| | |
| --- | --- |
| `dshtui` from an unrelated nested folder | opens that folder |
| `dshtui --resume` | reaches the launcher, draws the session picker |
| `ctrl-d` in both | exit 0 |
| `DSH_BIN` that does not exist | exit 127, names `DSH_HARNESS` |
| `DSH_HARNESS` that is not a checkout | exit 127, says why |
| neither, and no launcher anywhere | exit 127, prints the install commands |

Every place the wrong path appeared is corrected, and the install page gained a troubleshooting entry under the error text someone would actually search for.