### PR TITLE
fix(release): run checks for generated version PRs

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -30,11 +30,11 @@ jobs:
     name: open version PR
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    # Updating the generated branch and its PR needs these two write scopes; this
-    # job never tags or publishes, so it receives nothing else.
+    # VERSION_TOKEN supplies the two write scopes needed for the generated
+    # branch and PR. The built-in token stays read-only, so a compromised
+    # versioning dependency cannot inherit repository-write access.
     permissions:
-      contents: write # update the generated version branch
-      pull-requests: write # create or update its pull request
+      contents: read # check out the changesets to be consumed
     outputs:
       has-changesets: ${{ steps.check-changesets.outputs.has-changesets }}
 
@@ -68,6 +68,20 @@ jobs:
             exit 1
           fi
 
+      # A pull request made with GITHUB_TOKEN cannot start the required PR
+      # checks. Use a distinct, repository-scoped PAT so those checks run before
+      # a human merges the generated version PR; it never creates release tags.
+      - name: version PR token must be configured
+        if: steps.check-changesets.outputs.has-changesets == 'true'
+        env:
+          VERSION_TOKEN: ${{ secrets.VERSION_TOKEN }}
+        run: |
+          if [ -z "$VERSION_TOKEN" ]; then
+            printf '%s\n' 'VERSION_TOKEN is required to create a checked Version Packages PR.' >&2
+            printf '%s\n' 'Add a fine-grained, repository-scoped PAT with Contents and Pull requests: write.' >&2
+            exit 1
+          fi
+
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: steps.check-changesets.outputs.has-changesets == 'true'
 
@@ -95,7 +109,7 @@ jobs:
         if: steps.check-changesets.outputs.has-changesets == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # zizmor: ignore[superfluous-actions] updates one stable PR rather than creating one per commit; v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.VERSION_TOKEN }}
           commit-message: 'chore: version packages'
           title: 'Version Packages'
           body: |
@@ -126,6 +140,7 @@ jobs:
           PR_BASE: ${{ github.event.pull_request.base.ref }}
           PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           REPO: ${{ github.repository }}
+          REPO_OWNER: ${{ github.repository_owner }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_USER: ${{ github.event.pull_request.user.login }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -137,7 +152,7 @@ jobs:
               [ "$PR_BASE" = 'main' ] && \
               [ "$PR_REPO" = "$REPO" ] && \
               [ "$PR_BRANCH" = 'changeset-release/main' ] && \
-              { [ "$PR_USER" = 'app/github-actions' ] || [ "$PR_USER" = 'github-actions[bot]' ]; } && \
+              { [ "$PR_USER" = 'app/github-actions' ] || [ "$PR_USER" = 'github-actions[bot]' ] || [ "$PR_USER" = "$REPO_OWNER" ]; } && \
               [ "$PR_TITLE" = 'Version Packages' ]; then
               printf 'source=pr\n' >> "$GITHUB_OUTPUT"
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,18 +155,22 @@ publishing unless the user explicitly asks: those are the human release decision
 
 Before the first changeset reaches `main`, enable **Settings → Actions → General →
 Allow GitHub Actions to create and approve pull requests**. Keep the repository's
-default token read-only: only the version job asks for its own narrowly scoped
-`contents` and `pull-requests` write permissions to maintain the generated PR.
+default token read-only. The version workflow instead needs the repository secret
+`VERSION_TOKEN`: a fine-grained personal access token limited to **Contents: write**
+and **Pull requests: write**. It updates only the generated version branch and PR.
+Using a separate token matters because GitHub suppresses PR checks for a PR created
+with `GITHUB_TOKEN`; this token lets the required checks run normally. Do not reuse
+it for publishing or tagging.
 
-Merging that bot-authored PR creates the matching `v<version>` tag from its merge
-commit. Its tag step needs the repository secret `RELEASE_TOKEN`: a fine-grained
-personal access token limited to **Contents: write**. GitHub deliberately suppresses
-workflows triggered by `GITHUB_TOKEN`, so the normal job token would create a tag
-that never starts the tag-only publish workflow. The workflow checks that the secret
-exists before it produces the version PR, rather than discovering a missing tag token
+Merging that generated PR creates the matching `v<version>` tag from its merge
+commit. Its tag step needs the distinct repository secret `RELEASE_TOKEN`: a
+fine-grained personal access token limited to **Contents: write**. GitHub deliberately
+suppresses workflow events triggered with `GITHUB_TOKEN`, so the normal job token
+would create a tag that never starts the tag-only publisher. The workflow checks both
+secrets before it produces the version PR, rather than discovering a missing token
 after its merge. The tag starts `publish.yml`; after npm publishing and registry
 verification succeed, its separate write-scoped job creates the generated-notes
-GitHub Release. Configure the token before the first version run.
+GitHub Release. Configure both tokens before the first version run.
 
 If the Version Packages PR was merged but its tag job was skipped or failed before
 creating a tag, open **Actions → version → Run workflow**, select `main`, and enter

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,8 +41,9 @@ Not a promise of safety, just what is actually wired up and where to look.
 | Releases published from CI with a signed provenance attestation | `.github/workflows/publish.yml` |
 | The release credential scoped to a protected environment, not the repository | `environment: npm` |
 | A GitHub Release can be written only after publishing and registry verification succeed | separate `github-release` job in `.github/workflows/publish.yml` |
-| Version tags come from a merged bot-generated version PR, or an explicit recovery dispatch for a commit verified to be reachable from `main` | `.github/workflows/version.yml` |
-| The tag-triggering token is a fine-grained, Contents-only PAT rather than the broad release credential | `RELEASE_TOKEN` in `.github/workflows/version.yml` |
+| Version tags come from a merged generated version PR, or an explicit recovery dispatch for a commit verified to be reachable from `main` | `.github/workflows/version.yml` |
+| The version-PR token is separate from the read-only job token and limited to Contents and Pull requests write, so required PR checks are triggered without granting the job those scopes | `VERSION_TOKEN` in `.github/workflows/version.yml` |
+| The tag-triggering token is distinct and fine-grained Contents-only rather than the broad release credential | `RELEASE_TOKEN` in `.github/workflows/version.yml` |
 | A release build restores no cache any branch could have written | `package-manager-cache: false` |
 | A tag that disagrees with the versions it would publish fails the release | `tools/check-release-tag.mjs` |
 | A release that only half-landed fails rather than being discovered later | `tools/verify-published.mjs` |


### PR DESCRIPTION
## Summary
- use the dedicated `VERSION_TOKEN` for generated Version Packages PRs
- preserve a read-only built-in token and separate the version, tag, and npm credentials
- document the token boundaries and required-check behavior

## Validation
- `pnpm run lint:workflows`
- `pnpm test`
- `pnpm run typecheck`
- `git diff --check`

This restores automatic required PR checks for future generated version PRs; no Changeset is needed.