### PR TITLE
fix(version): skip gracefully when no changesets exist

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -30,25 +30,44 @@ jobs:
     permissions:
       contents: write # update the generated version branch
       pull-requests: write # create or update its pull request
+    outputs:
+      has-changesets: ${{ steps.check-changesets.outputs.has-changesets }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
+      # README.md documents Changesets; it is not a release record. Looking for
+      # every Markdown file would make an empty queue look non-empty and cause
+      # `changeset version` to fail after a Version Packages PR is merged.
+      - name: check for changesets
+        id: check-changesets
+        run: |
+          if [ -n "$(find .changeset -maxdepth 1 -type f -name '*.md' ! -name 'README.md' -print -quit)" ]; then
+            printf 'has-changesets=true\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'has-changesets=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        if: steps.check-changesets.outputs.has-changesets == 'true'
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.check-changesets.outputs.has-changesets == 'true'
         with:
           node-version: '24'
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile --ignore-scripts
+        if: steps.check-changesets.outputs.has-changesets == 'true'
 
       - name: consume changesets and bump versions
+        if: steps.check-changesets.outputs.has-changesets == 'true'
         run: pnpm changeset version
 
       - name: create or update version PR
+        if: steps.check-changesets.outputs.has-changesets == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # zizmor: ignore[superfluous-actions] updates one stable PR rather than creating one per commit; v7.0.11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,9 @@ Press the key that misbehaves. Each line shows the raw bytes and the key this pr
 1. **Open an issue first for anything larger than a fix**, so you do not spend time on something that does not fit the design. Small fixes can go straight to a pull request.
 2. **Read [`AGENTS.md`](AGENTS.md).** It lists the rules that are easy to break by accident, because breaking one causes a failure somewhere unrelated. It also explains a build step that, if you skip it, makes your change appear to do nothing.
 3. **Add a test that fails without your change.** Then break your own fix on purpose and confirm the test notices. A test that also passes against the broken version does not protect anything.
-4. **Do not add dependencies.** The drawing package has none, and that is a deliberate feature — see [why](docs/comparison.md#it-adds-no-third-party-packages). A change that needs a new package needs a discussion first.
-5. **Explain the reason in the commit message.** Say what a user saw, why the obvious fix is wrong, and how you checked yours. Long commit messages are normal here.
+4. **For a user-visible package change, run `pnpm changeset` and commit its Markdown file.** It is the release record the version workflow consumes; documentation, CI, and internal-only changes do not need one. [`AGENTS.md`](AGENTS.md#preparing-a-release) explains the version PR and tag flow.
+5. **Do not add dependencies.** The drawing package has none, and that is a deliberate feature — see [why](docs/comparison.md#it-adds-no-third-party-packages). A change that needs a new package needs a discussion first.
+6. **Explain the reason in the commit message.** Say what a user saw, why the obvious fix is wrong, and how you checked yours. Long commit messages are normal here.
 
 ```sh
 pnpm install


### PR DESCRIPTION
## Summary
- skip dependency setup, versioning, and PR creation when no release changeset exists
- exclude `.changeset/README.md`, which documents Changesets but is not a pending release record
- document the `pnpm changeset` requirement for user-visible package changes in the contributor guide

## Validation
- `pnpm run lint:workflows`
- verified the guard ignores README.md, detects a temporary release changeset, and leaves no files behind
- verified `pnpm changeset version` exits 1 when the queue is empty

`js-yaml` is not installed; the repository workflow linter parsed and validated the YAML successfully.