### PR TITLE
fix(tui): present plans in a scrollable review

### DIFF
--- a/packages/renderer/src/terminal.ts
+++ b/packages/renderer/src/terminal.ts
@@ -21,6 +21,8 @@ export interface TerminalStreams {
 
 /** A live raw-mode terminal. */
 export interface Terminal extends ScreenTarget {
+  /** Current terminal height in rows. */
+  rows(): number
   /** Observe decoded keystrokes; returns the removal disposer. */
   onKey(listener: (key: Key) => void): () => void
   /** Observe terminal resizes; returns the removal disposer. */
@@ -31,6 +33,9 @@ export interface Terminal extends ScreenTarget {
 
 /** Default columns when the stream reports none, matching the classic width. */
 const FALLBACK_COLUMNS = 80
+
+/** Default rows when the stream reports none, matching the classic height. */
+const FALLBACK_ROWS = 24
 
 /**
  * Bracketed paste. With it enabled the terminal wraps pasted content in
@@ -143,6 +148,7 @@ export function acquireTerminal(streams: TerminalStreams): Terminal {
   return {
     write: chunk => { output.write(chunk) },
     columns: () => output.columns ?? FALLBACK_COLUMNS,
+    rows: () => output.rows ?? FALLBACK_ROWS,
     onKey: listener => {
       keyListeners.add(listener)
       return () => { keyListeners.delete(listener) }

--- a/packages/renderer/tests/terminal.spec.ts
+++ b/packages/renderer/tests/terminal.spec.ts
@@ -138,17 +138,26 @@ describe('acquireTerminal()', () => {
     expect(log).toHaveLength(beforeSecondClose)
   })
 
-  it('falls back to a classic width when the stream reports none', () => {
+  it('reports the terminal height', () => {
+    const fake = fakeStreams(false)
+    Object.assign(fake.output, { rows: 37 })
+    const terminal = acquireTerminal({ input: fake.input, output: fake.output })
+    expect(terminal.rows()).toBe(37)
+    terminal.close()
+  })
+
+  it('falls back to a classic terminal size when dimensions are absent', () => {
     const terminal = acquireTerminal({
       input: {
         isTTY: true,
         setRawMode() {}, setEncoding() {}, resume() {}, pause() {}, on() {}, off() {},
       } as unknown as NodeJS.ReadStream,
       output: {
-        isTTY: true, columns: undefined, write() { return true }, on() {}, off() {},
+        isTTY: true, columns: undefined, rows: undefined, write() { return true }, on() {}, off() {},
       } as unknown as NodeJS.WriteStream,
     })
     expect(terminal.columns()).toBe(80)
+    expect(terminal.rows()).toBe(24)
     terminal.close()
   })
 })

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -195,7 +195,7 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
   }, 'dsh-tui: terminal ownership')
 
   const draw = (): void => {
-    const { lines, cursor } = ctx.tuiSlots.compose(terminal.columns())
+    const { lines, cursor } = ctx.tuiSlots.compose(terminal.columns(), terminal.rows())
     if (cursor === undefined) screen.setLive(lines)
     else screen.setLive(lines, cursor)
   }

--- a/packages/tui/src/plan-review.ts
+++ b/packages/tui/src/plan-review.ts
@@ -1,0 +1,157 @@
+/**
+ * The plan-review overlay.
+ *
+ * A completed plan is the decision a person needs to make, not incidental
+ * detail on an option picker. Keeping its whole body in the live region made a
+ * long plan taller than the terminal, which the append-and-live screen cannot
+ * redraw safely and which leaves only the bottom readable. This overlay keeps a
+ * fixed window over rendered plan rows and makes that window explicitly
+ * scrollable.
+ * @module @riesbri/dsh-tui/plan-review
+ */
+
+import type { Key } from '@riesbri/dsh-tui-renderer'
+import { BOX_CHROME_COLUMNS, box, escapeControls, renderMarkdown, style, truncateToWidth, wrapToWidth } from '@riesbri/dsh-tui-renderer'
+import type { TuiOverlay } from './slots.ts'
+import { chromeWidth } from './views.ts'
+
+/**
+ * Plan rows visible at once.
+ *
+ * Ten plan rows plus the frame, decision, and controls fit beneath ordinary
+ * terminal chrome, while still showing enough context to judge a step without
+ * paging for every line. A live overlay must stay this small: unlike committed
+ * transcript rows, rows beyond the screen cannot be climbed back to and erased.
+ */
+const PLAN_ROWS = 10
+
+/** One answer offered by the plan-mode review tool. */
+export interface PlanReviewChoice {
+  /** Value returned to the caller when this choice is confirmed. */
+  readonly value: string
+  /** Label a person sees for this choice. */
+  readonly label: string
+  /** Consequence of this choice, when the caller supplied one. */
+  readonly description?: string
+}
+
+/** Everything the plan-review overlay needs to render and settle. */
+export interface PlanReviewSpec {
+  /** Markdown plan submitted by the model for approval. */
+  readonly plan: string
+  /** The decision the caller is asking the person to make. */
+  readonly question: string
+  /** Choices supplied by the caller; the first is selected initially. */
+  readonly choices: readonly PlanReviewChoice[]
+  /** Called once with the selected value, or undefined after cancellation. */
+  settle(value: string | undefined): void
+  /** Asks the runner to redraw after scrolling or changing the selected choice. */
+  invalidate(): void
+}
+
+/**
+ * Render the completed plan as a bounded, scrollable review overlay.
+ *
+ * @param spec - plan content, decision choices, and callbacks.
+ * @returns an overlay that scrolls with up/down and changes the choice with tab.
+ */
+export function createPlanReviewOverlay(spec: PlanReviewSpec): TuiOverlay {
+  let offset = 0
+  let choice = 0
+  let renderedRows = 0
+  let settled = false
+
+  /** Settle no more than once, as terminal input can arrive after dismissal. */
+  const settle = (value: string | undefined): void => {
+    if (settled) return
+    settled = true
+    spec.settle(value)
+  }
+
+  /** The plan's physical terminal rows, with markdown made safe before styling. */
+  const rows = (columns: number): string[] => {
+    const inner = chromeWidth(columns) - BOX_CHROME_COLUMNS
+    return renderMarkdown(spec.plan).flatMap(line => wrapToWidth(line, inner))
+  }
+
+  /** Clamp the window after a resize or a scroll request. */
+  const limit = (count: number): number => Math.max(0, count - PLAN_ROWS)
+
+  /** Move the plan window one row and repaint only if it really moved. */
+  const scroll = (amount: number): void => {
+    const next = Math.min(Math.max(offset + amount, 0), limit(renderedRows))
+    if (next === offset) return
+    offset = next
+    spec.invalidate()
+  }
+
+  return {
+    render(columns) {
+      const rendered = rows(columns)
+      renderedRows = rendered.length
+      offset = Math.min(offset, limit(renderedRows))
+      const end = Math.min(offset + PLAN_ROWS, rendered.length)
+      const inner = chromeWidth(columns) - BOX_CHROME_COLUMNS
+      const selected = spec.choices[choice]
+      const description = selected?.description === undefined || selected.description === ''
+        ? []
+        : [style(`  ${truncateToWidth(escapeControls(selected.description), inner - 2)}`, 'gray')]
+      const content = [
+        style(truncateToWidth(escapeControls(spec.question), inner), 'dim'),
+        style(`rows ${String(offset + 1)}–${String(end)} of ${String(rendered.length)}`, 'gray'),
+        '',
+        ...rendered.slice(offset, end),
+        '',
+        ...spec.choices.map((item, index) => {
+          const label = truncateToWidth(escapeControls(item.label), inner - 2)
+          return index === choice ? style(`❯ ${label}`, 'cyan', 'bold') : `  ${label}`
+        }),
+        ...description,
+      ]
+      return [
+        '',
+        ...box(content, {
+          width: chromeWidth(columns),
+          title: style('Plan review', 'bold', 'yellow'),
+          border: text => style(text, 'yellow'),
+        }),
+        `  ${style(truncateToWidth('↑↓ plan · tab choose · enter confirm · esc cancel', Math.max(1, columns - 2)), 'gray')}`,
+      ]
+    },
+    handleKey(key: Key) {
+      if (key.kind !== 'key') return
+      switch (key.name) {
+        case 'up':
+          scroll(-1)
+          return
+        case 'down':
+          scroll(1)
+          return
+        case 'home':
+        case 'ctrl-a':
+          scroll(-Number.POSITIVE_INFINITY)
+          return
+        case 'end':
+        case 'ctrl-e':
+          scroll(Number.POSITIVE_INFINITY)
+          return
+        case 'tab':
+        case 'left':
+        case 'right':
+          if (spec.choices.length === 0) return
+          choice = (choice + 1) % spec.choices.length
+          spec.invalidate()
+          return
+        case 'enter':
+          settle(spec.choices[choice]?.value)
+          return
+        case 'escape':
+        case 'ctrl-c':
+          settle(undefined)
+          return
+        default:
+          return
+      }
+    },
+  }
+}

--- a/packages/tui/src/plan-review.ts
+++ b/packages/tui/src/plan-review.ts
@@ -32,6 +32,9 @@ const MAX_PLAN_ROWS = 10
  */
 const PLAN_REVIEW_FIXED_ROWS = 8
 
+/** Rows the readable compact box and its controls occupy. */
+const COMPACT_REVIEW_ROWS = 6
+
 /** One answer offered by the plan-mode review tool. */
 export interface PlanReviewChoice {
   /** Value returned to the caller when this choice is confirmed. */
@@ -135,13 +138,22 @@ export function createPlanReviewOverlay(spec: PlanReviewSpec): TuiOverlay {
       viewport.update(rendered.length, visiblePlanRows)
 
       if (visiblePlanRows === 0) {
+        if (terminalRows <= 0) return []
+        const label = oneRow(selected?.label ?? 'Decision', Math.max(1, columns - 13))
+        const decision = truncateToWidth(
+          `${style('Decision: ', 'gray')}${style(`‹ ${label} ›`, 'cyan', 'bold')}`,
+          Math.max(1, columns),
+        )
+        const help = style(truncateToWidth('←→ choose · enter confirm · esc cancel', Math.max(1, columns)), 'gray')
+        // A box is readable only when all six of its rows fit. Below that, keep
+        // the decision usable rather than letting the fallback itself overflow.
+        if (terminalRows < COMPACT_REVIEW_ROWS) return terminalRows === 1 ? [decision] : [decision, help]
         const heading = rendered.find(line => displayWidth(line) > 0) ?? 'Plan'
-        const label = oneRow(selected?.label ?? 'Decision', Math.max(1, inner - 13))
         return [
           ...box([
             truncateToWidth(heading, inner),
             style('resize terminal to read the plan', 'dim'),
-            `${style('Decision: ', 'gray')}${style(`‹ ${label} ›`, 'cyan', 'bold')}`,
+            decision,
           ], {
             width,
             title: style('Plan review', 'bold', 'yellow'),

--- a/packages/tui/src/plan-review.ts
+++ b/packages/tui/src/plan-review.ts
@@ -2,28 +2,35 @@
  * The plan-review overlay.
  *
  * A completed plan is the decision a person needs to make, not incidental
- * detail on an option picker. Keeping its whole body in the live region made a
- * long plan taller than the terminal, which the append-and-live screen cannot
- * redraw safely and which leaves only the bottom readable. This overlay keeps a
- * fixed window over rendered plan rows and makes that window explicitly
- * scrollable.
+ * detail on an option picker. The live region cannot safely grow past the
+ * terminal, so this overlay keeps a height-aware window over rendered plan rows
+ * and offers a compact decision-only form when even its fixed chrome cannot fit.
  * @module @riesbri/dsh-tui/plan-review
  */
 
 import type { Key } from '@riesbri/dsh-tui-renderer'
-import { BOX_CHROME_COLUMNS, box, escapeControls, renderMarkdown, style, truncateToWidth, wrapToWidth } from '@riesbri/dsh-tui-renderer'
+import { BOX_CHROME_COLUMNS, box, displayWidth, escapeControls, renderMarkdown, style, truncateToWidth, wrapToWidth } from '@riesbri/dsh-tui-renderer'
+import { RowViewport } from './scroll.ts'
 import type { TuiOverlay } from './slots.ts'
 import { chromeWidth } from './views.ts'
 
 /**
- * Plan rows visible at once.
+ * Largest document window shown in a tall terminal.
  *
- * Ten plan rows plus the frame, decision, and controls fit beneath ordinary
- * terminal chrome, while still showing enough context to judge a step without
- * paging for every line. A live overlay must stay this small: unlike committed
- * transcript rows, rows beyond the screen cannot be climbed back to and erased.
+ * More rows make a long plan easier to scan, but every one remains in the live
+ * region that Screen must climb back over on redraw. Ten leaves room for the
+ * decision chrome in a conventional twenty-four-row terminal.
  */
-const PLAN_ROWS = 10
+const MAX_PLAN_ROWS = 10
+
+/**
+ * Rows outside the plan document in the normal review layout.
+ *
+ * They are the leading blank, two box borders, question, counter, two plan
+ * spacers, and help line. Choices and their selected description are counted
+ * separately because they vary with the request.
+ */
+const PLAN_REVIEW_FIXED_ROWS = 8
 
 /** One answer offered by the plan-mode review tool. */
 export interface PlanReviewChoice {
@@ -50,15 +57,41 @@ export interface PlanReviewSpec {
 }
 
 /**
+ * Rows the normal layout may give to the plan document.
+ * @param terminalRows - terminal height in physical rows.
+ * @param choiceCount - decision rows beneath the plan.
+ * @param hasDescription - whether the selected choice adds its consequence row.
+ * @returns plan rows available without exceeding the terminal, capped for redraw safety.
+ */
+function normalPlanRows(terminalRows: number, choiceCount: number, hasDescription: boolean): number {
+  const fixedRows = PLAN_REVIEW_FIXED_ROWS + choiceCount + (hasDescription ? 1 : 0)
+  return Math.min(MAX_PLAN_ROWS, Math.max(0, terminalRows - fixedRows))
+}
+
+/**
+ * Make caller-supplied supporting text one physical frame row.
+ *
+ * A newline is safe text but would make the fixed layout budget false: box()
+ * would expand it into another row after the viewport had already decided how
+ * much room the plan owns. Replacing it is the only honest compact rendering of
+ * a label or question; the plan itself keeps its intentional markdown rows.
+ * @param text - untrusted caller-supplied text.
+ * @param width - available display columns.
+ * @returns escaped, one-row text no wider than the frame.
+ */
+function oneRow(text: string, width: number): string {
+  return truncateToWidth(escapeControls(text).replaceAll('\n', ' '), width)
+}
+
+/**
  * Render the completed plan as a bounded, scrollable review overlay.
  *
  * @param spec - plan content, decision choices, and callbacks.
- * @returns an overlay that scrolls with up/down and changes the choice with tab.
+ * @returns an overlay that scrolls with up/down and changes the choice with tab or arrows.
  */
 export function createPlanReviewOverlay(spec: PlanReviewSpec): TuiOverlay {
-  let offset = 0
+  const viewport = new RowViewport()
   let choice = 0
-  let renderedRows = 0
   let settled = false
 
   /** Settle no more than once, as terminal input can arrive after dismissal. */
@@ -69,41 +102,66 @@ export function createPlanReviewOverlay(spec: PlanReviewSpec): TuiOverlay {
   }
 
   /** The plan's physical terminal rows, with markdown made safe before styling. */
-  const rows = (columns: number): string[] => {
+  const planRows = (columns: number): string[] => {
     const inner = chromeWidth(columns) - BOX_CHROME_COLUMNS
     return renderMarkdown(spec.plan).flatMap(line => wrapToWidth(line, inner))
   }
 
-  /** Clamp the window after a resize or a scroll request. */
-  const limit = (count: number): number => Math.max(0, count - PLAN_ROWS)
+  /** Change document position and repaint only when it genuinely moved. */
+  const move = (amount: number): void => {
+    if (viewport.move(amount)) spec.invalidate()
+  }
 
-  /** Move the plan window one row and repaint only if it really moved. */
-  const scroll = (amount: number): void => {
-    const next = Math.min(Math.max(offset + amount, 0), limit(renderedRows))
-    if (next === offset) return
-    offset = next
+  /** Jump to a document end and repaint only when it genuinely moved. */
+  const jump = (last: boolean): void => {
+    if ((last ? viewport.last() : viewport.first())) spec.invalidate()
+  }
+
+  /** Change the selected answer while preserving left/right direction. */
+  const moveChoice = (amount: number): void => {
+    if (spec.choices.length === 0) return
+    choice = (choice + amount + spec.choices.length) % spec.choices.length
     spec.invalidate()
   }
 
   return {
-    render(columns) {
-      const rendered = rows(columns)
-      renderedRows = rendered.length
-      offset = Math.min(offset, limit(renderedRows))
-      const end = Math.min(offset + PLAN_ROWS, rendered.length)
-      const inner = chromeWidth(columns) - BOX_CHROME_COLUMNS
+    render(columns, terminalRows = 24) {
+      const rendered = planRows(columns)
+      const width = chromeWidth(columns)
+      const inner = width - BOX_CHROME_COLUMNS
       const selected = spec.choices[choice]
-      const description = selected?.description === undefined || selected.description === ''
-        ? []
-        : [style(`  ${truncateToWidth(escapeControls(selected.description), inner - 2)}`, 'gray')]
+      const hasDescription = selected?.description !== undefined && selected.description !== ''
+      const visiblePlanRows = normalPlanRows(terminalRows, spec.choices.length, hasDescription)
+      viewport.update(rendered.length, visiblePlanRows)
+
+      if (visiblePlanRows === 0) {
+        const heading = rendered.find(line => displayWidth(line) > 0) ?? 'Plan'
+        const label = oneRow(selected?.label ?? 'Decision', Math.max(1, inner - 13))
+        return [
+          ...box([
+            truncateToWidth(heading, inner),
+            style('resize terminal to read the plan', 'dim'),
+            `${style('Decision: ', 'gray')}${style(`‹ ${label} ›`, 'cyan', 'bold')}`,
+          ], {
+            width,
+            title: style('Plan review', 'bold', 'yellow'),
+            border: text => style(text, 'yellow'),
+          }),
+          `  ${style(truncateToWidth('←→ decision · enter confirm · esc cancel', Math.max(1, columns - 2)), 'gray')}`,
+        ]
+      }
+
+      const description = hasDescription
+        ? [style(`  ${oneRow(selected?.description ?? '', inner - 2)}`, 'gray')]
+        : []
       const content = [
-        style(truncateToWidth(escapeControls(spec.question), inner), 'dim'),
-        style(`rows ${String(offset + 1)}–${String(end)} of ${String(rendered.length)}`, 'gray'),
+        style(oneRow(spec.question, inner), 'dim'),
+        style(`rows ${String(viewport.start + 1)}–${String(viewport.end)} of ${String(rendered.length)}`, 'gray'),
         '',
-        ...rendered.slice(offset, end),
+        ...rendered.slice(viewport.start, viewport.end),
         '',
         ...spec.choices.map((item, index) => {
-          const label = truncateToWidth(escapeControls(item.label), inner - 2)
+          const label = oneRow(item.label, inner - 2)
           return index === choice ? style(`❯ ${label}`, 'cyan', 'bold') : `  ${label}`
         }),
         ...description,
@@ -111,36 +169,36 @@ export function createPlanReviewOverlay(spec: PlanReviewSpec): TuiOverlay {
       return [
         '',
         ...box(content, {
-          width: chromeWidth(columns),
+          width,
           title: style('Plan review', 'bold', 'yellow'),
           border: text => style(text, 'yellow'),
         }),
-        `  ${style(truncateToWidth('↑↓ plan · tab choose · enter confirm · esc cancel', Math.max(1, columns - 2)), 'gray')}`,
+        `  ${style(truncateToWidth('↑↓ plan · ←→ decision · enter confirm · esc cancel', Math.max(1, columns - 2)), 'gray')}`,
       ]
     },
     handleKey(key: Key) {
       if (key.kind !== 'key') return
       switch (key.name) {
         case 'up':
-          scroll(-1)
+          move(-1)
           return
         case 'down':
-          scroll(1)
+          move(1)
           return
         case 'home':
         case 'ctrl-a':
-          scroll(-Number.POSITIVE_INFINITY)
+          jump(false)
           return
         case 'end':
         case 'ctrl-e':
-          scroll(Number.POSITIVE_INFINITY)
+          jump(true)
           return
-        case 'tab':
         case 'left':
+          moveChoice(-1)
+          return
         case 'right':
-          if (spec.choices.length === 0) return
-          choice = (choice + 1) % spec.choices.length
-          spec.invalidate()
+        case 'tab':
+          moveChoice(1)
           return
         case 'enter':
           settle(spec.choices[choice]?.value)

--- a/packages/tui/src/questions.ts
+++ b/packages/tui/src/questions.ts
@@ -19,19 +19,75 @@ import type { AskUserQuestionAnswerItem, AskUserQuestionItem } from '@deepseek-a
 // `AskUserQuestionRequest` carries an `Agent`, so it lives on the service entry
 // point rather than the wire-safe `/types` module; importing it also carries the
 // `ctx.userQuestions` Context merge.
+import { UserQuestionError } from '@deepseek-ai/dsh-user-questions'
 import type { AskUserQuestionRequest } from '@deepseek-ai/dsh-user-questions'
+import { createPlanReviewOverlay } from './plan-review.ts'
 import { promptSelect } from './select.ts'
 
 /** Offered when a question carries no options of its own. */
 const ACKNOWLEDGE = [{ value: 'ok', label: 'OK' }] as const
 
 /**
+ * Ask for a completed plan's approval, keeping cancellation distinct from a
+ * declined choice. The plan-mode tool uses that distinction to tell the model a
+ * person dismissed the review to speak, rather than asking it to revise.
+ * @param ctx - the plugin context owning the overlay.
+ * @param item - the plan-review question and its markdown detail.
+ * @param signal - abort signal for the calling tool.
+ * @returns the selected option label.
+ */
+function askPlanReview(ctx: Context, item: AskUserQuestionItem, signal: AbortSignal | undefined): Promise<string> {
+  const choices = (item.options ?? []).map(option => ({
+    value: option.label,
+    label: option.label,
+    ...option.description === undefined ? {} : { description: option.description },
+  }))
+  return new Promise<string>((resolve, reject) => {
+    let dismiss = (): void => {}
+    let settled = false
+    const finish = (value: string | undefined, error: UserQuestionError | undefined): void => {
+      if (settled) return
+      settled = true
+      signal?.removeEventListener('abort', abort)
+      dismiss()
+      if (error !== undefined) reject(error)
+      else resolve(value ?? '')
+    }
+    const abort = (): void => {
+      finish(undefined, new UserQuestionError('ask_user_question was aborted before the user answered', 'ASK_ABORTED'))
+    }
+    const overlay = createPlanReviewOverlay({
+      plan: item.detail ?? '',
+      question: item.question,
+      choices: choices.length > 0 ? choices : ACKNOWLEDGE,
+      invalidate: () => { ctx.tuiSlots.invalidate() },
+      settle: value => {
+        finish(value, value === undefined
+          ? new UserQuestionError('The user dismissed the plan review to speak instead.', 'ASK_CANCELLED')
+          : undefined)
+      },
+    })
+    dismiss = ctx.tuiSlots.pushOverlay(overlay)
+    if (signal?.aborted === true) abort()
+    else signal?.addEventListener('abort', abort, { once: true })
+  })
+}
+
+/**
  * Ask one question, resolving once the user answers or cancels.
  * @param ctx - the plugin context owning the overlay.
  * @param item - the question to ask.
+ * @param signal - abort signal for the calling tool.
  * @returns the answer for this question.
  */
-async function askOne(ctx: Context, item: AskUserQuestionItem): Promise<AskUserQuestionAnswerItem> {
+async function askOne(
+  ctx: Context,
+  item: AskUserQuestionItem,
+  signal: AbortSignal | undefined,
+): Promise<AskUserQuestionAnswerItem> {
+  if (item.intent?.kind === 'plan-review' && item.detail !== undefined) {
+    return { id: item.id, selected: [await askPlanReview(ctx, item, signal)] }
+  }
   const choices = (item.options ?? []).map(option => ({
     value: option.label,
     label: option.label,
@@ -60,7 +116,7 @@ export function installQuestionProvider(ctx: Context): () => void {
       // only its top, so rendering several at once would hide all but the last.
       for (const item of request.questions) {
         if (request.signal?.aborted === true) break
-        answers.push(await askOne(ctx, item))
+        answers.push(await askOne(ctx, item, request.signal))
       }
       return { answers }
     },

--- a/packages/tui/src/scroll.ts
+++ b/packages/tui/src/scroll.ts
@@ -1,0 +1,78 @@
+/**
+ * A bounded window over physical rendered rows.
+ *
+ * Rendering owns what a row means; this class owns only which contiguous rows
+ * are visible. Keeping those concerns apart lets modal documents, lists, and
+ * future views share the same resize-safe position rules.
+ * @module @riesbri/dsh-tui/scroll
+ */
+
+/** A scroll position over a sequence of rendered rows. */
+export class RowViewport {
+  private offset = 0
+  private total = 0
+  private visible = 1
+
+  /**
+   * Update the document and window sizes, retaining the current position where
+   * it remains valid.
+   * @param total - rendered rows in the complete document.
+   * @param visible - rows the current layout can show, possibly zero.
+   * @returns whether a smaller document or wider window moved the viewport.
+   */
+  update(total: number, visible: number): boolean {
+    this.total = Math.max(0, total)
+    this.visible = Math.max(0, visible)
+    const next = Math.min(this.offset, this.maxOffset)
+    if (next === this.offset) return false
+    this.offset = next
+    return true
+  }
+
+  /**
+   * Move by physical rendered rows, clamped to the document's bounds.
+   * @param amount - positive moves down; negative moves up.
+   * @returns whether the position changed.
+   */
+  move(amount: number): boolean {
+    const next = Math.min(Math.max(this.offset + amount, 0), this.maxOffset)
+    if (next === this.offset) return false
+    this.offset = next
+    return true
+  }
+
+  /**
+   * Jump to the document's first row.
+   * @returns whether the position changed.
+   */
+  first(): boolean {
+    if (this.offset === 0) return false
+    this.offset = 0
+    return true
+  }
+
+  /**
+   * Jump to the last valid top row.
+   * @returns whether the position changed.
+   */
+  last(): boolean {
+    if (this.offset === this.maxOffset) return false
+    this.offset = this.maxOffset
+    return true
+  }
+
+  /** The first visible row, zero-based. */
+  get start(): number {
+    return this.offset
+  }
+
+  /** The exclusive end of the visible window. */
+  get end(): number {
+    return Math.min(this.offset + this.visible, this.total)
+  }
+
+  /** The greatest valid first visible row. */
+  get maxOffset(): number {
+    return Math.max(0, this.total - this.visible)
+  }
+}

--- a/packages/tui/src/slots.ts
+++ b/packages/tui/src/slots.ts
@@ -39,9 +39,10 @@ export interface TuiSlotView {
   /**
    * Lines this view contributes right now.
    * @param columns - the terminal's current width, for views that fit content.
+   * @param rows - the terminal's current height, when the view bounds itself.
    * @returns logical lines; the screen wraps them.
    */
-  render(columns: number): readonly string[]
+  render(columns: number, rows?: number): readonly string[]
   /**
    * Where the terminal cursor belongs inside THIS view's own lines, for the one
    * view that owns text entry. Row 0 is the view's first line, so a view can be
@@ -138,16 +139,17 @@ export class TuiSlots extends Service {
    * no cursor: text entry belongs to the composer, which is not on screen while
    * an overlay is up.
    * @param columns - the terminal's current width.
+   * @param rows - the terminal's current height; defaults for older callers.
    * @returns the lines to draw top to bottom, and where the cursor belongs.
    */
-  compose(columns: number): { lines: string[]; cursor: LiveCursor | undefined } {
+  compose(columns: number, rows = 24): { lines: string[]; cursor: LiveCursor | undefined } {
     const overlay = this.activeOverlay
-    if (overlay !== undefined) return { lines: [...overlay.render(columns)], cursor: undefined }
+    if (overlay !== undefined) return { lines: [...overlay.render(columns, rows)], cursor: undefined }
     const lines: string[] = []
     let cursor: LiveCursor | undefined
     for (const name of SLOT_ORDER) {
       for (const entry of this.slots.get(name) ?? []) {
-        const own = entry.view.render(columns)
+        const own = entry.view.render(columns, rows)
         const placement = cursor === undefined ? entry.view.cursor?.(columns) : undefined
         // Translate the view-relative row into the composed region's row space.
         if (placement !== undefined) cursor = { row: lines.length + placement.row, column: placement.column }

--- a/packages/tui/tests/plan-review-frames.spec.ts
+++ b/packages/tui/tests/plan-review-frames.spec.ts
@@ -1,0 +1,90 @@
+/** A long plan must remain a live overlay, never scrollback debris. */
+
+import { describe, expect, it } from 'vitest'
+import { Screen } from '@riesbri/dsh-tui-renderer'
+import { createEmulator } from '../../../tests/emulator.ts'
+import { createPlanReviewOverlay } from '../src/plan-review.ts'
+
+/** The width used by the real-terminal regression frames. */
+const COLUMNS = 80
+
+/** The choices and descriptions emitted by the plan-mode exit tool. */
+const CHOICES = [
+  {
+    value: 'Approve',
+    label: 'Approve',
+    description: 'Leave plan mode; the plan is carried out from the next step.',
+  },
+  {
+    value: 'Keep planning',
+    label: 'Keep planning',
+    description: 'Stay in plan mode; feedback goes back to the model.',
+  },
+] as const
+
+/** The long plan needs sentinels whose names cannot overlap. */
+const PLAN = [
+  '# Huge plan',
+  '- PLAN-FIRST-SENTINEL',
+  ...Array.from({ length: 98 }, (_, index) => `- PLAN-STEP-${String(index + 2)}`),
+  '- PLAN-LAST-SENTINEL',
+].join('\n')
+
+describe('plan review on a real terminal', () => {
+  it.each([24, 15])('keeps a long plan inside a %i-row terminal', async rows => {
+    const emulator = createEmulator(COLUMNS, rows)
+    const screen = new Screen(emulator.target)
+    screen.commit(['TRANSCRIPT before plan A', 'TRANSCRIPT before plan B'])
+    let overlay!: ReturnType<typeof createPlanReviewOverlay>
+    const draw = (): void => { screen.setLive(overlay.render(COLUMNS, rows)) }
+    overlay = createPlanReviewOverlay({
+      plan: PLAN,
+      question: 'Approve this plan and leave plan mode?',
+      choices: CHOICES,
+      settle: () => {},
+      invalidate: draw,
+    })
+
+    draw()
+    expect((await emulator.screen()).length).toBeLessThanOrEqual(rows)
+    for (let index = 0; index < 150; index += 1) overlay.handleKey({ kind: 'key', name: 'down' })
+
+    const visible = await emulator.screen()
+    const all = await emulator.scrollback()
+    expect(visible.join('\n')).toContain('PLAN-LAST-SENTINEL')
+    expect(all.filter(line => line.includes('PLAN-FIRST-SENTINEL'))).toHaveLength(0)
+    expect(all.filter(line => line.includes('TRANSCRIPT before plan A'))).toHaveLength(1)
+    expect(all.filter(line => line.includes('TRANSCRIPT before plan B'))).toHaveLength(1)
+    expect(all.filter(line => line.includes('Plan review'))).toHaveLength(1)
+    emulator.dispose()
+  })
+
+  it('keeps multiline review chrome inside a fifteen-row terminal', async () => {
+    const rows = 15
+    const emulator = createEmulator(COLUMNS, rows)
+    const screen = new Screen(emulator.target)
+    let overlay!: ReturnType<typeof createPlanReviewOverlay>
+    const draw = (): void => { screen.setLive(overlay.render(COLUMNS, rows)) }
+    overlay = createPlanReviewOverlay({
+      plan: PLAN,
+      question: 'Approve this plan\nand leave plan mode?',
+      choices: [{
+        value: 'Approve',
+        label: 'Approve\nplan',
+        description: 'Leave plan mode;\nthe plan is carried out next.',
+      }, {
+        value: 'Keep planning',
+        label: 'Keep\nplanning',
+        description: 'Stay in plan mode;\nfeedback goes to the model.',
+      }],
+      settle: () => {},
+      invalidate: draw,
+    })
+
+    draw()
+    expect((await emulator.screen()).length).toBeLessThanOrEqual(rows)
+    for (let index = 0; index < 150; index += 1) overlay.handleKey({ kind: 'key', name: 'down' })
+    expect((await emulator.screen()).join('\n')).toContain('PLAN-LAST-SENTINEL')
+    emulator.dispose()
+  })
+})

--- a/packages/tui/tests/plan-review-frames.spec.ts
+++ b/packages/tui/tests/plan-review-frames.spec.ts
@@ -59,6 +59,32 @@ describe('plan review on a real terminal', () => {
     emulator.dispose()
   })
 
+  it('keeps an ultra-compact review out of scrollback in a five-row terminal', async () => {
+    const rows = 5
+    const emulator = createEmulator(COLUMNS, rows)
+    const screen = new Screen(emulator.target)
+    screen.commit(['TRANSCRIPT before compact A', 'TRANSCRIPT before compact B'])
+    let overlay!: ReturnType<typeof createPlanReviewOverlay>
+    const draw = (): void => { screen.setLive(overlay.render(COLUMNS, rows)) }
+    overlay = createPlanReviewOverlay({
+      plan: PLAN,
+      question: 'Approve this plan?',
+      choices: CHOICES,
+      settle: () => {},
+      invalidate: draw,
+    })
+
+    draw()
+    for (let index = 0; index < 30; index += 1) overlay.handleKey({ kind: 'key', name: 'right' })
+    const visible = await emulator.screen()
+    const all = await emulator.scrollback()
+    expect(visible.length).toBeLessThanOrEqual(rows)
+    expect(all.filter(line => line.includes('TRANSCRIPT before compact A'))).toHaveLength(1)
+    expect(all.filter(line => line.includes('TRANSCRIPT before compact B'))).toHaveLength(1)
+    expect(all.filter(line => line.includes('Decision:'))).toHaveLength(1)
+    emulator.dispose()
+  })
+
   it('keeps multiline review chrome inside a fifteen-row terminal', async () => {
     const rows = 15
     const emulator = createEmulator(COLUMNS, rows)

--- a/packages/tui/tests/plan-review.spec.ts
+++ b/packages/tui/tests/plan-review.spec.ts
@@ -1,0 +1,93 @@
+/** The plan decision needs a bounded, readable presentation rather than a generic picker detail. */
+
+import { describe, expect, it } from 'vitest'
+import { displayWidth, stripAnsi } from '@riesbri/dsh-tui-renderer'
+import { createPlanReviewOverlay } from '../src/plan-review.ts'
+
+/** Choices the plan-mode tool sends with a review request. */
+const CHOICES = [
+  { value: 'Approve', label: 'Approve' },
+  { value: 'Keep planning', label: 'Keep planning' },
+] as const
+
+/** Remove styling so assertions name exactly the text a person reads. */
+function plain(lines: readonly string[]): string[] {
+  return lines.map(stripAnsi)
+}
+
+describe('plan review', () => {
+  it('renders a markdown plan in a bounded window that reaches every row', () => {
+    let redraws = 0
+    const overlay = createPlanReviewOverlay({
+      plan: `# Release plan\n\n${Array.from({ length: 18 }, (_, index) => `- unique step ${String(index + 1)}`).join('\n')}`,
+      question: 'Approve this plan and leave plan mode?',
+      choices: CHOICES,
+      settle: () => {},
+      invalidate: () => { redraws += 1 },
+    })
+
+    const first = plain(overlay.render(40))
+    // The specialized review identifies the document and parses its markdown;
+    // the generic picker used to show it as dim, truncated option detail.
+    expect(first.join('\n')).toContain('Plan review')
+    expect(first.join('\n')).toContain('Release plan')
+    expect(first.join('\n')).toContain('• unique step 1')
+    expect(first.join('\n')).not.toContain('• unique step 18')
+    expect(first.join('\n')).toContain('rows 1–10 of 20')
+    expect(first.every(row => displayWidth(row) <= 40)).toBe(true)
+
+    for (let index = 0; index < 20; index += 1) overlay.handleKey({ kind: 'key', name: 'down' })
+    const last = plain(overlay.render(40))
+    expect(redraws).toBe(10)
+    expect(last.join('\n')).toContain('• unique step 18')
+    expect(last.join('\n')).toContain('rows 11–20 of 20')
+  })
+
+  it('makes option text safe before putting it in the frame', () => {
+    const overlay = createPlanReviewOverlay({
+      plan: '# Plan',
+      question: 'Approve this plan?',
+      choices: [{
+        value: 'Approve',
+        label: 'Approve\u001b[2J',
+        description: 'Leave plan mode\u001b[2J and begin the work.',
+      }],
+      settle: () => {},
+      invalidate: () => {},
+    })
+    const frame = overlay.render(80).join('\n')
+    expect(frame).not.toContain('\u001b[2J')
+    expect(stripAnsi(frame)).toContain('Approve^[[2J')
+    expect(stripAnsi(frame)).toContain('Leave plan mode^[[2J and begin the work.')
+  })
+
+  it('scrolls the plan without changing which answer enter confirms', () => {
+    let answer: string | undefined = 'unanswered'
+    const overlay = createPlanReviewOverlay({
+      plan: `# Plan\n${Array.from({ length: 12 }, (_, index) => `step ${String(index + 1)}`).join('\n')}`,
+      question: 'Approve this plan?',
+      choices: CHOICES,
+      settle: value => { answer = value },
+      invalidate: () => {},
+    })
+    overlay.render(80)
+    overlay.handleKey({ kind: 'key', name: 'down' })
+    overlay.handleKey({ kind: 'key', name: 'enter' })
+    expect(answer).toBe('Approve')
+  })
+
+  it('changes the decision with tab instead of making the plan unreachable', () => {
+    let answer: string | undefined = 'unanswered'
+    const overlay = createPlanReviewOverlay({
+      plan: '# Plan',
+      question: 'Approve this plan?',
+      choices: CHOICES,
+      settle: value => { answer = value },
+      invalidate: () => {},
+    })
+    overlay.render(80)
+    overlay.handleKey({ kind: 'key', name: 'tab' })
+    overlay.handleKey({ kind: 'key', name: 'enter' })
+    expect(answer).toBe('Keep planning')
+  })
+})

--- a/packages/tui/tests/plan-review.spec.ts
+++ b/packages/tui/tests/plan-review.spec.ts
@@ -6,8 +6,16 @@ import { createPlanReviewOverlay } from '../src/plan-review.ts'
 
 /** Choices the plan-mode tool sends with a review request. */
 const CHOICES = [
-  { value: 'Approve', label: 'Approve' },
-  { value: 'Keep planning', label: 'Keep planning' },
+  {
+    value: 'Approve',
+    label: 'Approve',
+    description: 'Leave plan mode; the plan is carried out from the next step.',
+  },
+  {
+    value: 'Keep planning',
+    label: 'Keep planning',
+    description: 'Stay in plan mode; feedback goes back to the model.',
+  },
 ] as const
 
 /** Remove styling so assertions name exactly the text a person reads. */
@@ -26,7 +34,7 @@ describe('plan review', () => {
       invalidate: () => { redraws += 1 },
     })
 
-    const first = plain(overlay.render(40))
+    const first = plain(overlay.render(40, 24))
     // The specialized review identifies the document and parses its markdown;
     // the generic picker used to show it as dim, truncated option detail.
     expect(first.join('\n')).toContain('Plan review')
@@ -37,10 +45,44 @@ describe('plan review', () => {
     expect(first.every(row => displayWidth(row) <= 40)).toBe(true)
 
     for (let index = 0; index < 20; index += 1) overlay.handleKey({ kind: 'key', name: 'down' })
-    const last = plain(overlay.render(40))
+    const last = plain(overlay.render(40, 24))
     expect(redraws).toBe(10)
     expect(last.join('\n')).toContain('• unique step 18')
     expect(last.join('\n')).toContain('rows 11–20 of 20')
+  })
+
+  it('uses fewer plan rows in a short terminal and retains its scroll position on resize', () => {
+    const overlay = createPlanReviewOverlay({
+      plan: `# Release plan\n${Array.from({ length: 30 }, (_, index) => `- resize step ${String(index + 1)}`).join('\n')}`,
+      question: 'Approve this plan?',
+      choices: CHOICES,
+      settle: () => {},
+      invalidate: () => {},
+    })
+    overlay.render(80, 24)
+    for (let index = 0; index < 6; index += 1) overlay.handleKey({ kind: 'key', name: 'down' })
+    const short = plain(overlay.render(80, 15))
+    expect(short).toHaveLength(15)
+    expect(short.join('\n')).toContain('rows 7–10 of 31')
+    expect(short.join('\n')).toContain('• resize step 6')
+    expect(short.join('\n')).not.toContain('• resize step 10')
+
+    const tall = plain(overlay.render(80, 24))
+    expect(tall.join('\n')).toContain('rows 7–16 of 31')
+  })
+
+  it('keeps a compact decision-only review inside a terminal too short for one plan row', () => {
+    const overlay = createPlanReviewOverlay({
+      plan: '# Release plan\n- hidden until resized',
+      question: 'Approve this plan?',
+      choices: CHOICES,
+      settle: () => {},
+      invalidate: () => {},
+    })
+    const compact = plain(overlay.render(80, 8))
+    expect(compact).toHaveLength(6)
+    expect(compact.join('\n')).toContain('resize terminal to read the plan')
+    expect(compact.join('\n')).not.toContain('hidden until resized')
   })
 
   it('makes option text safe before putting it in the frame', () => {
@@ -55,7 +97,7 @@ describe('plan review', () => {
       settle: () => {},
       invalidate: () => {},
     })
-    const frame = overlay.render(80).join('\n')
+    const frame = overlay.render(80, 24).join('\n')
     expect(frame).not.toContain('\u001b[2J')
     expect(stripAnsi(frame)).toContain('Approve^[[2J')
     expect(stripAnsi(frame)).toContain('Leave plan mode^[[2J and begin the work.')
@@ -70,13 +112,17 @@ describe('plan review', () => {
       settle: value => { answer = value },
       invalidate: () => {},
     })
-    overlay.render(80)
+    overlay.render(80, 24)
     overlay.handleKey({ kind: 'key', name: 'down' })
     overlay.handleKey({ kind: 'key', name: 'enter' })
     expect(answer).toBe('Approve')
   })
 
-  it('changes the decision with tab instead of making the plan unreachable', () => {
+  it.each([
+    ['left', 'Keep planning'],
+    ['right', 'Keep planning'],
+    ['tab', 'Keep planning'],
+  ] as const)('moves the decision with %s', (key, expected) => {
     let answer: string | undefined = 'unanswered'
     const overlay = createPlanReviewOverlay({
       plan: '# Plan',
@@ -85,9 +131,9 @@ describe('plan review', () => {
       settle: value => { answer = value },
       invalidate: () => {},
     })
-    overlay.render(80)
-    overlay.handleKey({ kind: 'key', name: 'tab' })
+    overlay.render(80, 24)
+    overlay.handleKey({ kind: 'key', name: key })
     overlay.handleKey({ kind: 'key', name: 'enter' })
-    expect(answer).toBe('Keep planning')
+    expect(answer).toBe(expected)
   })
 })

--- a/packages/tui/tests/plan-review.spec.ts
+++ b/packages/tui/tests/plan-review.spec.ts
@@ -18,6 +18,13 @@ const CHOICES = [
   },
 ] as const
 
+/** Three choices make backwards motion distinguishable from forwards motion. */
+const DIRECTION_CHOICES = [
+  { value: 'A', label: 'A' },
+  { value: 'B', label: 'B' },
+  { value: 'C', label: 'C' },
+] as const
+
 /** Remove styling so assertions name exactly the text a person reads. */
 function plain(lines: readonly string[]): string[] {
   return lines.map(stripAnsi)
@@ -71,6 +78,17 @@ describe('plan review', () => {
     expect(tall.join('\n')).toContain('rows 7–16 of 31')
   })
 
+  it.each([0, 1, 2, 3, 4, 5, 6, 8, 15, 24])('never renders more than %i terminal rows', rows => {
+    const overlay = createPlanReviewOverlay({
+      plan: '# Release plan\n- hidden until resized',
+      question: 'Approve this plan?',
+      choices: CHOICES,
+      settle: () => {},
+      invalidate: () => {},
+    })
+    expect(overlay.render(80, rows).length).toBeLessThanOrEqual(rows)
+  })
+
   it('keeps a compact decision-only review inside a terminal too short for one plan row', () => {
     const overlay = createPlanReviewOverlay({
       plan: '# Release plan\n- hidden until resized',
@@ -119,15 +137,15 @@ describe('plan review', () => {
   })
 
   it.each([
-    ['left', 'Keep planning'],
-    ['right', 'Keep planning'],
-    ['tab', 'Keep planning'],
+    ['left', 'C'],
+    ['right', 'B'],
+    ['tab', 'B'],
   ] as const)('moves the decision with %s', (key, expected) => {
     let answer: string | undefined = 'unanswered'
     const overlay = createPlanReviewOverlay({
       plan: '# Plan',
       question: 'Approve this plan?',
-      choices: CHOICES,
+      choices: DIRECTION_CHOICES,
       settle: value => { answer = value },
       invalidate: () => {},
     })

--- a/packages/tui/tests/questions.spec.ts
+++ b/packages/tui/tests/questions.spec.ts
@@ -1,0 +1,99 @@
+/** Plan-review questions take their dedicated overlay instead of a generic detail picker. */
+
+import { describe, expect, it } from 'vitest'
+import type { Context } from '@deepseek-ai/cordis'
+import type { AskUserQuestionAnswer, AskUserQuestionRequest } from '@deepseek-ai/dsh-user-questions'
+import { stripAnsi } from '@riesbri/dsh-tui-renderer'
+import type { TuiOverlay } from '../src/slots.ts'
+import { installQuestionProvider } from '../src/questions.ts'
+
+/**
+ * A context just large enough to retain the questions provider and its overlay.
+ * @returns the context plus readers for the provider and active overlay.
+ */
+function questionContext(): {
+  ctx: Context
+  ask(): ((request: AskUserQuestionRequest) => Promise<AskUserQuestionAnswer>) | undefined
+  overlay(): TuiOverlay | undefined
+} {
+  let provider: { ask(request: AskUserQuestionRequest): Promise<AskUserQuestionAnswer> } | undefined
+  let active: TuiOverlay | undefined
+  const ctx = {
+    userQuestions: {
+      registerProvider(next: { ask(request: AskUserQuestionRequest): Promise<AskUserQuestionAnswer> }) {
+        provider = next
+        return () => {}
+      },
+    },
+    tuiSlots: {
+      invalidate: () => {},
+      pushOverlay(next: TuiOverlay) {
+        active = next
+        return () => { active = undefined }
+      },
+    },
+  } as unknown as Context
+  return { ctx, ask: () => provider?.ask, overlay: () => active }
+}
+
+describe('plan-review questions', () => {
+  it('uses the scrollable plan presentation and preserves the ordinary answer protocol', async () => {
+    const { ctx, ask, overlay } = questionContext()
+    installQuestionProvider(ctx)
+    const request = ask()
+    expect(request).toBeDefined()
+
+    const answer = request?.({
+      questions: [{
+        id: 'plan-review',
+        header: 'Plan review',
+        question: 'Approve this plan and leave plan mode?',
+        detail: '# Clear outcome\n\n- read every line',
+        options: [{ label: 'Approve' }, { label: 'Keep planning' }],
+        intent: { kind: 'plan-review', approve: 'Approve' },
+      }],
+    } as AskUserQuestionRequest)
+    const shown = stripAnsi(overlay()?.render(80).join('\n') ?? '')
+    expect(shown).toContain('Plan review')
+    expect(shown).toContain('Clear outcome')
+    expect(shown).toContain('• read every line')
+
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'plan-review', selected: ['Approve'] }] })
+  })
+
+  it('reports a dismissed plan as a cancellation, not a request to keep planning', async () => {
+    const { ctx, ask, overlay } = questionContext()
+    installQuestionProvider(ctx)
+    const answer = ask()?.({
+      questions: [{
+        id: 'plan-review',
+        question: 'Approve this plan?',
+        detail: '# Plan',
+        options: [{ label: 'Approve' }, { label: 'Keep planning' }],
+        intent: { kind: 'plan-review', approve: 'Approve' },
+      }],
+    } as AskUserQuestionRequest)
+    overlay()?.handleKey({ kind: 'key', name: 'escape' })
+    await expect(answer).rejects.toMatchObject({ code: 'ASK_CANCELLED' })
+  })
+
+  it('dismisses the review and rejects when its calling tool is aborted', async () => {
+    const { ctx, ask, overlay } = questionContext()
+    installQuestionProvider(ctx)
+    const abort = new AbortController()
+    const answer = ask()?.({
+      signal: abort.signal,
+      questions: [{
+        id: 'plan-review',
+        question: 'Approve this plan?',
+        detail: '# Plan',
+        options: [{ label: 'Approve' }, { label: 'Keep planning' }],
+        intent: { kind: 'plan-review', approve: 'Approve' },
+      }],
+    } as AskUserQuestionRequest)
+    abort.abort()
+    await expect(answer).rejects.toMatchObject({ code: 'ASK_ABORTED' })
+    expect(overlay()).toBeUndefined()
+  })
+})

--- a/packages/tui/tests/scroll.spec.ts
+++ b/packages/tui/tests/scroll.spec.ts
@@ -1,0 +1,57 @@
+/** A viewport owns row position across document and terminal-size changes. */
+
+import { describe, expect, it } from 'vitest'
+import { RowViewport } from '../src/scroll.ts'
+
+describe('RowViewport', () => {
+  it('starts at the first row and cannot move above it', () => {
+    const viewport = new RowViewport()
+    viewport.update(10, 3)
+    expect(viewport.start).toBe(0)
+    expect(viewport.move(-1)).toBe(false)
+  })
+
+  it('moves through rows and clamps at the last full window', () => {
+    const viewport = new RowViewport()
+    viewport.update(10, 3)
+    expect(viewport.move(4)).toBe(true)
+    expect([viewport.start, viewport.end]).toEqual([4, 7])
+    expect(viewport.move(100)).toBe(true)
+    expect([viewport.start, viewport.end, viewport.maxOffset]).toEqual([7, 10, 7])
+    expect(viewport.move(1)).toBe(false)
+  })
+
+  it('jumps to both ends', () => {
+    const viewport = new RowViewport()
+    viewport.update(10, 3)
+    expect(viewport.last()).toBe(true)
+    expect(viewport.start).toBe(7)
+    expect(viewport.first()).toBe(true)
+    expect(viewport.start).toBe(0)
+  })
+
+  it('keeps position when shrinking the window and clamps it when growing it', () => {
+    const viewport = new RowViewport()
+    viewport.update(20, 10)
+    viewport.move(8)
+    viewport.update(20, 4)
+    expect(viewport.start).toBe(8)
+    viewport.update(20, 15)
+    expect(viewport.start).toBe(5)
+  })
+
+  it('clamps when the document shrinks', () => {
+    const viewport = new RowViewport()
+    viewport.update(20, 4)
+    viewport.last()
+    viewport.update(6, 4)
+    expect([viewport.start, viewport.end]).toEqual([2, 6])
+  })
+
+  it('allows a zero-row window without invalid offsets', () => {
+    const viewport = new RowViewport()
+    viewport.update(4, 0)
+    expect(viewport.last()).toBe(true)
+    expect([viewport.start, viewport.end, viewport.maxOffset]).toEqual([4, 4, 4])
+  })
+})


### PR DESCRIPTION
Plan-mode's exit tool sends the complete plan as a question detail. The generic picker put that unbounded detail in the live region, so a plan taller than the terminal could not be redrawn safely: its start became inaccessible and the plan looked like dim reasoning rather than the decision to approve.

Render the plan as markdown in a dedicated, fixed ten-row review window. Up/down scroll its rendered rows, tab changes the decision, and the review retains the question and selected option's consequence. This preserves native terminal safety without trying to turn scrollback into a modal viewport. The plan and option text are escaped before styling.

A dismissed review now raises ASK_CANCELLED, which lets plan mode tell the model the user took over instead of treating it as a request for another draft. An aborted tool request likewise removes the overlay and raises ASK_ABORTED.

Verified the focused plan-review and user-question tests, build, typecheck, and security checks. Deliberately changed the window from ten rows to one hundred and confirmed the bounded-review test failed by showing the final plan step on the first frame. The full suite is otherwise green but currently fails the pre-existing unstaged Screen placeholder test in packages/renderer/tests/screen.spec.ts; that test is outside this change.