### PR TITLE
fix(release): synchronize embedded banner version

### DIFF
--- a/.changeset/smart-cats-remember.md
+++ b/.changeset/smart-cats-remember.md
@@ -1,0 +1,5 @@
+---
+"@riesbri/dsh-tui": patch
+---
+
+Keep the startup banner version synchronized with generated package releases.

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -84,6 +84,13 @@ jobs:
         if: steps.check-changesets.outputs.has-changesets == 'true'
         run: pnpm changeset version
 
+      # Changesets owns the manifests, while the runner's startup banner embeds
+      # the version in source. Keep the generated PR's two copies together so
+      # the release gate never discovers this only after a tag was pushed.
+      - name: sync the embedded banner version
+        if: steps.check-changesets.outputs.has-changesets == 'true'
+        run: node tools/sync-version.mjs
+
       - name: create or update version PR
         if: steps.check-changesets.outputs.has-changesets == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # zizmor: ignore[superfluous-actions] updates one stable PR rather than creating one per commit; v8.1.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,13 @@ both. Do not edit package versions or `CHANGELOG.md` by hand: after a changeset
 reaches `main`, the **version** workflow maintains one `Version Packages` pull
 request that consumes it.
 
+**Agent responsibility:** for every user-visible change in a published package,
+add the changeset in the same pull request and propose its bump level and changelog
+summary. Use `patch` for a fix and `minor` for new capability; ask when compatibility
+or release impact is unclear. Documentation, CI, test-only, and internal-only changes
+need no changeset. An agent must not merge the Version Packages PR or approve npm
+publishing unless the user explicitly asks: those are the human release decisions.
+
 Before the first changeset reaches `main`, enable **Settings → Actions → General →
 Allow GitHub Actions to create and approve pull requests**. Keep the repository's
 default token read-only: only the version job asks for its own narrowly scoped

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It prints into your terminal's normal scroll history instead of taking over the 
 </div>
 
 > [!WARNING]
-> **This is alpha software, version 0.2.0.** It works, it is tested, and it is used daily by its author — but it is young. Expect rough edges, expect features to be missing, and expect small breaking changes before 1.0. Two things to know before you point it at code you care about:
+> **This is alpha software.** It works, it is tested, and it is used daily by its author — but it is young. Expect rough edges, expect features to be missing, and expect small breaking changes before 1.0. Two things to know before you point it at code you care about:
 >
 > 1. **Tool calls are not reviewed before they run.** In a standard setup, the agent can edit files and run shell commands inside your working folder without asking you first. That is how the harness is configured by default, not a choice this interface makes. [How to change that →](docs/usage.md#permissions-and-the-sandbox)
 > 2. **Three other terminal interfaces for the harness exist, and one of them has more features than this one.** [An honest comparison →](docs/comparison.md)
@@ -40,7 +40,7 @@ It prints into your terminal's normal scroll history instead of taking over the 
 
 ```
 ╭──────────────────────────────────────────────────────────────────╮
-│ dsh-tui 0.2.0                                                    │
+│ dsh-tui <version>                                                │
 │ ~/code/my-project                                                │
 │ deepseek-official / deepseek-v4-flash                            │
 ╰──────────────────────────────────────────────────────────────────╯

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -76,8 +76,8 @@ export const inject = ['tuiStartup', 'agents', 'userQuestions', 'commands', 'llm
 export type { TuiOverlay, TuiSlotName, TuiSlotView } from './slots.ts'
 export { TuiSlots } from './slots.ts'
 
-/** Reported in the banner; kept beside the code so a release bumps one place. */
-const VERSION = '0.2.0'
+/** Reported in the banner; sync-version.mjs keeps it aligned with the manifest. */
+const VERSION = '0.3.0'
 
 /** What `/profile` accepts, for completing its argument. */
 const PROFILE_VALUES: readonly LocalCommandChoice[] = [

--- a/tools/sync-version.mjs
+++ b/tools/sync-version.mjs
@@ -1,0 +1,37 @@
+/**
+ * Synchronize the runner banner's embedded version with its package manifest.
+ *
+ * Changesets owns package.json and changelog updates, but the startup banner
+ * embeds the same value in source. Keeping the replacement here rather than in
+ * a workflow shell fragment gives the generated version PR one auditable owner
+ * for the duplicated fact that the release gate checks.
+ * @module tools/sync-version
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const manifestPath = join(root, 'packages', 'tui', 'package.json')
+const sourcePath = join(root, 'packages', 'tui', 'src', 'index.ts')
+const VERSION = /^const VERSION = '(?<version>[^']+)'$/mu
+
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+if (typeof manifest.version !== 'string' || manifest.version === '') {
+  throw new Error(`${manifestPath} has no package version`)
+}
+
+const source = await readFile(sourcePath, 'utf8')
+const match = VERSION.exec(source)
+if (match?.groups?.version === undefined) {
+  throw new Error(`no VERSION constant found in ${sourcePath}`)
+}
+
+if (match.groups.version !== manifest.version) {
+  const updated = source.replace(VERSION, `const VERSION = '${manifest.version}'`)
+  await writeFile(sourcePath, updated)
+  process.stdout.write(`sync-version: banner ${match.groups.version} -> ${manifest.version}\n`)
+} else {
+  process.stdout.write(`sync-version: banner already matches ${manifest.version}\n`)
+}


### PR DESCRIPTION
## Summary
- synchronize the source-embedded startup banner after Changesets updates manifests
- add a patch Changeset, producing a fresh `0.3.1` release rather than moving failed tag `v0.3.0`
- remove stale README version text and clarify agent/human release responsibilities

## Validation
- `pnpm run lint:workflows`
- `pnpm test`
- full disposable-worktree simulation: `pnpm changeset version`, `node tools/sync-version.mjs`, and `RELEASE_TAG=v0.3.1 node tools/check-release-tag.mjs`

The failed `v0.3.0` tag remains immutable and unpublished. After this PR merges, the version workflow will open a `0.3.1` Version Packages PR.