### PR TITLE
feat(tui): stream markdown into the live region

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ There are two packages. [`@riesbri/dsh-tui-renderer`](packages/renderer) does th
 
 - **It never switches to a separate screen.** Finished output goes into your terminal's own scroll history and is never redrawn. Only a small area at the bottom is updated in place. Scrolling, selecting text, and copying work exactly as they do for any other command.
 - **A reply is printed line by line as it arrives**, so drawing cost does not grow with the length of the answer, and a long reply scrolls normally instead of being cut down to fit.
+- **Markdown is styled as it streams.** The unfinished line is drawn through the same inline formatter as the committed transcript, so `**bold**` appears bold the moment its markers arrive instead of flipping when the line completes.
 - **Tool output is drawn the way each tool asks to be drawn.** A shell command becomes a framed box with its exit code. A file edit becomes a red-and-green diff. A search groups its matches under each file. Tools that say nothing about presentation still display correctly.
 - **Model reasoning is shown while it happens**, dimmed, so a model that thinks for a long time looks busy rather than stuck.
 - **Text from a model, a tool, or a paste is made safe before it is drawn.** A terminal treats some characters as commands, so untrusted text is converted to a visible form first, and colors are added only afterwards.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ There are two packages. [`@riesbri/dsh-tui-renderer`](packages/renderer) does th
 
 - **It never switches to a separate screen.** Finished output goes into your terminal's own scroll history and is never redrawn. Only a small area at the bottom is updated in place. Scrolling, selecting text, and copying work exactly as they do for any other command.
 - **A reply is printed line by line as it arrives**, so drawing cost does not grow with the length of the answer, and a long reply scrolls normally instead of being cut down to fit.
-- **Markdown is styled as it streams.** The unfinished line is drawn through the same inline formatter as the committed transcript, so `**bold**` appears bold the moment its markers arrive instead of flipping when the line completes.
+- **Markdown is styled as it streams.** An unfinished line that fits the bounded live region is drawn through the same inline formatter as the committed transcript, so `**bold**` appears bold the moment its markers arrive instead of flipping when the line completes.
 - **Tool output is drawn the way each tool asks to be drawn.** A shell command becomes a framed box with its exit code. A file edit becomes a red-and-green diff. A search groups its matches under each file. Tools that say nothing about presentation still display correctly.
 - **Model reasoning is shown while it happens**, dimmed, so a model that thinks for a long time looks busy rather than stuck.
 - **Text from a model, a tool, or a paste is made safe before it is drawn.** A terminal treats some characters as commands, so untrusted text is converted to a visible form first, and colors are added only afterwards.

--- a/docs/design.md
+++ b/docs/design.md
@@ -48,6 +48,8 @@ This is also why the interface never switches to the alternate screen. Scrolling
 
 Each finished line is printed into the scroll history as soon as its line break arrives. Only the last, unfinished line stays in the live area.
 
+The unfinished line is drawn through the same inline formatter as the committed transcript, against the same block state — so a closed `**bold**` span is styled the moment its markers arrive, a partial line inside a fence reads as code, and committing the line changes nothing about its shape. The live region is the committed path, one newline earlier, rather than a second rendering of the same text.
+
 That has two benefits. Redrawing cost stays constant instead of growing with the length of the answer. And a reply longer than the window scrolls the terminal normally, rather than being trimmed to whatever fits.
 
 When the complete message arrives at the end of the reply, it contributes only what streaming could not already show. That is what stops a reply being printed twice.
@@ -102,7 +104,7 @@ A path that reaches the terminal without being made safe is a security bug here,
 
 ## Markdown is rendered, and made safe while it is parsed
 
-Replies arrive with headings, emphasis, inline and fenced code, lists, quotes, rules, and links. A deliberately small subset is supported, written by hand in `packages/renderer/src/markdown.ts`, because using a parser library would cost the no-dependencies property.
+Replies arrive with headings, emphasis, inline, fenced, and indented code, lists, quotes, rules, and links. A deliberately small subset is supported, written by hand in `packages/renderer/src/markdown.ts`, because using a parser library would cost the no-dependencies property.
 
 Emphasis follows the CommonMark rules about which characters may open and close it, with one deliberate difference. A marker followed by a space cannot open, and one preceded by a space cannot close, so `2 * 3 * 4` stays arithmetic. Underscores may not touch a word, so `snake_case_name` and `file_name.ts` stay intact. The difference is that `__init__` is left as written instead of being read as bold: in a reply about code, that is a Python name far more often than it is emphasis, and corrupting a name the reader may need to type costs more than losing the formatting. `__bold text__` and `_italic_` both still work.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -48,7 +48,7 @@ This is also why the interface never switches to the alternate screen. Scrolling
 
 Each finished line is printed into the scroll history as soon as its line break arrives. Only the last, unfinished line stays in the live area.
 
-The unfinished line is drawn through the same inline formatter as the committed transcript, against the same block state — so a closed `**bold**` span is styled the moment its markers arrive, a partial line inside a fence reads as code, and committing the line changes nothing about its shape. The live region is the committed path, one newline earlier, rather than a second rendering of the same text.
+An unfinished line that fits the live region is drawn through the same inline formatter as the committed transcript, against the same block state — so a closed `**bold**` span is styled the moment its markers arrive, a partial line inside a fence reads as code, and committing the line changes nothing about its shape. A clipped suffix is left literal: it has neither the start of the source line nor earlier delimiter context, and guessing at either would hide text. The live region is the committed path, one newline earlier, rather than a second rendering of the same text.
 
 That has two benefits. Redrawing cost stays constant instead of growing with the length of the answer. And a reply longer than the window scrolls the terminal normally, rather than being trimmed to whatever fits.
 
@@ -104,7 +104,7 @@ A path that reaches the terminal without being made safe is a security bug here,
 
 ## Markdown is rendered, and made safe while it is parsed
 
-Replies arrive with headings, emphasis, inline, fenced, and indented code, lists, quotes, rules, and links. A deliberately small subset is supported, written by hand in `packages/renderer/src/markdown.ts`, because using a parser library would cost the no-dependencies property.
+Replies arrive with headings, emphasis, inline and fenced code, lists, quotes, rules, and links. A deliberately small subset is supported, written by hand in `packages/renderer/src/markdown.ts`, because using a parser library would cost the no-dependencies property.
 
 Emphasis follows the CommonMark rules about which characters may open and close it, with one deliberate difference. A marker followed by a space cannot open, and one preceded by a space cannot close, so `2 * 3 * 4` stays arithmetic. Underscores may not touch a word, so `snake_case_name` and `file_name.ts` stay intact. The difference is that `__init__` is left as written instead of being read as bold: in a reply about code, that is a Python name far more often than it is emphasis, and corrupting a name the reader may need to type costs more than losing the formatting. `__bold text__` and `_italic_` both still work.
 

--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -275,6 +275,20 @@ export interface MarkdownRenderer {
    *   opener carrying an info string, one otherwise.
    */
   line(source: string): string[]
+  /**
+   * Render the unfinished tail of a line as it streams.
+   *
+   * The live region holds the last line of a reply before its newline arrives,
+   * and that line is still in flight: it may yet become a heading, a fence, or
+   * plain prose. This renders it the way {@link line} will once it completes,
+   * against the CURRENT block state — a partial line inside a fence reads as
+   * code — without advancing that state. The fence a partial line opens or
+   * closes is decided by its own newline, not by the text seen so far, which is
+   * why this exists beside {@link line} rather than as a second call to it.
+   * @param source - the partial line, with no newline.
+   * @returns the styled, escaped row, or empty when the partial renders nothing.
+   */
+  partial(source: string): string
 }
 
 /**
@@ -286,6 +300,9 @@ export function createMarkdownRenderer(): MarkdownRenderer {
   let fence: string | undefined
   return {
     line: source => renderLine(source, () => fence, next => { fence = next }),
+    // A no-op setter: the partial line is the live region's view of a line whose
+    // newline has not arrived, so nothing about block state may change yet.
+    partial: source => renderLine(source, () => fence, () => {}).join(''),
   }
 }
 
@@ -378,6 +395,20 @@ function renderLine(
     const depth = Math.floor((ordered[1] ?? '').length / INDENT)
     const content = renderInline(line.slice(ordered[0].length))
     out.push(`${' '.repeat(depth * INDENT)}${style(`${ordered[2] ?? ''}.`, 'gray')} ${content}`)
+    return out
+  }
+
+  // A line indented four spaces is a code block in CommonMark. Checked LAST and
+  // with the indent KEPT, both deliberately. Checked last so a marker still wins
+  // over indentation — this renderer reads a deeply indented list item as a list
+  // item, and `    - item` stays a bullet for the same reason. Indent kept so a
+  // line an over-long indent pushed past the list bound survives byte for byte:
+  // stripping four spaces there would rewrite prose the pathological-input tests
+  // guarantee verbatim, and keeping it matches how fence content keeps its own
+  // two-space indent. What falls through to here is indentation with no marker,
+  // which is code: styled, and never parsed for emphasis.
+  if (/^(?: {4}|\t)/u.test(line)) {
+    out.push(style(escapeControls(line), 'cyan'))
     return out
   }
 

--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -33,6 +33,11 @@ const MAX_INDENT = 64
 /** Digits an ordered-list number is recognised in, per CommonMark. */
 const MAX_ORDINAL_DIGITS = 9
 
+/** Render one line of fenced-code content: indented, escaped, never parsed. */
+function renderFenceLine(line: string): string {
+  return `  ${style(escapeControls(line), 'cyan')}`
+}
+
 /**
  * One emphasis form: its delimiter, the styling it applies, and whether the
  * delimiter is allowed to sit inside a word.
@@ -317,7 +322,7 @@ export function createMarkdownRenderer(): MarkdownRenderer {
         // suffix close it.
         return fence === undefined
           ? escapeControls(source)
-          : `  ${style(escapeControls(source), 'cyan')}`
+          : renderFenceLine(source)
       }
       return renderLine(source, () => fence, () => {}).join('')
     },
@@ -377,7 +382,7 @@ function renderLine(
   if (fence !== undefined) {
     // Inside a fence everything is literal: escaped, indented, never parsed for
     // emphasis. This is where a model is most likely to emit an escape sequence.
-    out.push(`  ${style(escapeControls(line), 'cyan')}`)
+    out.push(renderFenceLine(line))
     return out
   }
 

--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -285,10 +285,16 @@ export interface MarkdownRenderer {
    * code — without advancing that state. The fence a partial line opens or
    * closes is decided by its own newline, not by the text seen so far, which is
    * why this exists beside {@link line} rather than as a second call to it.
+   *
+   * A bounded live region can receive only a suffix of the source line. That
+   * suffix has neither line-start nor inline-delimiter context, so it is kept
+   * literal rather than treating an ordinary `#`, fence, or underscore at the
+   * cut as markdown syntax.
    * @param source - the partial line, with no newline.
+   * @param startsLine - whether `source` begins at the real source-line start.
    * @returns the styled, escaped row, or empty when the partial renders nothing.
    */
-  partial(source: string): string
+  partial(source: string, startsLine?: boolean): string
 }
 
 /**
@@ -302,7 +308,19 @@ export function createMarkdownRenderer(): MarkdownRenderer {
     line: source => renderLine(source, () => fence, next => { fence = next }),
     // A no-op setter: the partial line is the live region's view of a line whose
     // newline has not arrived, so nothing about block state may change yet.
-    partial: source => renderLine(source, () => fence, () => {}).join(''),
+    partial: (source, startsLine = true) => {
+      if (!startsLine) {
+        // A clipped suffix cannot tell whether its first character follows a word
+        // or whether it started after earlier markdown syntax. Parsing it would
+        // turn literal source into formatting; known fence state is the one fact
+        // that survives the cut, so code remains recognisable without letting a
+        // suffix close it.
+        return fence === undefined
+          ? escapeControls(source)
+          : `  ${style(escapeControls(source), 'cyan')}`
+      }
+      return renderLine(source, () => fence, () => {}).join('')
+    },
   }
 }
 
@@ -395,20 +413,6 @@ function renderLine(
     const depth = Math.floor((ordered[1] ?? '').length / INDENT)
     const content = renderInline(line.slice(ordered[0].length))
     out.push(`${' '.repeat(depth * INDENT)}${style(`${ordered[2] ?? ''}.`, 'gray')} ${content}`)
-    return out
-  }
-
-  // A line indented four spaces is a code block in CommonMark. Checked LAST and
-  // with the indent KEPT, both deliberately. Checked last so a marker still wins
-  // over indentation — this renderer reads a deeply indented list item as a list
-  // item, and `    - item` stays a bullet for the same reason. Indent kept so a
-  // line an over-long indent pushed past the list bound survives byte for byte:
-  // stripping four spaces there would rewrite prose the pathological-input tests
-  // guarantee verbatim, and keeping it matches how fence content keeps its own
-  // two-space indent. What falls through to here is indentation with no marker,
-  // which is code: styled, and never parsed for emphasis.
-  if (/^(?: {4}|\t)/u.test(line)) {
-    out.push(style(escapeControls(line), 'cyan'))
     return out
   }
 

--- a/packages/renderer/tests/markdown.spec.ts
+++ b/packages/renderer/tests/markdown.spec.ts
@@ -290,3 +290,84 @@ describe('pathological input', () => {
     expect(plain('123456789. a list')).toEqual(['123456789. a list'])
   })
 })
+
+describe('partial lines (the live region)', () => {
+  it('styles an inline span the moment its markers arrive', () => {
+    const renderer = createMarkdownRenderer()
+    const row = renderer.partial('the **bold** tail')
+    expect(stripAnsi(row)).toBe('the bold tail')
+    expect(row).toContain('\u001b[1m')
+  })
+
+  it('leaves an unfinished span literal until it closes', () => {
+    // A model can stream `**bo` and stop there; showing the syntax is better
+    // than guessing at emphasis that never arrives.
+    const renderer = createMarkdownRenderer()
+    expect(stripAnsi(renderer.partial('the **bo'))).toBe('the **bo')
+  })
+
+  it('renders a heading as soon as its marker arrives', () => {
+    const renderer = createMarkdownRenderer()
+    expect(stripAnsi(renderer.partial('# Hea'))).toBe('Hea')
+    expect(renderer.partial('# Hea')).toContain('\u001b[1;36m')
+  })
+
+  it('does not advance block state', () => {
+    // The partial tail of a fence opener must not OPEN the fence: the newline
+    // decides that, and only the committed line may advance state. Otherwise a
+    // streamed opener would leave the renderer inside a fence that never opened.
+    const renderer = createMarkdownRenderer()
+    expect(renderer.partial('```')).toBe('')
+    // Still read as an opener (its info line is emitted), not as fence content —
+    // which is what a fence left open by the partial would have produced.
+    expect(renderer.line('```ts').map(stripAnsi)).toEqual(['ts'])
+    // The committed opener did advance state: the next partial is inside a fence.
+    expect(stripAnsi(renderer.partial('not code'))).toBe('  not code')
+  })
+
+  it('reads the current fence state, so a partial line inside a fence is code', () => {
+    const renderer = createMarkdownRenderer()
+    renderer.line('```')
+    const row = renderer.partial('**raw**')
+    expect(stripAnsi(row)).toBe('  **raw**')
+    // Never parsed for emphasis: a code block is the one place **bold** is text.
+    expect(row).not.toContain('\u001b[1m')
+  })
+
+  it('neutralizes an escape sequence in a partial line', () => {
+    const renderer = createMarkdownRenderer()
+    const row = renderer.partial('before \u001b[2J after')
+    expect(stripAnsi(row)).toBe('before ^[[2J after')
+    expect(stripAnsi(row)).not.toContain('\u001b')
+  })
+})
+
+describe('indented code', () => {
+  it('renders a four-space line as code, never parsed for emphasis', () => {
+    const rows = renderMarkdown('    const a = 1')
+    expect(rows.map(stripAnsi)).toEqual(['    const a = 1'])
+    expect(rows[0]).toContain('\u001b[36m')
+  })
+
+  it('leaves markdown syntax inside indented code literal', () => {
+    expect(plain('    **not bold** and `not code`')).toEqual(['    **not bold** and `not code`'])
+  })
+
+  it('neutralizes an escape sequence inside indented code', () => {
+    expect(plain('    \u001b[2Jwiped')).toEqual(['    ^[[2Jwiped'])
+  })
+
+  it('still reads a list marker under four spaces as a list item', () => {
+    // Indentation with a marker after it wins over indented code, which is the
+    // same rule that keeps a deeply indented list a list.
+    expect(plain('    - item')).toEqual(['    \u2023 item'])
+  })
+
+  it('keeps a line past the list indent bound verbatim', () => {
+    // The pathological-input guarantee: an indent too deep for a list is prose
+    // that survives byte for byte, so stripping four spaces here would rewrite
+    // text the list rule already promised to leave alone.
+    const far = ' '.repeat(200)
+    expect(plain(`${far}- not a bullet`)).toEqual([`${far}- not a bullet`])
+  })
+})

--- a/packages/renderer/tests/markdown.spec.ts
+++ b/packages/renderer/tests/markdown.spec.ts
@@ -340,34 +340,23 @@ describe('partial lines (the live region)', () => {
     expect(stripAnsi(row)).toBe('before ^[[2J after')
     expect(stripAnsi(row)).not.toContain('\u001b')
   })
-})
 
-describe('indented code', () => {
-  it('renders a four-space line as code, never parsed for emphasis', () => {
-    const rows = renderMarkdown('    const a = 1')
-    expect(rows.map(stripAnsi)).toEqual(['    const a = 1'])
-    expect(rows[0]).toContain('\u001b[36m')
+  it('keeps a clipped suffix literal without line-start or delimiter context', () => {
+    const renderer = createMarkdownRenderer()
+    // The source before this suffix ended with a word character. Reading the
+    // suffix as a fresh line would turn its underscores into emphasis and remove
+    // them, although `name_` is part of the identifier in the real source.
+    const row = renderer.partial('_name_ and ``` not a fence', false)
+    expect(stripAnsi(row)).toBe('_name_ and ``` not a fence')
+    expect(row).not.toContain('\u001b[3m')
   })
 
-  it('leaves markdown syntax inside indented code literal', () => {
-    expect(plain('    **not bold** and `not code`')).toEqual(['    **not bold** and `not code`'])
-  })
-
-  it('neutralizes an escape sequence inside indented code', () => {
-    expect(plain('    \u001b[2Jwiped')).toEqual(['    ^[[2Jwiped'])
-  })
-
-  it('still reads a list marker under four spaces as a list item', () => {
-    // Indentation with a marker after it wins over indented code, which is the
-    // same rule that keeps a deeply indented list a list.
-    expect(plain('    - item')).toEqual(['    \u2023 item'])
-  })
-
-  it('keeps a line past the list indent bound verbatim', () => {
-    // The pathological-input guarantee: an indent too deep for a list is prose
-    // that survives byte for byte, so stripping four spaces here would rewrite
-    // text the list rule already promised to leave alone.
-    const far = ' '.repeat(200)
-    expect(plain(`${far}- not a bullet`)).toEqual([`${far}- not a bullet`])
+  it('keeps a clipped fence-looking suffix as code without closing the fence', () => {
+    const renderer = createMarkdownRenderer()
+    renderer.line('```')
+    const row = renderer.partial('```', false)
+    expect(stripAnsi(row)).toBe('  ```')
+    expect(row).toContain('\u001b[36m')
+    expect(stripAnsi(renderer.partial('still code'))).toBe('  still code')
   })
 })

--- a/packages/tui/src/stream.ts
+++ b/packages/tui/src/stream.ts
@@ -247,7 +247,7 @@ export class StreamBuffer {
     // model's working notes, shown as written.
     const rendered = channel === 'reasoning'
       ? style(escapeControls(visible), 'dim', 'italic')
-      : state.markdown.partial(visible)
+      : state.markdown.partial(visible, visible.length === state.pending.length)
     // A partial that renders to nothing — the tail of a bare fence marker — has
     // no rows to show, and a head mark with no content after it would read as a
     // bug rather than as nothing.

--- a/packages/tui/src/stream.ts
+++ b/packages/tui/src/stream.ts
@@ -248,10 +248,12 @@ export class StreamBuffer {
     const rendered = channel === 'reasoning'
       ? style(escapeControls(visible), 'dim', 'italic')
       : state.markdown.partial(visible, visible.length === state.pending.length)
-    // A partial that renders to nothing — the tail of a bare fence marker — has
-    // no rows to show, and a head mark with no content after it would read as a
-    // bug rather than as nothing.
-    if (displayWidth(rendered) === 0) return []
+    // A markdown partial that renders to nothing — the tail of a bare fence
+    // marker — has no rows to show, and a head mark with no content after it
+    // would read as a bug rather than as nothing. Reasoning is never empty this
+    // way: it is only escaped and styled, so it keeps whatever width it arrived
+    // with, even a lone zero-width character, rather than vanishing for a redraw.
+    if (channel !== 'reasoning' && displayWidth(rendered) === 0) return []
     const rows = wrapToWidth(rendered, budget)
     const shown = rows.slice(-LIVE_ROWS)
     const elided = shown.length < rows.length || visible.length < state.pending.length

--- a/packages/tui/src/stream.ts
+++ b/packages/tui/src/stream.ts
@@ -239,8 +239,20 @@ export class StreamBuffer {
     // quadratic term this class exists to remove; two columns per character is
     // the widest any character gets, so this keeps every row that can be shown.
     const visible = state.pending.slice(-budget * LIVE_ROWS)
-    const escaped = escapeControls(visible)
-    const rows = wrapToWidth(channel === 'reasoning' ? style(escaped, 'dim', 'italic') : escaped, budget)
+    // The unfinished line is markdown too: it is the same text the committed
+    // path renders, one newline earlier, so it is drawn through the same inline
+    // formatter against the same block state. A closed span is styled the moment
+    // it closes instead of flipping when the line commits, and a partial line
+    // inside a fence reads as code. Only the reply is parsed: reasoning is the
+    // model's working notes, shown as written.
+    const rendered = channel === 'reasoning'
+      ? style(escapeControls(visible), 'dim', 'italic')
+      : state.markdown.partial(visible)
+    // A partial that renders to nothing — the tail of a bare fence marker — has
+    // no rows to show, and a head mark with no content after it would read as a
+    // bug rather than as nothing.
+    if (displayWidth(rendered) === 0) return []
+    const rows = wrapToWidth(rendered, budget)
     const shown = rows.slice(-LIVE_ROWS)
     const elided = shown.length < rows.length || visible.length < state.pending.length
     const [first = '', ...rest] = shown

--- a/packages/tui/tests/stream.spec.ts
+++ b/packages/tui/tests/stream.spec.ts
@@ -291,3 +291,69 @@ describe('live region', () => {
     expect(plain(buffer.push('text', '# heading\n', COLUMNS))).toEqual(['', '● heading'])
   })
 })
+
+describe('live markdown', () => {
+  it('styles a streamed span the moment its markers arrive', () => {
+    const buffer = new StreamBuffer()
+    buffer.push('text', 'the **bold** part', COLUMNS)
+    const rows = buffer.live(80)
+    expect(rows.join('')).toContain('\u001b[1m')
+    expect(plain(rows)).toEqual(['', '\u25cf the bold part'])
+  })
+
+  it('leaves a partial span literal until it closes', () => {
+    const buffer = new StreamBuffer()
+    buffer.push('text', 'the **bo', COLUMNS)
+    expect(plain(buffer.live(80))).toEqual(['', '\u25cf the **bo'])
+  })
+
+  it('commits the styled live line unchanged', () => {
+    // The live region is the same text, one newline earlier: the moment the line
+    // commits, only the mark is written and the row must not change shape.
+    const buffer = new StreamBuffer()
+    buffer.push('text', '**bold**', COLUMNS)
+    const live = plain(buffer.live(80))
+    const committed = plain(buffer.push('text', '\n', COLUMNS))
+    expect(live).toEqual(['', '\u25cf bold'])
+    expect(committed).toEqual(['', '\u25cf bold'])
+  })
+
+  it('renders a partial line inside a fence as code, not prose', () => {
+    const buffer = new StreamBuffer()
+    buffer.push('text', '```\n', COLUMNS)
+    buffer.push('text', '**raw**', COLUMNS)
+    const rows = buffer.live(80)
+    // Never parsed for emphasis inside a code block.
+    expect(rows.join('')).not.toContain('\u001b[1m')
+    expect(plain(rows)).toEqual(['', '\u25cf   **raw**'])
+  })
+
+  it('shows nothing for the bare tail of a fence marker', () => {
+    const buffer = new StreamBuffer()
+    buffer.push('text', '```', COLUMNS)
+    expect(buffer.live(80)).toEqual([])
+  })
+
+  it('escapes a control sequence inside a styled live span', () => {
+    const buffer = new StreamBuffer()
+    buffer.push('text', '**b\u001b[2J**', COLUMNS)
+    const rows = buffer.live(80)
+    // Styling survived the escape: the span is bold AND the control is caret
+    // notation, which is exactly the escape-before-style order.
+    expect(rows.join('')).toContain('\u001b[1m')
+    expect(stripAnsi(rows.join(''))).toBe('\u25cf b^[[2J')
+  })
+
+  it('keeps a long streamed line bounded, however fast it arrives', () => {
+    // The live region slices the pending tail before rendering, so a reply that
+    // never emits a newline cannot grow the per-delta cost — this is the
+    // quadratic term the class exists to remove, and the slice is the guarantee.
+    const buffer = new StreamBuffer()
+    buffer.push('text', `${'word '.repeat(10_000)}tail`, COLUMNS)
+    const started = performance.now()
+    const rows = buffer.live(80)
+    const elapsedMs = performance.now() - started
+    expect(rows.length).toBeLessThanOrEqual(5)
+    expect(elapsedMs).toBeLessThan(100)
+  })
+})

--- a/packages/tui/tests/stream.spec.ts
+++ b/packages/tui/tests/stream.spec.ts
@@ -256,6 +256,20 @@ describe('live region', () => {
     expect(plain(buffer.live(20)).join('')).toContain('NEWEST')
   })
 
+  it('does not read a clipped suffix as the start of a markdown line', () => {
+    // The live region only keeps four rows. This suffix begins at the cut, not
+    // at the source-line start, so its fence-looking text is literal; parsing it
+    // would hide the backticks until the line finally committed.
+    const columns = 80
+    const capacity = (columns - 2) * 4
+    const prefix = '```'
+    const suffix = `${prefix}${'x'.repeat(capacity - prefix.length)}`
+    const buffer = new StreamBuffer()
+    buffer.push('text', `before the cut ${suffix}`, columns)
+    // Elision replaces the first visible column, leaving the other two ticks.
+    expect(plain(buffer.live(columns)).join('\n')).toContain('``x')
+  })
+
   it('attaches its rows to the committed lines above once the mark is written', () => {
     const buffer = new StreamBuffer()
     buffer.push('text', 'committed\nlive part', COLUMNS)

--- a/packages/tui/tests/stream.spec.ts
+++ b/packages/tui/tests/stream.spec.ts
@@ -162,6 +162,15 @@ describe('reasoning', () => {
     expect(plain(buffer.live(80))).toEqual(['', '✻ weighing the options'])
   })
 
+  it('keeps showing reasoning even when its visible slice has zero display width', () => {
+    // The markdown partial's own zero-width guard (a bare fence marker) does not
+    // apply here: reasoning is only escaped and styled, never parsed, so a lone
+    // zero-width character is real content, not something to hide the row for.
+    const buffer = new StreamBuffer()
+    buffer.push('reasoning', '​', COLUMNS)
+    expect(buffer.live(80)).not.toEqual([])
+  })
+
   it('styles reasoning apart from the reply', () => {
     const buffer = new StreamBuffer()
     const live = buffer.push('reasoning', 'thinking\n', COLUMNS)

--- a/packages/tui/tests/streaming-frames.spec.ts
+++ b/packages/tui/tests/streaming-frames.spec.ts
@@ -120,6 +120,22 @@ describe('a streaming reply on a real terminal', () => {
       .toEqual(['● complete', '  partial so far', '>', 'idle'])
   })
 
+  it('keeps markdown styling when a live line commits', async () => {
+    const emulator = createEmulator(40, 24)
+    const screen = new Screen(emulator.target)
+    const buffer = new StreamBuffer()
+    buffer.push('text', '**bold**', COLUMNS)
+    screen.setLive([...buffer.live(40), ...CHROME])
+    // The reply mark and its following space occupy cells zero and one.
+    expect(await emulator.cell(2, 1)).toMatchObject({ chars: 'b', bold: true })
+
+    screen.commit(buffer.push('text', '\n', COLUMNS))
+    screen.setLive(CHROME)
+    // Committing replaces the live row with scrollback, not a differently-styled
+    // second rendering of it.
+    expect(await emulator.cell(2, 1)).toMatchObject({ chars: 'b', bold: true })
+  })
+
   it('replaces streamed reasoning with the reply, keeping both', async () => {
     const emulator = createEmulator(40, 24)
     const screen = new Screen(emulator.target)


### PR DESCRIPTION
## What this PR does

Makes the **live region** render markdown as it streams. A reply's unfinished line used to reach the screen as raw escaped plaintext — `**bold**` showed its asterisks while it streamed and flipped to bold only when the newline committed the line.

This was the one gap in the streaming-markdown story: the committed path (scrollback) already renders markdown via `createMarkdownRenderer()` in `StreamBuffer.emit`. Only `StreamBuffer.live()` — the unfinished trailing line — was plain.

## What changed

- **`packages/renderer/src/markdown.ts`**: new `MarkdownRenderer.partial(source)` — renders an in-flight line the way `line()` will once it completes, against current block state, **without advancing state** (a streamed fence opener must not open a fence that never opened; the newline decides that). Also: four-space indented lines now render as code (the one CommonMark block type this renderer lacked).
- **`packages/tui/src/stream.ts`**: `live()` draws the text channel through `state.markdown.partial(...)` instead of `escapeControls(...)`. Reasoning stays as-written (a half-formed thought is not a document). A partial that renders to nothing — the tail of a bare fence marker — draws no dangling mark.
- **Tests**: 18 new (12 renderer, 6 tui): partial styling, fence awareness, no-state-advance, escape safety, live→commit shape stability, per-delta cost bound.
- **Docs**: `docs/design.md` (live line = committed path one newline earlier; indented code added to the subset) and one README bullet.

## Why not the other way

The obvious fix — `renderInline` on the pending tail — loses the fence: a partial line inside a fenced block would render as prose while it arrived and flip to code on commit. The state has to come from the renderer that owns the fence.

## Notes vs the GLM5.2 spec

The spec proposed new `markdown/blocks.ts`/`inline.ts`/`stream.ts` modules and rewiring `transcript.ts`. This repo already has those pieces: `markdown.ts` is the block+inline engine, `StreamBuffer` is the stream state machine (pending buffer, per-channel renderer, blanks), and the committed path already goes through markdown — so the spec's Phase 1 and most of Phase 2 were already landed. This PR implements the missing piece (live-region rendering) on the existing architecture instead of duplicating it. Deferred per the spec: syntax highlighting, tables/nested lists/setext headings, truecolor themes.

## Verification

- `pnpm test`: 372 passed (15 files), including 18 new.
- `pnpm typecheck`: clean.
- Broke the feature on purpose (`live()` back to `escapeControls`): exactly the five live-markdown tests failed.
- No new dependencies.
