### PR TITLE
refactor(tui): centralize local commands

### DIFF
--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -47,6 +47,8 @@ import { createCompletion } from './completion.ts'
 import { isTranscriptEvent, pickSession, readTranscript, resumeBanner } from './resume.ts'
 import { listModelOptions, pickModel } from './model.ts'
 import { installQuestionProvider } from './questions.ts'
+import { LocalCommandRegistry } from './local-commands.ts'
+import type { LocalCommandChoice } from './local-commands.ts'
 import { TuiSlots } from './slots.ts'
 import { StreamBuffer } from './stream.ts'
 import { effortLabel, pickReasoning, reasoningValues } from './reasoning.ts'
@@ -74,53 +76,11 @@ export { TuiSlots } from './slots.ts'
 /** Reported in the banner; kept beside the code so a release bumps one place. */
 const VERSION = '0.2.0'
 
-/**
- * Slash lines this frontend answers itself, rather than passing to the registry.
- *
- * Deliberately NOT registered with `ctx.commands`. That registry is shared by every
- * surface in the process, and these two are things only a terminal can do: a web
- * client or the automation server has no terminal to leave and no picker to open,
- * so offering them there would advertise commands that cannot work. They are listed
- * in the completion menu alongside the registered ones, because a person typing `/`
- * wants to see what they can type, not which registry it came from.
- */
-const LOCAL_COMMANDS: readonly { readonly name: string; readonly description: string }[] = [
-  { name: 'model', description: 'Choose the provider and model for the next turn' },
-  { name: 'profile', description: 'Show where the time went in each turn, under the reply' },
-  { name: 'reasoning', description: 'Set how hard the model thinks, for the next turn' },
-  { name: 'usage', description: 'Choose what the status line reports: cost, tokens, or nothing' },
-  { name: 'exit', description: 'Leave the session, as ctrl-d does' },
-  { name: 'quit', description: 'Leave the session, as ctrl-d does' },
-]
-
-/**
- * The local gesture that opens the model picker rather than reaching the model.
- *
- * A NAME, not a whole line, as {@link EXIT_COMMANDS} are too. The line is what the
- * user typed: `/model` carrying an argument, or the trailing space that accepting
- * the completion leaves behind, is still the same gesture. Comparing whole lines
- * sent those to the registry, which does not have them either — so the frontend's
- * own commands came back as unknown.
- */
-const MODEL_COMMAND = 'model'
-
-/** The local gesture that sets reasoning effort; it reads its argument, unlike `/model`. */
-const REASONING_COMMAND = 'reasoning'
-
-/** The local gesture that chooses how much the usage reading reports. */
-const USAGE_COMMAND = 'usage'
-
-/** The local toggle for the turn profiler; binary, so bare flips it. */
-const PROFILE_COMMAND = 'profile'
-
 /** What `/profile` accepts, for completing its argument. */
-const PROFILE_VALUES: readonly { value: string; note: string }[] = [
+const PROFILE_VALUES: readonly LocalCommandChoice[] = [
   { value: 'on', note: 'Chart each turn under its reply' },
   { value: 'off', note: 'Stop charting turns' },
 ]
-
-/** Local gestures that leave, so a person who types one is not told it is unknown. */
-const EXIT_COMMANDS = ['exit', 'quit'] as const
 
 /**
  * Budget for a slash command, so a command that never settles cannot wedge the
@@ -248,43 +208,6 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
 
   const composer = new Composer()
   const composerView = createComposerView(composer, workspace)
-  // Completion reads the harness through two narrow functions rather than taking a
-  // context, so its rules are testable without one. `ctx.fs` is optional: a profile
-  // that mounts no filesystem offers no path completion rather than failing.
-  const completion = createCompletion(composer, {
-    // The frontend's own gestures listed beside the registry's, so `/` shows what
-    // can be typed rather than what happens to be registered.
-    commands: () => [...LOCAL_COMMANDS, ...ctx.commands.list(agent)]
-      .sort((left, right) => left.name.localeCompare(right.name)),
-    // Only this frontend's own commands offer values. A registered command
-    // describes its argument as a free-text hint rather than as a list, so there
-    // is nothing to enumerate, and inventing candidates for one would suggest a
-    // vocabulary the handler never agreed to.
-    commandArguments: async name => {
-      if (name === REASONING_COMMAND) return reasoningValues(reasoning)
-      if (name === USAGE_COMMAND) return USAGE_MODES.map(mode => ({ value: mode.id, note: mode.description }))
-      if (name === PROFILE_COMMAND) return PROFILE_VALUES
-      if (name === MODEL_COMMAND) {
-        return (await listModelOptions(ctx)).map(option => ({ value: option.model, note: option.provider }))
-      }
-      return []
-    },
-    paths: async directory => {
-      const fs = ctx.get('fs')
-      if (fs === undefined) return []
-      try {
-        const target = await fs.resolve(directory === '' ? '.' : directory, { cwd: workspace })
-        return (await fs.listDir(target)).map(entry => ({
-          name: entry.name,
-          directory: entry.type === 'directory',
-        }))
-      } catch {
-        // A path that does not resolve, or a directory the policy refuses, simply
-        // offers nothing: a completion list is not the place to report either.
-        return []
-      }
-    },
-  }, () => { ctx.tuiSlots.invalidate() })
   const stream = new StreamBuffer()
   // Scoped to the agent: a scoped tool shadows a global one, and a restricted-away
   // tool reads as absent, so the card must come from the definition that ran.
@@ -338,6 +261,142 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
       .catch(() => {})
   }
   refreshModelInfo()
+
+  // Deliberately NOT registered with `ctx.commands`. That registry is shared by
+  // every surface in the process, and a web client or automation server has no
+  // terminal to leave, picker to open, or status line to switch. The registry
+  // still supplies these commands to completion, because `/` should show what a
+  // person can type rather than which service happens to answer it.
+  const localCommands = new LocalCommandRegistry([
+    {
+      name: 'model',
+      description: 'Choose the provider and model for the next turn',
+      complete: async () => (await listModelOptions(ctx))
+        .map(option => ({ value: option.model, note: option.provider })),
+      execute: async rawInput => {
+        const outcome = await pickModel(ctx, selection, rawInput)
+        if (outcome !== undefined) {
+          refreshModelInfo()
+          commit([style(`· ${outcome}`, 'gray')])
+        }
+        draw()
+      },
+    },
+    {
+      name: 'profile',
+      description: 'Show where the time went in each turn, under the reply',
+      complete: () => PROFILE_VALUES,
+      execute: rawInput => {
+        const named = rawInput.trim().toLowerCase()
+        if (named !== '' && named !== 'on' && named !== 'off') {
+          commit([style('\u2717 /profile takes on or off, or nothing to flip it', 'red')])
+          draw()
+          return
+        }
+        // Binary, so a bare gesture flips it rather than opening a list of two.
+        profiling = named === '' ? !profiling : named === 'on'
+        commit([style(
+          profiling ? '· turn profiler: on, from the next turn' : '· turn profiler: off',
+          'gray',
+        )])
+        draw()
+      },
+    },
+    {
+      name: 'reasoning',
+      description: 'Set how hard the model thinks, for the next turn',
+      complete: () => reasoningValues(reasoning),
+      execute: async rawInput => {
+        // The levels are a short fixed set a person learns by heart, so
+        // `/reasoning max` should not cost a picker.
+        const outcome = await pickReasoning(ctx, selection, reasoning, rawInput)
+        if (outcome !== undefined) commit([style(`· ${outcome}`, 'gray')])
+        draw()
+      },
+    },
+    {
+      name: 'usage',
+      description: 'Choose what the status line reports: cost, tokens, or nothing',
+      complete: () => USAGE_MODES.map(mode => ({ value: mode.id, note: mode.description })),
+      execute: async rawInput => {
+        // Named or asked for, never both: an argument is the form that should not
+        // cost an overlay, and the picker is where the descriptions live. The two
+        // meet again at one resolve, so a typed word and a chosen row cannot drift.
+        const named = rawInput.trim()
+        const picked = named === ''
+          ? await promptSelect(ctx, {
+            title: 'What the status line reports',
+            detail: `current: ${usageMode}`,
+            choices: USAGE_MODES.map(mode => ({
+              value: mode.id,
+              label: mode.name,
+              description: mode.description,
+            })),
+          })
+          : named
+        // Dismissed, so nothing changed and there is nothing to report.
+        if (picked === undefined) {
+          draw()
+          return
+        }
+        const chosen = resolveUsageMode(picked)
+        if (chosen === undefined) {
+          const offered = USAGE_MODES.map(mode => mode.id).join(', ')
+          commit([style(
+            `\u2717 no usage setting named ${escapeControls(picked)}; try one of: ${offered}`,
+            'red',
+          )])
+          draw()
+          return
+        }
+        usageMode = chosen
+        // Acknowledged by name, as `ctrl-o` is: switching a segment OFF removes the
+        // only evidence the command did anything, so silence would read as failure.
+        commit([style(`· usage: ${usageMode}`, 'gray')])
+        draw()
+      },
+    },
+    {
+      name: 'exit',
+      description: 'Leave the session, as ctrl-d does',
+      execute: () => { exit?.(0) },
+    },
+    {
+      name: 'quit',
+      description: 'Leave the session, as ctrl-d does',
+      execute: () => { exit?.(0) },
+    },
+  ])
+
+  // Completion reads the harness through two narrow functions rather than taking a
+  // context, so its rules are testable without one. `ctx.fs` is optional: a profile
+  // that mounts no filesystem offers no path completion rather than failing.
+  const completion = createCompletion(composer, {
+    // The frontend's own gestures listed beside the registry's, so `/` shows what
+    // can be typed rather than what happens to be registered.
+    commands: () => [...localCommands.list(), ...ctx.commands.list(agent)]
+      .sort((left, right) => left.name.localeCompare(right.name)),
+    // Only this frontend's own commands offer values. A registered command
+    // describes its argument as a free-text hint rather than as a list, so there
+    // is nothing to enumerate, and inventing candidates for one would suggest a
+    // vocabulary the handler never agreed to.
+    commandArguments: name => localCommands.arguments(name),
+    paths: async directory => {
+      const fs = ctx.get('fs')
+      if (fs === undefined) return []
+      try {
+        const target = await fs.resolve(directory === '' ? '.' : directory, { cwd: workspace })
+        return (await fs.listDir(target)).map(entry => ({
+          name: entry.name,
+          directory: entry.type === 'directory',
+        }))
+      } catch {
+        // A path that does not resolve, or a directory the policy refuses, simply
+        // offers nothing: a completion list is not the place to report either.
+        return []
+      }
+    },
+  }, () => { ctx.tuiSlots.invalidate() })
 
   /**
    * The current goal, or nothing when there is none to report.
@@ -541,81 +600,7 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
     // have to agree on what a command line is, and the registry's parser is the
     // authority on that. A second rule written here would drift from it.
     const parsed = parseCommand(line)
-    if (parsed !== undefined && (EXIT_COMMANDS as readonly string[]).includes(parsed.name)) {
-      exit?.(0)
-      return
-    }
-    if (parsed?.name === MODEL_COMMAND) {
-      const outcome = await pickModel(ctx, selection, parsed.rawInput)
-      if (outcome !== undefined) {
-        refreshModelInfo()
-        commit([style(`· ${outcome}`, 'gray')])
-      }
-      draw()
-      return
-    }
-    if (parsed?.name === REASONING_COMMAND) {
-      // The argument is read, unlike `/model`'s: the levels are a short fixed set
-      // a person learns by heart, so `/reasoning max` should not cost a picker.
-      const outcome = await pickReasoning(ctx, selection, reasoning, parsed.rawInput)
-      if (outcome !== undefined) commit([style(`· ${outcome}`, 'gray')])
-      draw()
-      return
-    }
-    if (parsed?.name === USAGE_COMMAND) {
-      // Named or asked for, never both: an argument is the form that should not
-      // cost an overlay, and the picker is where the descriptions live. The two
-      // meet again at one resolve, so a typed word and a chosen row cannot drift.
-      const named = parsed.rawInput.trim()
-      const picked = named === ''
-        ? await promptSelect(ctx, {
-          title: 'What the status line reports',
-          detail: `current: ${usageMode}`,
-          choices: USAGE_MODES.map(mode => ({
-            value: mode.id,
-            label: mode.name,
-            description: mode.description,
-          })),
-        })
-        : named
-      // Dismissed, so nothing changed and there is nothing to report.
-      if (picked === undefined) {
-        draw()
-        return
-      }
-      const chosen = resolveUsageMode(picked)
-      if (chosen === undefined) {
-        const offered = USAGE_MODES.map(mode => mode.id).join(', ')
-        commit([style(
-          `\u2717 no usage setting named ${escapeControls(picked)}; try one of: ${offered}`,
-          'red',
-        )])
-        draw()
-        return
-      }
-      usageMode = chosen
-      // Acknowledged by name, as `ctrl-o` is: switching a segment OFF removes the
-      // only evidence the command did anything, so silence would read as failure.
-      commit([style(`· usage: ${usageMode}`, 'gray')])
-      draw()
-      return
-    }
-    if (parsed?.name === PROFILE_COMMAND) {
-      const named = parsed.rawInput.trim().toLowerCase()
-      if (named !== '' && named !== 'on' && named !== 'off') {
-        commit([style('\u2717 /profile takes on or off, or nothing to flip it', 'red')])
-        draw()
-        return
-      }
-      // Binary, so a bare gesture flips it rather than opening a list of two.
-      profiling = named === '' ? !profiling : named === 'on'
-      commit([style(
-        profiling ? '· turn profiler: on, from the next turn' : '· turn profiler: off',
-        'gray',
-      )])
-      draw()
-      return
-    }
+    if (parsed !== undefined && await localCommands.execute(parsed.name, parsed.rawInput)) return
     // A registered command runs without a model turn, and its `command/run` and
     // `command/done` events are what the transcript shows — projected above, so the
     // live session and a resumed one read identically. Nothing is committed here.

--- a/packages/tui/src/local-commands.ts
+++ b/packages/tui/src/local-commands.ts
@@ -1,0 +1,82 @@
+/**
+ * Commands that belong to this terminal frontend rather than the shared harness.
+ *
+ * The harness registry is shared by every surface in a process. These commands
+ * can therefore be completed beside it without being registered into it.
+ * @module @riesbri/dsh-tui/local-commands
+ */
+
+/** A value one local command can complete after its name. */
+export interface LocalCommandChoice {
+  /** Text inserted as the command argument. */
+  readonly value: string
+  /** Optional explanation shown beside the value. */
+  readonly note?: string
+}
+
+/** One command this terminal frontend handles itself. */
+export interface LocalCommand {
+  /** Name without the leading slash. */
+  readonly name: string
+  /** Summary shown in the slash-command completion list. */
+  readonly description: string
+  /**
+   * Values available for the command's one-word argument.
+   * @returns the currently available values, synchronously or asynchronously.
+   */
+  complete?(): readonly LocalCommandChoice[] | Promise<readonly LocalCommandChoice[]>
+  /**
+   * Handle the text after the command name.
+   * @param rawInput - exactly what followed the command name in the submitted line.
+   * @returns when handling is complete, synchronously or asynchronously.
+   */
+  execute(rawInput: string): void | Promise<void>
+}
+
+/** Finds, completes, and dispatches the terminal's own commands. */
+export class LocalCommandRegistry {
+  /**
+   * @param commands - commands owned by this terminal frontend.
+   */
+  constructor(private readonly commands: readonly LocalCommand[]) {}
+
+  /**
+   * Command summaries suitable for the shared completion list.
+   * @returns names and descriptions, in registration order.
+   */
+  list(): readonly { readonly name: string; readonly description: string }[] {
+    return this.commands.map(({ name, description }) => ({ name, description }))
+  }
+
+  /**
+   * Find one local command.
+   * @param name - command name without its leading slash.
+   * @returns the command, or undefined when the harness should handle the name.
+   */
+  get(name: string): LocalCommand | undefined {
+    return this.commands.find(command => command.name === name)
+  }
+
+  /**
+   * Complete one local command's argument.
+   * @param name - command name without its leading slash.
+   * @returns offered values, or none when the command is not local or has none.
+   */
+  async arguments(name: string): Promise<readonly LocalCommandChoice[]> {
+    const complete = this.get(name)?.complete
+    return complete === undefined ? [] : await complete()
+  }
+
+  /**
+   * Run one local command when this registry owns it.
+   * @param name - command name without its leading slash.
+   * @param rawInput - exactly what followed the command name in the submitted line.
+   * @returns whether this terminal frontend handled the command.
+   */
+  async execute(name: string, rawInput: string): Promise<boolean> {
+    const command = this.get(name)
+    if (command === undefined) return false
+    await command.execute(rawInput)
+    return true
+  }
+}

--- a/packages/tui/tests/local-commands.spec.ts
+++ b/packages/tui/tests/local-commands.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { LocalCommandRegistry } from '../src/local-commands.ts'
+
+describe('LocalCommandRegistry', () => {
+  it('lists only the completion-facing command summaries', () => {
+    const registry = new LocalCommandRegistry([
+      {
+        name: 'profile',
+        description: 'Chart each turn',
+        execute: () => {},
+      },
+    ])
+
+    expect(registry.list()).toEqual([{ name: 'profile', description: 'Chart each turn' }])
+    expect(registry.get('profile')?.name).toBe('profile')
+    expect(registry.get('missing')).toBeUndefined()
+  })
+
+  it('returns each command’s synchronous or asynchronous completion values', async () => {
+    const registry = new LocalCommandRegistry([
+      {
+        name: 'profile',
+        description: '',
+        complete: () => [{ value: 'on', note: 'Chart each turn' }],
+        execute: () => {},
+      },
+      {
+        name: 'model',
+        description: '',
+        complete: async () => [{ value: 'deepseek-v4-pro', note: 'DeepSeek' }],
+        execute: () => {},
+      },
+      { name: 'exit', description: '', execute: () => {} },
+    ])
+
+    await expect(registry.arguments('profile')).resolves.toEqual([{ value: 'on', note: 'Chart each turn' }])
+    await expect(registry.arguments('model')).resolves.toEqual([{ value: 'deepseek-v4-pro', note: 'DeepSeek' }])
+    await expect(registry.arguments('exit')).resolves.toEqual([])
+    await expect(registry.arguments('missing')).resolves.toEqual([])
+  })
+
+  it('runs only a local command and preserves its raw input', async () => {
+    const executed: string[] = []
+    const registry = new LocalCommandRegistry([
+      {
+        name: 'usage',
+        description: '',
+        execute: async rawInput => { executed.push(rawInput) },
+      },
+    ])
+
+    await expect(registry.execute('usage', '  tokens  ')).resolves.toBe(true)
+    await expect(registry.execute('harness-command', '')).resolves.toBe(false)
+    expect(executed).toEqual(['  tokens  '])
+  })
+
+  it('lets a local command failure reach the runner’s existing error reporter', async () => {
+    const registry = new LocalCommandRegistry([
+      {
+        name: 'model',
+        description: '',
+        execute: () => { throw new Error('provider unavailable') },
+      },
+    ])
+
+    await expect(registry.execute('model', '')).rejects.toThrow('provider unavailable')
+  })
+})


### PR DESCRIPTION
## Summary
- add `LocalCommand`, `LocalCommandChoice`, and `LocalCommandRegistry`
- keep each terminal-local command's description, completion, and execution closure together
- route completion and submission through that registry before the unchanged harness path
- port `/model`, `/reasoning`, `/usage`, `/profile`, `/exit`, and `/quit` without changing their output

This branch starts at `main` after #26.

## Verification
- `pnpm build`
- `pnpm test` (537 tests)
- `pnpm typecheck`
- `pnpm security`
- deliberately returned `false` after a local command executed; `LocalCommandRegistry > runs only a local command and preserves its raw input` failed as expected