### PR TITLE
fix(release): harden automated version handoff

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -50,6 +50,19 @@ jobs:
             printf 'has-changesets=false\n' >> "$GITHUB_OUTPUT"
           fi
 
+      # Do this before producing a PR: a missing token otherwise is discovered
+      # only after its merge, when the tag cannot start the tag-only publisher.
+      - name: release tag token must be configured
+        if: steps.check-changesets.outputs.has-changesets == 'true'
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_TOKEN" ]; then
+            printf '%s\n' 'RELEASE_TOKEN is required to create the release tag.' >&2
+            printf '%s\n' 'Add a fine-grained, repository-scoped PAT with Contents: write.' >&2
+            exit 1
+          fi
+
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: steps.check-changesets.outputs.has-changesets == 'true'
 
@@ -68,7 +81,7 @@ jobs:
 
       - name: create or update version PR
         if: steps.check-changesets.outputs.has-changesets == 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # zizmor: ignore[superfluous-actions] updates one stable PR rather than creating one per commit; v7.0.11
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # zizmor: ignore[superfluous-actions] updates one stable PR rather than creating one per commit; v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: version packages'
@@ -83,13 +96,16 @@ jobs:
 
   tag:
     name: tag merged version PR
+    # The PR action's GITHUB_TOKEN identity is the GitHub App account, not the
+    # similarly named github-actions[bot] user. Keep the exact identity and the
+    # same-repository branch checks so another bot cannot request a release.
     if: >-
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.head.ref == 'changeset-release/main' &&
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      github.event.pull_request.user.login == 'app/github-actions' &&
       github.event.pull_request.title == 'Version Packages'
     runs-on: ubuntu-latest
     # RELEASE_TOKEN is a fine-grained PAT whose tag push is not limited by this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,12 +146,18 @@ both. Do not edit package versions or `CHANGELOG.md` by hand: after a changeset
 reaches `main`, the **version** workflow maintains one `Version Packages` pull
 request that consumes it.
 
+Before the first changeset reaches `main`, enable **Settings → Actions → General →
+Allow GitHub Actions to create and approve pull requests**. Keep the repository's
+default token read-only: only the version job asks for its own narrowly scoped
+`contents` and `pull-requests` write permissions to maintain the generated PR.
+
 Merging that bot-authored PR creates the matching `v<version>` tag from its merge
 commit. Its tag step needs the repository secret `RELEASE_TOKEN`: a fine-grained
 personal access token limited to **Contents: write**. GitHub deliberately suppresses
 workflows triggered by `GITHUB_TOKEN`, so the normal job token would create a tag
-that never starts the tag-only publish workflow. The tag starts `publish.yml`; after
-npm publishing and registry verification succeed, its separate write-scoped job
-creates the generated-notes GitHub Release. Configure the token before merging the
-first version PR, and retry the workflow rather than creating the tag by hand if
-that step fails.
+that never starts the tag-only publish workflow. The workflow checks that the secret
+exists before it produces the version PR, rather than discovering a missing tag token
+after its merge. The tag starts `publish.yml`; after npm publishing and registry
+verification succeed, its separate write-scoped job creates the generated-notes
+GitHub Release. Configure the token before the first version run, and retry the
+workflow rather than creating the tag by hand if that step fails.


### PR DESCRIPTION
## Summary
- match the actual `app/github-actions` identity of the generated Version Packages PR before tagging
- fail before creating a version PR if the required `RELEASE_TOKEN` is absent
- update `create-pull-request` to pinned v8.1.1, which uses Node 24
- document the required GitHub Actions PR-creation setting

## Validation
- `pnpm run lint:workflows`
- confirmed #35 is authored by `app/github-actions`
- inspected the pinned v8.1.1 action metadata: `runs.using: node24`

## Required configuration before merging #35
Create repository secret `RELEASE_TOKEN` from a fine-grained PAT scoped only to this repository with **Contents: write**. It is deliberately not a `GITHUB_TOKEN`, because its tag push must trigger `publish.yml`.