### PR TITLE
ci: check compatibility with the unreleased harness

### DIFF
--- a/.github/workflows/harness-compatibility.yml
+++ b/.github/workflows/harness-compatibility.yml
@@ -1,0 +1,72 @@
+name: harness compatibility
+
+# The harness is in developer preview, so its unpublished default branch can
+# change before its `next` registry types do. Check it weekly without making
+# every ordinary pull request depend on an external repository's availability.
+on:
+  schedule:
+    # Monday, after the weekly dependency-audit schedule and outside its runner peak.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+# This job executes the harness's current source to build declarations. It has
+# no secrets and only a read-only repository token, so that external code cannot
+# alter this repository or release credentials even if its branch is compromised.
+permissions:
+  contents: read
+
+concurrency:
+  group: harness-compatibility
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: typecheck against harness default branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # check out this repository and the public harness source
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          # Do not carry a cache across runs that build code from an unpinned
+          # external branch. The ordinary CI workflow retains its safe cache.
+          package-manager-cache: false
+
+      # The upstream repository currently calls its default branch `master`, not
+      # `main`. This intentionally follows that movable branch: detecting the
+      # next incompatible harness commit is this workflow's purpose.
+      - name: check out the latest harness source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: deepseek-ai/deepseek-harness
+          ref: master
+          path: .harness
+          persist-credentials: false
+
+      # Build only inside the separate checkout. `--ignore-scripts` avoids
+      # lifecycle code; the explicit build below is the one reviewed operation
+      # needed to emit the declarations that link-harness.mjs validates.
+      - name: install and build harness declarations
+        working-directory: .harness
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm run build
+
+      # This rewrites package links and the lockfile only in the disposable
+      # runner. It lets TypeScript resolve the declarations just built above,
+      # rather than the registry's stale `next` tag.
+      - name: link the built harness declarations
+        run: |
+          node tools/link-harness.mjs .harness
+          pnpm install --no-frozen-lockfile --ignore-scripts
+          node tools/link-harness.mjs --check
+
+      - run: pnpm run typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,16 @@ node tools/link-harness.mjs --restore   # back to the registry
 
 It writes a relative path when the checkout is reachable from this repository, so the manifest stays portable and contains no personal folder names. `--check` looks for the type declaration files rather than just the folders, because an unbuilt harness has every manifest and no types.
 
+The **harness compatibility** workflow does the same check every Monday against the
+upstream default branch (currently `master`), before an unreleased change reaches
+the registry's `next` tag. Run it from the repository's **Actions** tab with
+**Run workflow** when an upstream change needs checking now. It builds declarations
+in a separate checkout, links them only in the disposable runner, then runs this
+repository's typecheck. A red result means the current upstream declarations are
+incompatible; it neither changes the supported registry version nor publishes
+anything. The job deliberately has no secrets and only read access because it
+builds external branch code.
+
 ## Style
 
 Match the code around you; it is consistent on purpose.


### PR DESCRIPTION
## Summary
- add a weekly/manual, read-only typecheck against the latest DeepSeek Harness default branch
- build its declarations in a separate checkout, then use `link-harness.mjs` in the disposable runner
- avoid credentials and the Actions cache while executing external branch code

## Validation
- `pnpm run lint:workflows`
- built upstream harness at `141eb6fef83422698aef7a981029e843e8161534`; the full linked typecheck correctly surfaced the current API incompatibility: `packages/tui/src/index.ts:623` now needs a fourth argument

The upstream default branch is currently `master`, not `main`, so the workflow deliberately follows `master`.