### PR TITLE
fix(tui): accept completions with enter

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -65,9 +65,9 @@ Models that reason send their thinking as a separate kind of output, sometimes f
 
 ## Suggestions come from what the agent really has
 
-Typing `/` lists the commands this agent actually registered. Typing `@` lists real entries from the folder. `tab` accepts, the arrow keys move, `esc` closes.
+Typing `/` lists the commands this agent actually registered. Typing `@` lists real entries from the folder. `tab` accepts the highlighted suggestion; `enter` accepts it when it completes the current token, otherwise it submits normally. The arrow keys move, `esc` closes.
 
-The suggestion list is deliberately not a modal box. A modal box takes every keystroke, and suggestions have to coexist with typing — so the list claims only its own keys, never `enter`, and it narrows as you type instead of trapping the line.
+The suggestion list is deliberately not a modal box. A modal box takes every keystroke, and suggestions have to coexist with typing — so the list claims only its own keys, and it narrows as you type instead of trapping the line. An exact command, path, or argument is already complete, so `enter` still belongs to the composer and preserves the command's bare behavior.
 
 Only the text before the cursor is considered. Completing against text after the cursor would rewrite characters nobody asked about. And `/` only starts a command at the beginning of a line, because `/help` is a command while `see /etc/hosts` is a path.
 

--- a/packages/tui/src/completion.ts
+++ b/packages/tui/src/completion.ts
@@ -245,7 +245,7 @@ export function createCompletion(
         })
         const hidden = candidates.length - shown.length
         if (hidden > 0) rows.push(`    ${style(`… ${String(hidden)} more`, 'gray')}`)
-        rows.push(`    ${style('tab complete · esc dismiss', 'gray')}`)
+        rows.push(`    ${style('tab/enter complete · esc dismiss', 'gray')}`)
         return rows
       },
     },
@@ -262,6 +262,19 @@ export function createCompletion(
         case 'down':
           cursor = (cursor + 1) % candidates.length
           return true
+        case 'enter': {
+          const candidate = candidates[cursor]
+          // Tab explicitly accepts, including the separator on an exact token.
+          // Enter only completes: otherwise a bare command's own behavior would
+          // require a second Enter just because its name remains listed.
+          if (
+            candidate === undefined ||
+            token === undefined ||
+            candidate.replace.trimEnd() === token.text
+          ) return false
+          accept(candidate)
+          return true
+        }
         case 'tab': {
           const candidate = candidates[cursor]
           if (candidate !== undefined) accept(candidate)
@@ -274,8 +287,7 @@ export function createCompletion(
           clear()
           return true
         default:
-          // Every other key is the composer's. `enter` in particular: a completion
-          // list must never swallow a submission.
+          // Every other key is the composer's.
           return false
       }
     },

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -674,9 +674,9 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
       overlay.handleKey(key)
       return
     }
-    // Completion sees the key BEFORE the composer, but claims only its own
-    // gestures — never `enter`, never a printable character — so the list narrows
-    // as text arrives and a submission is never swallowed.
+    // Completion sees the key BEFORE the composer. It leaves printable characters
+    // alone so the list narrows as text arrives, and leaves an exact candidate's
+    // enter alone so an already-complete instruction still submits.
     if (completion.active && completion.handleKey(key)) {
       draw()
       return

--- a/packages/tui/tests/completion.spec.ts
+++ b/packages/tui/tests/completion.spec.ts
@@ -20,6 +20,7 @@ const TREE: Record<string, { name: string; directory: boolean }[]> = {
 
 /** Commands to complete against. */
 const COMMANDS = [
+  { name: 'exit', description: 'leave the session' },
   { name: 'model', description: 'pick a model' },
   { name: 'clear', description: 'clear the session' },
   { name: 'compact', description: 'compact the session' },
@@ -93,7 +94,7 @@ type Rendered = { view: { render(columns: number): readonly string[] } }
 /** The candidate rows, styling and selection marker removed, hint line dropped. */
 function rows(completion: Rendered): string[] {
   return completion.view.render(80).map(stripAnsi).map(row => row.trim())
-    .filter(row => row !== '' && !row.startsWith('tab complete') && !row.startsWith('…'))
+    .filter(row => row !== '' && !row.endsWith('complete · esc dismiss') && !row.startsWith('…'))
     .map(row => (row.startsWith('\u203a ') ? row.slice(2) : row))
 }
 
@@ -309,6 +310,51 @@ describe('accepting a candidate', () => {
     expect(composer.value).toBe('/model ')
   })
 
+  it('accepts a command with enter', async () => {
+    const { composer, completion } = typed('/ex')
+    await completion.refresh()
+    expect(completion.handleKey({ kind: 'key', name: 'enter' })).toBe(true)
+    expect(composer.value).toBe('/exit ')
+  })
+
+  it('accepts the highlighted path with enter', async () => {
+    const { composer, completion } = typed('@pack')
+    await completion.refresh()
+    expect(completion.handleKey({ kind: 'key', name: 'enter' })).toBe(true)
+    expect(composer.value).toBe('@packages/')
+  })
+
+  it('accepts a partial command argument with enter', async () => {
+    const { composer, completion } = typed('/reasoning h')
+    await completion.refresh()
+    expect(completion.handleKey({ kind: 'key', name: 'enter' })).toBe(true)
+    expect(composer.value).toBe('/reasoning high ')
+  })
+
+  it('submits an already-complete command with enter', async () => {
+    const { composer, completion } = typed('/exit')
+    await completion.refresh()
+    const enter = { kind: 'key', name: 'enter' } as const
+    expect(completion.handleKey(enter)).toBe(false)
+    expect(composer.handle(enter)).toEqual({ kind: 'submit', text: '/exit' })
+  })
+
+  it('submits a bare command with optional arguments with enter', async () => {
+    const { composer, completion } = typed('/reasoning')
+    await completion.refresh()
+    const enter = { kind: 'key', name: 'enter' } as const
+    expect(completion.handleKey(enter)).toBe(false)
+    expect(composer.handle(enter)).toEqual({ kind: 'submit', text: '/reasoning' })
+  })
+
+  it('submits an already-complete path with enter', async () => {
+    const { composer, completion } = typed('@README.md')
+    await completion.refresh()
+    const enter = { kind: 'key', name: 'enter' } as const
+    expect(completion.handleKey(enter)).toBe(false)
+    expect(composer.handle(enter)).toEqual({ kind: 'submit', text: '@README.md' })
+  })
+
   it('counts a wide character once when replacing', async () => {
     // The token is measured in code points, the unit the buffer stores, so a wide
     // or astral character does not consume two positions of the replacement.
@@ -335,10 +381,12 @@ describe('keys the completion claims, and those it does not', () => {
     expect(selected(completion)).toBe('README.md')
   })
 
-  it('never claims enter, so a submission is never swallowed', async () => {
-    const { completion } = typed('/c')
+  it('leaves enter to the composer when no completion is visible', async () => {
+    const { composer, completion } = typed('ordinary prose')
     await completion.refresh()
-    expect(completion.handleKey({ kind: 'key', name: 'enter' })).toBe(false)
+    const enter = { kind: 'key', name: 'enter' } as const
+    expect(completion.handleKey(enter)).toBe(false)
+    expect(composer.handle(enter)).toEqual({ kind: 'submit', text: 'ordinary prose' })
   })
 
   it('never claims a printable character, so the list narrows as you type', async () => {
@@ -353,6 +401,15 @@ describe('keys the completion claims, and those it does not', () => {
     for (const name of ['up', 'down', 'tab', 'escape'] as const) {
       expect(completion.handleKey({ kind: 'key', name })).toBe(false)
     }
+  })
+
+  it('does not accept a dismissed candidate when enter submits', async () => {
+    const { composer, completion } = typed('@pack')
+    await completion.refresh()
+    expect(completion.handleKey({ kind: 'key', name: 'escape' })).toBe(true)
+    const enter = { kind: 'key', name: 'enter' } as const
+    expect(completion.handleKey(enter)).toBe(false)
+    expect(composer.handle(enter)).toEqual({ kind: 'submit', text: '@pack' })
   })
 
   it('dismisses for the current token only', async () => {


### PR DESCRIPTION
## Summary
- let Enter accept a highlighted command, path, or argument only when it changes the current token
- preserve normal Composer submission for exact command names, paths, and arguments, including bare commands with optional arguments and Escape-dismissed completion
- document the distinction and cover partial and exact tokens

## Why it is safe
`/reasoning h` completes to `/reasoning high `, while `/reasoning high` has no candidate and submits normally. `/exit`, `/reasoning`, and `@README.md` may still have exact candidates, but Enter leaves those unchanged and submits; Tab explicitly accepts and adds the separator.

## Verification
- `pnpm vitest run packages/tui/tests/completion.spec.ts` (44 passing)
- `pnpm build`
- `pnpm typecheck`
- `pnpm security`
- Deliberately removed the Enter case and confirmed partial command, path, and argument tests fail.
- Deliberately accepted exact candidates and confirmed exact command, bare optional-argument command, and exact-path tests fail.

`pnpm test` was run in the shared working tree; it has one unrelated failure in the pre-existing, unstaged `Screen > keeps a placeholder live region out of scrollback` test.
