### PR TITLE
fix(tui): bump peerDependencies to the published 0.1.0-rc.7 line

### DIFF
--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riesbri/dsh-tui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An interactive terminal surface for DeepSeek Harness: an in-process Cordis bundle over the real interaction seams",
   "type": "module",
   "license": "MIT",
@@ -37,18 +37,18 @@
     "@riesbri/dsh-tui-renderer": "workspace:^"
   },
   "peerDependencies": {
-    "@deepseek-ai/cordis": "^4.0.1-rc.4",
-    "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-fs": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-session-query": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-tool-ask-user": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-tools": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.6",
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-agent": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-cmdline": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-commands": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-fs": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-llm": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-session": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-session-query": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-tool-ask-user": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-user-approval": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-user-questions": "^0.1.0-rc.7",
     "commander": "^15.0.0"
   },
   "dsh": {


### PR DESCRIPTION
## What this fixes

`@riesbri/dsh-tui@0.1.0`'s `peerDependencies` pinned every `@deepseek-ai/dsh-*` package to `^0.1.0-rc.6` and cordis to `^4.0.1-rc.4`. `devDependencies` floated on the `next` tag instead, so local installs, tests, and CI never actually touched the `peerDependencies` field — it silently went stale after publish.

The real `@deepseek-ai/*` ecosystem has since moved to `0.1.0-rc.7` across the board. Installing `@riesbri/dsh-tui@0.1.0` globally with plain `npm install -g` reproduces a hard crash in npm's dependency resolver:

```
npm error Cannot read properties of null (reading 'children')
```

Reproduced in a clean, isolated global prefix with nothing else installed, so it's not an environment conflict — npm's arborist chokes while reconciling our stale `^0.1.0-rc.6` requirement against the `rc.7` versions the rest of the graph (dsh-agent's own transitive deps, etc.) actually needs.

## Verification

- Installed `@deepseek-ai/dsh` fresh into an isolated prefix and read the actual resolved versions of every peer package from its `node_modules` — all `0.1.0-rc.7` (cordis `4.0.1`).
- Cross-checked `@deepseek-ai/dsh`'s own `package.json`: it directly requires `@deepseek-ai/dsh-cmdline@^0.1.0-rc.7` and `@deepseek-ai/dsh-tool-ask-user@^0.1.0-rc.7`.
- Built a scratch package with the corrected dependency set (rc.7 across the board) — resolves cleanly, 30 packages, no crash.
- `pnpm test` (372 passed), `pnpm typecheck`, `pnpm build` all clean after the bump.

Version bumped `0.1.0` → `0.1.1` since `0.1.0` is already published and immutable on npm.