### PR TITLE
feat(tui): add input history

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,11 +6,6 @@ This is version 0.2.0 — early software. This page is meant to set expectations
 
 Ordered by how much each would change daily use, not by how easy it is.
 
-### Next
-
-- **Let `enter` accept the highlighted suggestion.** Today only `tab` does, because the suggestion list must never swallow a message you meant to send. The result is that typing `/ex` and pressing enter submits `/ex`, which is then reported as an unknown command. Accepting *only while a suggestion is highlighted* is what every comparable interface does; the care needed is in the case where you meant to send.
-- **History in the input line** — the up and down arrow keys moving through your previous messages, once those keys are not needed by the suggestion list.
-
 ### Later
 
 - **Real file attachments** — turning `@path` into actual attached content, instead of a file name the model has to go and read for itself.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,11 +41,18 @@ Without a global `dsh` and without that variable, `pnpm dsh` still works — but
 | `ctrl-d` | Quit, from anywhere — including a picker, a question, or an approval prompt |
 | `ctrl-l` | Clear the display |
 | `ctrl-o` | Change how much tool output is shown: compact, full, hidden |
-| `↑` `↓` `enter` `esc` | Move, confirm, and close a box or a suggestion list |
+| `↑` `↓` | Move through your earlier messages; while a suggestion list is open, move through it instead |
+| `enter` `esc` | Confirm or close a box or a suggestion list |
 
 Editing keys: `←` `→` to move, `home` and `end` (or `ctrl-a` and `ctrl-e`) for the ends of the line, `backspace` and `delete`, and `ctrl-u`, `ctrl-k`, `ctrl-w` to delete to the start, to the end, and by word.
 
 Pasting several lines inserts all of them and sends them as a single message.
+
+### Input history
+
+When no suggestion list is open, `↑` steps back through the lines you sent this session — prompts and slash commands alike — and `↓` steps forward again. A half-typed line is kept for you: step back to look at an earlier message, and stepping forward past the newest one restores your unfinished line exactly as it was.
+
+Consecutive identical submissions are remembered once, so running `run tests` three times in a row does not fill the history with three copies of it. Reopening a session restores its history from the saved log.
 
 ### About shift-enter
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,7 +52,9 @@ Pasting several lines inserts all of them and sends them as a single message.
 
 When no suggestion list is open, `↑` steps back through the lines you sent this session — prompts and slash commands alike — and `↓` steps forward again. A half-typed line is kept for you: step back to look at an earlier message, and stepping forward past the newest one restores your unfinished line exactly as it was.
 
-Consecutive identical submissions are remembered once, so running `run tests` three times in a row does not fill the history with three copies of it. Reopening a session restores its history from the saved log.
+Consecutive identical submissions are remembered once, so running `run tests` three times in a row does not fill the history with three copies of it.
+
+Reopening a session restores the history the saved log recorded: every prompt and every resolved slash command. The commands this interface handles itself (`/model`, `/reasoning`, `/usage`, `/profile`, `/exit`, `/quit`) and mistyped commands are remembered while the session is open but are not written to the session log, so they are not restored after a resume.
 
 ### About shift-enter
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,7 +54,7 @@ When no suggestion list is open, `↑` steps back through the lines you sent thi
 
 Consecutive identical submissions are remembered once, so running `run tests` three times in a row does not fill the history with three copies of it.
 
-Reopening a session restores the history the saved log recorded: every prompt and every resolved slash command. The commands this interface handles itself (`/model`, `/reasoning`, `/usage`, `/profile`, `/exit`, `/quit`) and mistyped commands are remembered while the session is open but are not written to the session log, so they are not restored after a resume.
+Reopening a session restores the history the saved log recorded: every prompt and every resolved slash command whose input was recorded. The commands this interface handles itself (`/model`, `/reasoning`, `/usage`, `/profile`, `/exit`, `/quit`) and mistyped commands are remembered while the session is open but are not written to the session log, so they are not restored after a resume.
 
 ### About shift-enter
 

--- a/packages/tui/src/completion.ts
+++ b/packages/tui/src/completion.ts
@@ -141,21 +141,29 @@ export interface Completion {
    * @returns whether the completion consumed it.
    */
   handleKey(key: Key): boolean
-  /** Stop offering candidates until the next refresh finds some. */
-  dismiss(): void
+  /**
+   * Abandon any lookup still in flight and stop offering candidates, without
+   * recomputing against the composer's current text.
+   *
+   * Used when the composer is replaced wholesale — a submitted line or a
+   * recalled history entry — so a slow directory read cannot revive candidates
+   * for text that no longer exists. `refresh()` must run again before anything
+   * is offered.
+   */
+  invalidate(): void
 }
 
 /**
  * Wire completion to a composer.
  * @param composer - the buffer being edited; accepting a candidate rewrites it.
  * @param sources - where candidates come from.
- * @param invalidate - asks the runner to redraw.
+ * @param redraw - asks the runner to redraw.
  * @returns the live completion state.
  */
 export function createCompletion(
   composer: Composer,
   sources: CompletionSources,
-  invalidate: () => void,
+  redraw: () => void,
 ): Completion {
   let candidates: readonly Candidate[] = []
   let token: Token | undefined
@@ -186,7 +194,7 @@ export function createCompletion(
     // say so: every replacement ends in a space, and neither token rule reaches
     // past one. `/reasoning high ` is not a completable token, and would not be
     // one even if it were read as a finished value — see {@link argumentCandidates}.
-    void refresh().then(invalidate)
+    void refresh().then(redraw)
   }
 
   const refresh = async (): Promise<void> => {
@@ -291,8 +299,12 @@ export function createCompletion(
           return false
       }
     },
-    dismiss() {
-      dismissedFor = token?.text
+    invalidate() {
+      // Advancing the generation is what abandons an in-flight lookup: its
+      // resolution checks `generation !== mine` and drops the result. Clearing
+      // alone would leave that lookup free to revive candidates afterwards.
+      generation += 1
+      dismissedFor = undefined
       clear()
     },
   }

--- a/packages/tui/src/history.ts
+++ b/packages/tui/src/history.ts
@@ -1,0 +1,121 @@
+/**
+ * Submitted-line history for the composer.
+ *
+ * The composer stays a dumb editable buffer: it knows how to insert, delete, and
+ * move, and it does not know which of its contents were ever sent. This class is
+ * the memory around it — a list of submitted lines plus a navigation position —
+ * and the runner asks it for a value before every up/down arrow the completion
+ * list did not take.
+ *
+ * The rule that is easy to get wrong is the draft. Stepping back from a
+ * half-typed line must not throw that line away, so the first step back captures
+ * it and the step forward past the newest entry returns it. Only a new
+ * submission, or an edit made while a history entry is showing, replaces it.
+ * @module @riesbri/dsh-tui/history
+ */
+
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { textOf } from './transcript.ts'
+
+/** One submitted line, plus the navigation position around it. */
+export class InputHistory {
+  /** Submissions in chronological order; a consecutive repeat collapses to one. */
+  private readonly entries: string[] = []
+  /** Index of the entry on screen, or `entries.length` while at the draft. */
+  private cursor = 0
+  /** The draft captured when navigation first stepped into history. */
+  private draft: string | undefined
+
+  /**
+   * Record a submitted line.
+   *
+   * Empty lines never enter, and a line identical to the one just recorded is
+   * not stored again — `run tests` submitted three times is one entry rather
+   * than three. Recording is also the point where navigation restarts: a
+   * submission returns the composer to a fresh draft, so the next up arrow
+   * walks from the newest entry rather than from wherever the last walk stopped.
+   * @param text - the submitted text.
+   */
+  record(text: string): void {
+    if (text === '') return
+    if (this.entries[this.entries.length - 1] !== text) this.entries.push(text)
+    // Reset even when the line was a duplicate: a submission ends navigation
+    // whether or not it added an entry, so the next up arrow walks from the
+    // newest line rather than from wherever the last walk had stopped.
+    this.cursor = this.entries.length
+    this.draft = undefined
+  }
+
+  /**
+   * Step back to the next older entry.
+   *
+   * The first step back captures the current draft, which is what makes it
+   * possible to return to it. Stepping back from the oldest entry returns
+   * undefined and changes nothing, so the arrow falls through to the composer,
+   * which ignores it.
+   * @param currentDraft - the composer's text when navigation begins.
+   * @returns the entry to show, or undefined when there is no older one.
+   */
+  previous(currentDraft: string): string | undefined {
+    if (this.entries.length === 0) return undefined
+    if (this.cursor === this.entries.length) this.draft = currentDraft
+    if (this.cursor === 0) return undefined
+    this.cursor -= 1
+    return this.entries[this.cursor]
+  }
+
+  /**
+   * Step forward to the next newer entry, or back to the saved draft.
+   *
+   * Past the newest entry the saved draft is returned rather than undefined,
+   * because a draft is a thing to restore, not delete. At the draft already,
+   * undefined tells the runner there is nowhere further forward to go.
+   * @returns the entry or draft to show, or undefined when already at the draft.
+   */
+  next(): string | undefined {
+    if (this.cursor === this.entries.length) return undefined
+    this.cursor += 1
+    if (this.cursor === this.entries.length) return this.draft
+    return this.entries[this.cursor]
+  }
+
+  /**
+   * Return to the draft and forget the one that was saved.
+   *
+   * Called when the composer is edited by anything other than history itself, so
+   * the next up arrow captures the edited text as the new draft instead of
+   * restoring the line that was showing before the edit.
+   */
+  reset(): void {
+    this.cursor = this.entries.length
+    this.draft = undefined
+  }
+}
+
+/**
+ * Reconstruct the submitted lines a durable session log carries.
+ *
+ * Two event kinds are human submissions: a `user/message` whose source is
+ * `user`, and a `command/run` that recorded its input. A command that suppressed
+ * its input is skipped rather than reconstructed as a bare `/name`, because that
+ * would put a line into history the user never typed. The result is fed into
+ * {@link InputHistory.record} in log order, so the duplicate rule and the
+ * newest-first navigation behave for a reopened session exactly as they did
+ * while it was being typed.
+ * @param events - a session log, in order.
+ * @returns the submitted lines, oldest first.
+ */
+export function historyLines(events: readonly SessionEvent[]): string[] {
+  const lines: string[] = []
+  for (const event of events) {
+    if (event.type === 'user/message') {
+      if (event.data.source.kind !== 'user') continue
+      const text = textOf(event.data.content).trim()
+      if (text !== '') lines.push(text)
+    } else if (event.type === 'command/run') {
+      if (event.data.args === undefined) continue
+      lines.push(`/${event.data.name}${event.data.args.trimEnd()}`)
+    }
+  }
+  return lines
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -682,8 +682,9 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
     }
     const action = composer.handle(key)
     if (action.kind === 'submit') {
-      // Whatever was being completed is gone with the line.
-      completion.dismiss()
+      // Whatever was being completed is gone with the line, and any lookup it
+      // had in flight must not land afterwards.
+      completion.invalidate()
       draw()
       submit(action.text).catch(report)
       return

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -40,10 +40,11 @@ import type {} from '@deepseek-ai/dsh-cmdline'
 // offers none rather than failing, so this carries the type without a hard need.
 import type {} from '@deepseek-ai/dsh-fs'
 import type { Key } from '@riesbri/dsh-tui-renderer'
-import { acquireTerminal, Composer, escapeControls, Screen, SPINNER_INTERVAL_MS, style } from '@riesbri/dsh-tui-renderer'
+import { acquireTerminal, Composer, escapeControls, sanitizePasted, Screen, SPINNER_INTERVAL_MS, style } from '@riesbri/dsh-tui-renderer'
 import { CARD_DETAIL_CYCLE, ToolCards } from './cards.ts'
 import { installApprovalAnswerer } from './approval.ts'
 import { createCompletion } from './completion.ts'
+import { historyLines, InputHistory } from './history.ts'
 import { isTranscriptEvent, pickSession, readTranscript, resumeBanner } from './resume.ts'
 import { listModelOptions, pickModel } from './model.ts'
 import { installQuestionProvider } from './questions.ts'
@@ -207,6 +208,7 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
   const workspace = agent.session.header.cwd ?? startup.cwd
 
   const composer = new Composer()
+  const history = new InputHistory()
   const composerView = createComposerView(composer, workspace)
   const stream = new StreamBuffer()
   // Scoped to the agent: a scoped tool shadows a global one, and a restricted-away
@@ -596,6 +598,10 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
    */
   const submit = async (text: string): Promise<void> => {
     const line = text.trim()
+    // Recorded before dispatch, and before any early return, so a submitted line
+    // is navigable even when it was an unknown command or a command that failed —
+    // the user typed it, and the next up arrow should find it.
+    if (line !== '') history.record(line)
     // Parsed once, up front: the local gestures and the unknown-command guard below
     // have to agree on what a command line is, and the registry's parser is the
     // authority on that. A second rule written here would drift from it.
@@ -659,12 +665,42 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
       overlay.handleKey(key)
       return
     }
-    // Completion sees the key BEFORE the composer. It leaves printable characters
-    // alone so the list narrows as text arrives, and leaves an exact candidate's
-    // enter alone so an already-complete instruction still submits.
+    // Completion sees the key BEFORE the composer, and before history. It leaves
+    // printable characters alone so the list narrows as text arrives, and leaves
+    // an exact candidate's enter alone so an already-complete instruction still
+    // submits.
     if (completion.active && completion.handleKey(key)) {
+      // Accepting a candidate edits the buffer, which is a new draft exactly as a
+      // typed character would be: history navigation must restart from it rather
+      // than later restore the line that was showing before the accept.
+      if (key.kind === 'key' && (key.name === 'tab' || key.name === 'enter')) history.reset()
       draw()
       return
+    }
+    // History answers the vertical arrows only when completion did not. The two
+    // share one pair of keys, and completion always wins while it is showing:
+    // a history entry that is itself completable (a `/reasoning max`) reopens the
+    // list, and the next arrow then moves through IT rather than through time.
+    if (key.kind === 'key' && key.name === 'up') {
+      const value = history.previous(composer.value)
+      if (value !== undefined) {
+        // `Composer.set` writes verbatim, and a seeded history entry came from a
+        // session log — untrusted for the same reason a paste is. Sanitized here
+        // so the buffer keeps its safe-to-draw invariant.
+        composer.set(sanitizePasted(value))
+        draw()
+        completion.refresh().then(draw).catch(report)
+        return
+      }
+    }
+    if (key.kind === 'key' && key.name === 'down') {
+      const value = history.next()
+      if (value !== undefined) {
+        composer.set(sanitizePasted(value))
+        draw()
+        completion.refresh().then(draw).catch(report)
+        return
+      }
     }
     const action = composer.handle(key)
     if (action.kind === 'submit') {
@@ -675,6 +711,10 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
       return
     }
     if (action.kind === 'changed') {
+      // Any direct edit abandons history navigation: the edited text is the new
+      // draft, and the next up arrow must capture it rather than the line that
+      // was showing before the edit.
+      history.reset()
       // Recomputed after the edit, because what is completable is a function of the
       // text as it now stands. The redraw comes with the result, not before it.
       draw()
@@ -724,8 +764,12 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
     // session reads exactly like the one that was watched happen. Committed in ONE
     // write: an event-by-event commit would redraw the live region thousands of
     // times to produce a screen nobody sees until the end of it.
-    const history = await readTranscript(ctx, resumeId)
-    const replayed = history.filter(isTranscriptEvent)
+    const events = await readTranscript(ctx, resumeId)
+    const replayed = events.filter(isTranscriptEvent)
+    // History is seeded from the same durable events the transcript replays, so
+    // a reopened session navigates what was actually submitted — direct prompts
+    // and recorded slash commands — rather than only what this process has seen.
+    for (const line of historyLines(replayed)) history.record(line)
     const columns = terminal.columns()
     const lines = replayed.flatMap(event => project(event, columns))
     // The buffer is left holding nothing: a log can end mid-reply, and a partial

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -40,11 +40,12 @@ import type {} from '@deepseek-ai/dsh-cmdline'
 // offers none rather than failing, so this carries the type without a hard need.
 import type {} from '@deepseek-ai/dsh-fs'
 import type { Key } from '@riesbri/dsh-tui-renderer'
-import { acquireTerminal, Composer, escapeControls, sanitizePasted, Screen, SPINNER_INTERVAL_MS, style } from '@riesbri/dsh-tui-renderer'
+import { acquireTerminal, Composer, escapeControls, Screen, SPINNER_INTERVAL_MS, style } from '@riesbri/dsh-tui-renderer'
 import { CARD_DETAIL_CYCLE, ToolCards } from './cards.ts'
 import { installApprovalAnswerer } from './approval.ts'
 import { createCompletion } from './completion.ts'
 import { historyLines, InputHistory } from './history.ts'
+import { routeInputKey } from './input.ts'
 import { isTranscriptEvent, pickSession, readTranscript, resumeBanner } from './resume.ts'
 import { listModelOptions, pickModel } from './model.ts'
 import { installQuestionProvider } from './questions.ts'
@@ -665,42 +666,19 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
       overlay.handleKey(key)
       return
     }
-    // Completion sees the key BEFORE the composer, and before history. It leaves
-    // printable characters alone so the list narrows as text arrives, and leaves
-    // an exact candidate's enter alone so an already-complete instruction still
-    // submits.
-    if (completion.active && completion.handleKey(key)) {
-      // Accepting a candidate edits the buffer, which is a new draft exactly as a
-      // typed character would be: history navigation must restart from it rather
-      // than later restore the line that was showing before the accept.
-      if (key.kind === 'key' && (key.name === 'tab' || key.name === 'enter')) history.reset()
+    // Completion, then history, then the composer. The two share the vertical
+    // arrows, and completion always wins while it is showing. History traversal
+    // deliberately does NOT recompute completion, so a recalled line that would
+    // be completable (`/model`) does not steal the next arrow press: the user
+    // entered history navigation, and stays there until they edit or submit.
+    const routed = routeInputKey(key, composer, completion, history)
+    if (routed === 'completion') {
       draw()
       return
     }
-    // History answers the vertical arrows only when completion did not. The two
-    // share one pair of keys, and completion always wins while it is showing:
-    // a history entry that is itself completable (a `/reasoning max`) reopens the
-    // list, and the next arrow then moves through IT rather than through time.
-    if (key.kind === 'key' && key.name === 'up') {
-      const value = history.previous(composer.value)
-      if (value !== undefined) {
-        // `Composer.set` writes verbatim, and a seeded history entry came from a
-        // session log — untrusted for the same reason a paste is. Sanitized here
-        // so the buffer keeps its safe-to-draw invariant.
-        composer.set(sanitizePasted(value))
-        draw()
-        completion.refresh().then(draw).catch(report)
-        return
-      }
-    }
-    if (key.kind === 'key' && key.name === 'down') {
-      const value = history.next()
-      if (value !== undefined) {
-        composer.set(sanitizePasted(value))
-        draw()
-        completion.refresh().then(draw).catch(report)
-        return
-      }
+    if (routed === 'history') {
+      draw()
+      return
     }
     const action = composer.handle(key)
     if (action.kind === 'submit') {

--- a/packages/tui/src/input.ts
+++ b/packages/tui/src/input.ts
@@ -1,0 +1,58 @@
+/**
+ * The vertical-arrow decision shared by completion and history.
+ *
+ * Both features want the same pair of keys, and the runner's answer has to be a
+ * single ordering rather than two handlers that might both move. It is: a
+ * visible completion list keeps the arrows; otherwise the arrows walk history.
+ * The composer comes last, as it always has.
+ *
+ * Extracted from the session loop because the loop itself cannot be unit-tested
+ * (it needs a terminal and an agent), while this decision is testable with the
+ * real completion and history objects.
+ * @module @riesbri/dsh-tui/input
+ */
+
+import type { Composer, Key } from '@riesbri/dsh-tui-renderer'
+import { sanitizePasted } from '@riesbri/dsh-tui-renderer'
+import type { Completion } from './completion.ts'
+import { InputHistory } from './history.ts'
+
+/** Who consumed the key, after the overlay has declined it. */
+export type InputRoute = 'completion' | 'history' | 'composer'
+
+/**
+ * Offer one key to completion, then to history, in that order.
+ *
+ * History writes into the composer through {@link Composer.set}, which does not
+ * sanitize, so a seeded entry from a session log is made safe here exactly as a
+ * paste would be — the composer's buffer must stay safe to draw. When neither
+ * completion nor history claims the key, the caller hands it to the composer.
+ * @param key - the decoded keystroke.
+ * @param composer - the buffer being edited; history navigation rewrites it.
+ * @param completion - the live completion state, consulted first.
+ * @param history - the input history, consulted for the vertical arrows.
+ * @returns which handler consumed the key.
+ */
+export function routeInputKey(
+  key: Key,
+  composer: Composer,
+  completion: Completion,
+  history: InputHistory,
+): InputRoute {
+  if (completion.active && completion.handleKey(key)) return 'completion'
+  if (key.kind === 'key' && key.name === 'up') {
+    const value = history.previous(composer.value)
+    if (value !== undefined) {
+      composer.set(sanitizePasted(value))
+      return 'history'
+    }
+  }
+  if (key.kind === 'key' && key.name === 'down') {
+    const value = history.next()
+    if (value !== undefined) {
+      composer.set(sanitizePasted(value))
+      return 'history'
+    }
+  }
+  return 'composer'
+}

--- a/packages/tui/src/input.ts
+++ b/packages/tui/src/input.ts
@@ -43,6 +43,10 @@ export function routeInputKey(
   if (key.kind === 'key' && key.name === 'up') {
     const value = history.previous(composer.value)
     if (value !== undefined) {
+      // The composer is about to be replaced, so any lookup started against the
+      // old text is abandoned — without recomputing, which would reopen a list
+      // for the recalled line and steal the next arrow press.
+      completion.invalidate()
       composer.set(sanitizePasted(value))
       return 'history'
     }
@@ -50,6 +54,7 @@ export function routeInputKey(
   if (key.kind === 'key' && key.name === 'down') {
     const value = history.next()
     if (value !== undefined) {
+      completion.invalidate()
       composer.set(sanitizePasted(value))
       return 'history'
     }

--- a/packages/tui/tests/history.spec.ts
+++ b/packages/tui/tests/history.spec.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { historyLines, InputHistory } from '../src/history.ts'
+
+/** Build the minimum event the history seeding reads, without the full envelope. */
+function event(type: string, data: unknown): SessionEvent {
+  return { type, data } as unknown as SessionEvent
+}
+
+describe('InputHistory', () => {
+  it('walks newest to oldest, then stops without wrapping', () => {
+    const history = new InputHistory()
+    history.record('fix the failing tests')
+    history.record('explain this function')
+    history.record('/refactoring ...')
+
+    expect(history.previous('my unfinished draft')).toBe('/refactoring ...')
+    expect(history.previous('my unfinished draft')).toBe('explain this function')
+    expect(history.previous('my unfinished draft')).toBe('fix the failing tests')
+    // There is nothing older than the first entry, and wrapping would loop back
+    // to the newest line the moment the user wanted to leave the list.
+    expect(history.previous('my unfinished draft')).toBe(undefined)
+  })
+
+  it('restores the unfinished draft past the newest entry', () => {
+    const history = new InputHistory()
+    history.record('fix the failing tests')
+    history.record('explain this function')
+    history.record('/refactoring ...')
+
+    expect(history.previous('can you investigate the auth')).toBe('/refactoring ...')
+    expect(history.previous('can you investigate the auth')).toBe('explain this function')
+    expect(history.next()).toBe('/refactoring ...')
+    expect(history.next()).toBe('can you investigate the auth')
+    // Already back at the draft; a further step forward changes nothing.
+    expect(history.next()).toBe(undefined)
+  })
+
+  it('restores an empty draft rather than deleting it', () => {
+    const history = new InputHistory()
+    history.record('first')
+
+    expect(history.previous('')).toBe('first')
+    expect(history.next()).toBe('')
+  })
+
+  it('does nothing while there are no entries', () => {
+    const history = new InputHistory()
+
+    expect(history.previous('draft')).toBe(undefined)
+    expect(history.next()).toBe(undefined)
+  })
+
+  it('collapses consecutive duplicates to one entry', () => {
+    const history = new InputHistory()
+    history.record('run tests')
+    history.record('run tests')
+    history.record('run tests')
+
+    expect(history.previous('draft')).toBe('run tests')
+    expect(history.previous('draft')).toBe(undefined)
+  })
+
+  it('keeps a duplicate that is not adjacent', () => {
+    const history = new InputHistory()
+    history.record('run tests')
+    history.record('run the build')
+    history.record('run tests')
+
+    expect(history.previous('draft')).toBe('run tests')
+    expect(history.previous('draft')).toBe('run the build')
+    expect(history.previous('draft')).toBe('run tests')
+  })
+
+  it('makes a line navigable as soon as it is recorded', () => {
+    const history = new InputHistory()
+    history.record('just submitted')
+
+    expect(history.previous('draft')).toBe('just submitted')
+  })
+
+  it('re-submitting a recalled duplicate still returns to the draft', () => {
+    const history = new InputHistory()
+    history.record('a')
+    history.record('b')
+    expect(history.previous('my draft')).toBe('b')
+    // Re-running the newest entry is a submission, so navigation restarts even
+    // though the entry list did not grow.
+    history.record('b')
+    expect(history.previous('')).toBe('b')
+    expect(history.next()).toBe('')
+  })
+
+  it('round-trips a multiline prompt unchanged', () => {
+    const history = new InputHistory()
+    history.record('first line\nsecond line')
+
+    expect(history.previous('draft')).toBe('first line\nsecond line')
+  })
+
+  it('round-trips a multiline draft unchanged', () => {
+    const history = new InputHistory()
+    history.record('an earlier prompt')
+
+    expect(history.previous('line one\nline two')).toBe('an earlier prompt')
+    expect(history.next()).toBe('line one\nline two')
+  })
+
+  it('round-trips a CJK prompt unchanged', () => {
+    const history = new InputHistory()
+    history.record('请修复失败的测试')
+
+    expect(history.previous('草稿')).toBe('请修复失败的测试')
+    expect(history.next()).toBe('草稿')
+  })
+
+  it('reset returns to the draft and forgets the saved one', () => {
+    const history = new InputHistory()
+    history.record('first')
+    history.record('second')
+
+    expect(history.previous('old draft')).toBe('second')
+    history.reset()
+    expect(history.next()).toBe(undefined)
+    // The next step back captures the edited text, not the draft from before.
+    expect(history.previous('new draft')).toBe('second')
+    expect(history.next()).toBe('new draft')
+  })
+})
+
+describe('historyLines()', () => {
+  it('seeds direct human prompts in log order', () => {
+    expect(historyLines([
+      event('user/message', { content: [{ type: 'text', text: 'first prompt' }], source: { kind: 'user' } }),
+      event('user/message', { content: [{ type: 'text', text: 'second prompt' }], source: { kind: 'user' } }),
+    ])).toEqual(['first prompt', 'second prompt'])
+  })
+
+  it('skips synthetic injections the user never typed', () => {
+    expect(historyLines([
+      event('user/message', {
+        content: [{ type: 'text', text: 'Additional instructions from docs/AGENTS.md' }],
+        source: { kind: 'plugin', plugin: 'agent-instructions' },
+      }),
+      event('user/message', { content: [{ type: 'text', text: 'real prompt' }], source: { kind: 'user' } }),
+    ])).toEqual(['real prompt'])
+  })
+
+  it('skips an empty human prompt', () => {
+    expect(historyLines([
+      event('user/message', { content: [{ type: 'text', text: '   ' }], source: { kind: 'user' } }),
+    ])).toEqual([])
+  })
+
+  it('reconstructs a recorded slash command', () => {
+    expect(historyLines([
+      event('command/run', { commandId: 'c1', name: 'permission', args: ' read-only', source: { kind: 'user' } }),
+    ])).toEqual(['/permission read-only'])
+  })
+
+  it('reconstructs a bare slash command with no arguments', () => {
+    expect(historyLines([
+      event('command/run', { commandId: 'c1', name: 'exit', args: '', source: { kind: 'user' } }),
+    ])).toEqual(['/exit'])
+  })
+
+  it('skips a command that suppressed its input rather than faking a bare name', () => {
+    expect(historyLines([
+      event('command/run', { commandId: 'c1', name: 'goal', source: { kind: 'user' } }),
+    ])).toEqual([])
+  })
+
+  it('interleaves prompts and commands in the order they were submitted', () => {
+    expect(historyLines([
+      event('user/message', { content: [{ type: 'text', text: 'a question' }], source: { kind: 'user' } }),
+      event('command/run', { commandId: 'c1', name: 'model', args: ' deepseek-v4-pro', source: { kind: 'user' } }),
+      event('user/message', { content: [{ type: 'text', text: 'another' }], source: { kind: 'user' } }),
+    ])).toEqual(['a question', '/model deepseek-v4-pro', 'another'])
+  })
+})

--- a/packages/tui/tests/input.spec.ts
+++ b/packages/tui/tests/input.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { Composer } from '@riesbri/dsh-tui-renderer'
+import { createCompletion } from '../src/completion.ts'
+import { InputHistory } from '../src/history.ts'
+import { routeInputKey } from '../src/input.ts'
+
+/** Completion sources offering only the named commands. */
+function completionFor(composer: Composer, commands: readonly string[]): ReturnType<typeof createCompletion> {
+  return createCompletion(composer, {
+    commands: () => commands.map(name => ({ name, description: '' })),
+    commandArguments: async () => [],
+    paths: async () => [],
+  }, () => {})
+}
+
+describe('routeInputKey()', () => {
+  it('lets a visible completion list keep the vertical arrows', async () => {
+    const composer = new Composer()
+    composer.handle({ kind: 'text', text: '/m' })
+    const completion = completionFor(composer, ['model'])
+    await completion.refresh()
+    const history = new InputHistory()
+    history.record('an older prompt')
+
+    expect(completion.active).toBe(true)
+    expect(routeInputKey({ kind: 'key', name: 'up' }, composer, completion, history)).toBe('completion')
+    // Completion moved, not history: the buffer still holds the typed token.
+    expect(composer.value).toBe('/m')
+  })
+
+  it('does not let a recalled line steal the next arrow press', async () => {
+    const composer = new Composer()
+    const completion = completionFor(composer, ['model'])
+    const history = new InputHistory()
+    history.record('explain this function')
+    history.record('/model')
+
+    expect(routeInputKey({ kind: 'key', name: 'up' }, composer, completion, history)).toBe('history')
+    expect(composer.value).toBe('/model')
+    // History traversal does not recompute completion, so the recalled `/model`
+    // does not open a list that would swallow the next arrow.
+    expect(completion.active).toBe(false)
+    expect(routeInputKey({ kind: 'key', name: 'up' }, composer, completion, history)).toBe('history')
+    expect(composer.value).toBe('explain this function')
+  })
+
+  it('restores the unfinished draft past the newest entry', () => {
+    const composer = new Composer()
+    composer.handle({ kind: 'text', text: 'half-typed draft' })
+    const completion = completionFor(composer, [])
+    const history = new InputHistory()
+    history.record('earlier')
+
+    expect(routeInputKey({ kind: 'key', name: 'up' }, composer, completion, history)).toBe('history')
+    expect(composer.value).toBe('earlier')
+    expect(routeInputKey({ kind: 'key', name: 'down' }, composer, completion, history)).toBe('history')
+    expect(composer.value).toBe('half-typed draft')
+    // Already back at the draft: the composer would ignore a further down.
+    expect(routeInputKey({ kind: 'key', name: 'down' }, composer, completion, history)).toBe('composer')
+  })
+
+  it('sanitizes a recalled seeded entry before it reaches the composer', () => {
+    const composer = new Composer()
+    const completion = completionFor(composer, [])
+    const history = new InputHistory()
+    history.record('evil\u001b[2J')
+
+    expect(routeInputKey({ kind: 'key', name: 'up' }, composer, completion, history)).toBe('history')
+    expect(composer.value).toBe('evil^[[2J')
+  })
+
+  it('leaves every non-arrow key to the composer', () => {
+    const composer = new Composer()
+    composer.handle({ kind: 'text', text: 'plain' })
+    const completion = completionFor(composer, [])
+    const history = new InputHistory()
+    history.record('unused')
+
+    expect(routeInputKey({ kind: 'text', text: 'x' }, composer, completion, history)).toBe('composer')
+    expect(composer.value).toBe('plain')
+  })
+
+  it('falls through to the composer when history has nothing to show', () => {
+    const composer = new Composer()
+    const completion = completionFor(composer, [])
+    const history = new InputHistory()
+
+    expect(routeInputKey({ kind: 'key', name: 'up' }, composer, completion, history)).toBe('composer')
+    expect(routeInputKey({ kind: 'key', name: 'down' }, composer, completion, history)).toBe('composer')
+  })
+})

--- a/packages/tui/tests/input.spec.ts
+++ b/packages/tui/tests/input.spec.ts
@@ -44,6 +44,37 @@ describe('routeInputKey()', () => {
     expect(composer.value).toBe('explain this function')
   })
 
+  it('abandons an in-flight completion lookup once history navigation starts', async () => {
+    const composer = new Composer()
+    composer.handle({ kind: 'text', text: '@pack' })
+    let release = (): void => {}
+    const completion = createCompletion(composer, {
+      commands: () => [],
+      commandArguments: async () => [],
+      paths: () => new Promise(resolve => { release = () => { resolve([{ name: 'packages', directory: true }]) } }),
+    }, () => {})
+    const pending = completion.refresh()
+    // The lookup cleared the list and is still awaiting the directory read.
+    expect(completion.active).toBe(false)
+
+    const history = new InputHistory()
+    history.record('explain this function')
+    history.record('/model')
+
+    expect(routeInputKey({ kind: 'key', name: 'up' }, composer, completion, history)).toBe('history')
+    expect(composer.value).toBe('/model')
+
+    // The stale `@pack` read resolves now. It must not revive candidates for a
+    // token the composer no longer holds, or the next arrow would move through
+    // completion instead of continuing through history.
+    release()
+    await pending
+
+    expect(completion.active).toBe(false)
+    expect(routeInputKey({ kind: 'key', name: 'up' }, composer, completion, history)).toBe('history')
+    expect(composer.value).toBe('explain this function')
+  })
+
   it('restores the unfinished draft past the newest entry', () => {
     const composer = new Composer()
     composer.handle({ kind: 'text', text: 'half-typed draft' })


### PR DESCRIPTION
## What

The input line remembers every non-empty submitted line — prompts and slash commands — and the up/down arrows walk it when the suggestion list is closed. A half-typed line is preserved: stepping forward past the newest entry restores it exactly.

Interaction rule:

- completion visible → `↑` `↓` navigate completion
- completion not visible → `↑` `↓` navigate history

History traversal deliberately does **not** recompute completion, so recalling a completable line (`/model`, `/reasoning max`, `@path`) does not open a list that would steal the next arrow press. It also **invalidates** any completion lookup that was already in flight against the pre-history text, so a slow `paths()`/`commandArguments()` read cannot revive stale candidates and steal the arrows later.

## How

- `packages/tui/src/history.ts` (new): `InputHistory` (`record` / `previous` / `next` / `reset`) plus `historyLines()` for durable reconstruction.
- `packages/tui/src/input.ts` (new): `routeInputKey`, the extracted completion→history→composer decision, so the interaction is unit-testable.
- `packages/tui/src/completion.ts`: `invalidate()` replaces `dismiss()`; it advances the async generation and clears state without recomputing.
- `packages/tui/src/index.ts`: wiring only — records submissions, seeds resumed sessions, routes keys.
- The renderer's `Composer` is untouched and stays a dumb buffer.

Consecutive duplicates collapse to one entry.

## Resume contract

Reopening a session restores the history the session log recorded: human `user/message` events (source `user`) and `command/run` events that recorded their input. A command with `recordInput: false` is skipped rather than faked.

Commands this interface handles locally (`/model`, `/reasoning`, `/usage`, `/profile`, `/exit`, `/quit`) and mistyped commands are remembered in-process but are **not** durable. That is a deliberate limitation: the harness's `Session.append` has no downstream-ignorable event surface yet, and converting the local commands to agent-scoped harness commands would leak TUI-only handlers into the shared registry. The docs state this rather than implying full restore.

## Tests

- `history.spec.ts` (19): navigation, draft restoration, duplicates, multiline/CJK round-trips, resumed seeding.
- `input.spec.ts` (7): completion wins while showing; a recalled `/model` does not steal the next arrow; a stale in-flight lookup is abandoned; draft restoration; sanitization; fall-through.

## Verified

- `pnpm build` ✓
- `pnpm typecheck` ✓
- `pnpm test` ✓ (572 tests)
- `pnpm audit` ✓