### PR TITLE
fix(version): recover skipped release tags safely

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -101,26 +101,9 @@ jobs:
 
   tag:
     name: tag version
-    # GitHub has reported the PR action as both app/github-actions and
-    # github-actions[bot]. The branch, repository, and title checks stay strict;
-    # a recovery dispatch must name an immutable commit already on main.
-    if: >-
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true &&
-        github.event.pull_request.base.ref == 'main' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.head.ref == 'changeset-release/main' &&
-        (
-          github.event.pull_request.user.login == 'app/github-actions' ||
-          github.event.pull_request.user.login == 'github-actions[bot]'
-        ) &&
-        github.event.pull_request.title == 'Version Packages'
-      ) || (
-        github.event_name == 'workflow_dispatch' &&
-        github.ref == 'refs/heads/main' &&
-        github.event.inputs.recovery-commit != ''
-      )
+    # A job condition resolves before its steps, so source validation belongs in
+    # the first step. Keep routine main pushes out of this job entirely.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # RELEASE_TOKEN is a fine-grained PAT whose tag push is not limited by this
     # job token. The job itself only reads the merged tree before using that PAT.
@@ -128,7 +111,37 @@ jobs:
       contents: read # check out the merged version PR tree
 
     steps:
+      - name: determine tag source
+        id: tag-source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REPO: ${{ github.repository }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REF: ${{ github.ref }}
+          RECOVERY_COMMIT: ${{ github.event.inputs.recovery-commit }}
+        run: |
+          if [ "$EVENT_NAME" = 'pull_request' ]; then
+            if [ "$PR_MERGED" = 'true' ] && \
+              [ "$PR_BASE" = 'main' ] && \
+              [ "$PR_REPO" = "$REPO" ] && \
+              [ "$PR_BRANCH" = 'changeset-release/main' ] && \
+              { [ "$PR_USER" = 'app/github-actions' ] || [ "$PR_USER" = 'github-actions[bot]' ]; } && \
+              [ "$PR_TITLE" = 'Version Packages' ]; then
+              printf 'source=pr\n' >> "$GITHUB_OUTPUT"
+            fi
+          elif [ "$EVENT_NAME" = 'workflow_dispatch' ] && \
+            [ "$REF" = 'refs/heads/main' ] && \
+            [ -n "$RECOVERY_COMMIT" ]; then
+            printf 'source=recovery\n' >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.tag-source.outputs.source != ''
         with:
           # A merged PR tags its merge commit; recovery checks out the selected
           # commit and verifies it is already reachable from protected main.
@@ -137,11 +150,13 @@ jobs:
           persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.tag-source.outputs.source != ''
         with:
           node-version: '24'
 
       - name: read renderer version
         id: renderer-version
+        if: steps.tag-source.outputs.source != ''
         run: |
           VERSION="$(node -e "process.stdout.write(JSON.parse(require('node:fs').readFileSync('packages/renderer/package.json')).version)")"
           printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
@@ -151,6 +166,7 @@ jobs:
       # job token, its tag push starts publish.yml and therefore preserves the
       # tag-only release entry point.
       - name: create and push release tag
+        if: steps.tag-source.outputs.source != ''
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           RECOVERY_COMMIT: ${{ inputs.recovery-commit }}
@@ -158,6 +174,8 @@ jobs:
           WORKFLOW_EVENT: ${{ github.event_name }}
         run: |
           if [ "$WORKFLOW_EVENT" = 'workflow_dispatch' ]; then
+            echo "Recovery mode: tagging commit $RECOVERY_COMMIT"
+            echo 'This tag was pushed via manual recovery dispatch, not a merged PR.'
             test "$(git rev-parse HEAD)" = "$(git rev-parse "$RECOVERY_COMMIT^{commit}")"
             git merge-base --is-ancestor "$RECOVERY_COMMIT" origin/main
           fi

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [closed]
   workflow_dispatch:
+    inputs:
+      recovery-commit:
+        description: merged Version Packages commit whose missing tag should be recovered
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -95,18 +100,27 @@ jobs:
           delete-branch: true
 
   tag:
-    name: tag merged version PR
-    # The PR action's GITHUB_TOKEN identity is the GitHub App account, not the
-    # similarly named github-actions[bot] user. Keep the exact identity and the
-    # same-repository branch checks so another bot cannot request a release.
+    name: tag version
+    # GitHub has reported the PR action as both app/github-actions and
+    # github-actions[bot]. The branch, repository, and title checks stay strict;
+    # a recovery dispatch must name an immutable commit already on main.
     if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.head.ref == 'changeset-release/main' &&
-      github.event.pull_request.user.login == 'app/github-actions' &&
-      github.event.pull_request.title == 'Version Packages'
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.ref == 'changeset-release/main' &&
+        (
+          github.event.pull_request.user.login == 'app/github-actions' ||
+          github.event.pull_request.user.login == 'github-actions[bot]'
+        ) &&
+        github.event.pull_request.title == 'Version Packages'
+      ) || (
+        github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/main' &&
+        github.event.inputs.recovery-commit != ''
+      )
     runs-on: ubuntu-latest
     # RELEASE_TOKEN is a fine-grained PAT whose tag push is not limited by this
     # job token. The job itself only reads the merged tree before using that PAT.
@@ -116,9 +130,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tag the version PR's merge commit, not a later main commit that could
-          # have arrived while this closed-PR workflow was waiting for a runner.
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          # A merged PR tags its merge commit; recovery checks out the selected
+          # commit and verifies it is already reachable from protected main.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || inputs.recovery-commit }}
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -138,8 +153,14 @@ jobs:
       - name: create and push release tag
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          RECOVERY_COMMIT: ${{ inputs.recovery-commit }}
           RELEASE_TAG: v${{ steps.renderer-version.outputs.version }}
+          WORKFLOW_EVENT: ${{ github.event_name }}
         run: |
+          if [ "$WORKFLOW_EVENT" = 'workflow_dispatch' ]; then
+            test "$(git rev-parse HEAD)" = "$(git rev-parse "$RECOVERY_COMMIT^{commit}")"
+            git merge-base --is-ancestor "$RECOVERY_COMMIT" origin/main
+          fi
           git check-ref-format --allow-onelevel "refs/tags/$RELEASE_TAG"
           if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG"; then
             printf 'Tag %s already exists; leaving it unchanged.\n' "$RELEASE_TAG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,5 +159,11 @@ that never starts the tag-only publish workflow. The workflow checks that the se
 exists before it produces the version PR, rather than discovering a missing tag token
 after its merge. The tag starts `publish.yml`; after npm publishing and registry
 verification succeed, its separate write-scoped job creates the generated-notes
-GitHub Release. Configure the token before the first version run, and retry the
-workflow rather than creating the tag by hand if that step fails.
+GitHub Release. Configure the token before the first version run.
+
+If the Version Packages PR was merged but its tag job was skipped or failed before
+creating a tag, open **Actions → version → Run workflow**, select `main`, and enter
+the Version Packages PR's merge commit in **recovery-commit**. Recovery verifies
+that exact immutable commit is already reachable from `main`, reads its package
+version, and does nothing when that `v<version>` tag already exists. It is the
+recovery path instead of creating a tag by hand; a normal release never needs it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ Not a promise of safety, just what is actually wired up and where to look.
 | Releases published from CI with a signed provenance attestation | `.github/workflows/publish.yml` |
 | The release credential scoped to a protected environment, not the repository | `environment: npm` |
 | A GitHub Release can be written only after publishing and registry verification succeed | separate `github-release` job in `.github/workflows/publish.yml` |
-| Version tags come only from a merged bot-generated version PR | `.github/workflows/version.yml` |
+| Version tags come from a merged bot-generated version PR, or an explicit recovery dispatch for a commit verified to be reachable from `main` | `.github/workflows/version.yml` |
 | The tag-triggering token is a fine-grained, Contents-only PAT rather than the broad release credential | `RELEASE_TOKEN` in `.github/workflows/version.yml` |
 | A release build restores no cache any branch could have written | `package-manager-cache: false` |
 | A tag that disagrees with the versions it would publish fails the release | `tools/check-release-tag.mjs` |


### PR DESCRIPTION
## Summary
- accept both GitHub-controlled identities observed for generated Version Packages PRs
- add a manual recovery path for a skipped tag job
- require the immutable Version Packages merge commit and verify it is already reachable from `main` before tagging
- document the recovery path and its security boundary

## Recovery after merge
Run the `version` workflow on `main` with `recovery-commit` set to:

`e2b88c322337524da163e910949285d71cfc71f5`

This is PR #35’s merge commit and contains package version `0.3.0`.

## Validation
- `pnpm run lint:workflows`
- verified the recovery commit resolves and is an ancestor of current `main`