### PR TITLE
fix: harden recent interaction and release flows

### DIFF
--- a/.changeset/quiet-terms-navigate.md
+++ b/.changeset/quiet-terms-navigate.md
@@ -1,0 +1,6 @@
+---
+'@riesbri/dsh-tui': patch
+'@riesbri/dsh-tui-renderer': patch
+---
+
+Keep exact-width composer navigation, recalled drafts, and review overlays correct at terminal boundaries.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,13 @@ name: publish
 # tarball to this repository, this commit, and this workflow. Anyone installing
 # the package can then check that what they got was built from the source they can
 # read, which is not a claim a local `npm publish` can make at all.
-# A tag is the only trigger. There is deliberately no workflow_dispatch: one
-# entry point means one thing to reason about, and re-running the failed run is
-# how a broken release gets retried.
+# Tags are the only trigger that can PUBLISH. The manual entry point performs
+# only the two OIDC token exchanges, so trusted-publisher configuration can be
+# checked without creating an irreversible package version.
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
 
 # One release at a time, across every tag. The group is deliberately CONSTANT: a
 # ref-scoped group gives each tag its own lane, so two tags pushed close together
@@ -35,19 +36,34 @@ permissions:
   contents: read
 
 jobs:
+  trusted-publisher:
+    name: verify npm trusted publishers
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # check out the verification script
+      id-token: write # exchange this workflow identity for short-lived npm tokens
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - run: node tools/check-trusted-publishers.mjs
+
   publish:
     name: publish to npm
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
-
-    # The token lives in this environment, not in the repository, so no other
-    # workflow can read it — a malicious workflow landing on any branch still
-    # cannot reach it. Add a required reviewer to the environment and every
-    # release also waits for a human to say yes.
-    environment: npm
 
     permissions:
       contents: read # read the tagged tree
-      id-token: write # sign the provenance attestation; without this there is none
+      id-token: write # authenticate to npm and sign provenance with this job identity
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -66,8 +82,8 @@ jobs:
           # making. Twenty seconds of download is the right price.
           package-manager-cache: false
           #
-          # registry-url writes an .npmrc pointing at the public registry and
-          # reading NODE_AUTH_TOKEN, which is how pnpm picks the credential up.
+          # Keep the public registry explicit. pnpm 11.22 exchanges this job's
+          # GitHub OIDC identity before considering any static npmrc credential.
           registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile --ignore-scripts
@@ -80,6 +96,13 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: node tools/check-release-tag.mjs
 
+      # Exchange both package identities before either package is published. A
+      # recursive publish authenticates one at a time, so discovering that only
+      # the second package was configured after the renderer went out would leave
+      # an irreversible half-release.
+      - name: npm must trust this workflow for both packages
+        run: node tools/check-trusted-publishers.mjs
+
       # A release is the one build that cannot be taken back, so it gates on
       # everything: types, tests, and advisories. Re-running them here costs a
       # minute and removes the assumption that whoever tagged had checked.
@@ -91,14 +114,16 @@ jobs:
 
       - run: pnpm run audit
 
-      # --provenance is what produces the attestation, and it needs the id-token
-      # permission above. Order is topological: the renderer publishes before the
-      # bundle that depends on it, and pnpm rewrites `workspace:^` to the real
-      # version as it goes.
+      # Trusted publishing exchanges the job's OIDC identity for short-lived,
+      # package-scoped credentials. --provenance remains explicit as defense in
+      # depth even though npm now enables it automatically for trusted publishers.
+      # Order is topological: the renderer publishes before the bundle that
+      # depends on it, and pnpm rewrites `workspace:^` to the real version as it goes.
+      # The repository's 24-hour minimum release age remains in force for install;
+      # publishing alone disables it so an immediate retry can see and skip the
+      # first package if a prior run failed after only half the workspace landed.
       - name: publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm -r publish --access public --provenance --no-git-checks
+        run: pnpm -r publish --access public --provenance --no-git-checks --config.minimum-release-age=0
 
       # A workspace publish is not atomic: the renderer goes out before the bundle
       # that depends on it, so a failure in between leaves one package published and

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,12 +23,10 @@ on:
 # most ONE pending run per group and cancels the pending one when another is
 # queued, `cancel-in-progress: false` notwithstanding. So pushing a THIRD tag
 # while a release is still running discards the middle tag's run, and that run
-# never executes, so nothing inside it can report the loss. Expressing a real FIFO
-# queue would take a dispatcher workflow, which is more moving parts than a
-# rarely-released package should carry in its most safety-critical path. The
-# operational rule instead: push one release tag and let its run finish. If a run
-# was discarded, re-push that tag; and the next release's verification step below
-# surfaces any version that never reached the registry.
+# never executes, so nothing inside it can report the loss. The version workflow
+# therefore refuses to create another tag while a publisher is active, leaving
+# the next tag absent and safely retryable. A manually pushed tag bypasses that
+# guard, so the operational rule remains: never push release tags by hand.
 concurrency:
   group: publish
   cancel-in-progress: false

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -122,6 +122,11 @@ jobs:
 
   tag:
     name: tag version
+    # Serialize the preflight and tag creation. Without this, two merged/recovery
+    # events could both observe no active publisher before either creates its tag.
+    concurrency:
+      group: release-tag-handoff
+      cancel-in-progress: false
     # A job condition resolves before its steps, so source validation belongs in
     # the first step. Keep routine main pushes out of this job entirely.
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
@@ -129,7 +134,9 @@ jobs:
     # RELEASE_TOKEN is a fine-grained PAT whose tag push is not limited by this
     # job token. The job itself only reads the merged tree before using that PAT.
     permissions:
+      actions: read # refuse a second tag while its predecessor is still publishing
       contents: read # check out the merged version PR tree
+      pull-requests: read # validate a recovery commit against its merged PR
 
     steps:
       - name: determine tag source
@@ -156,9 +163,11 @@ jobs:
               [ "$PR_TITLE" = 'Version Packages' ]; then
               printf 'source=pr\n' >> "$GITHUB_OUTPUT"
             fi
-          elif [ "$EVENT_NAME" = 'workflow_dispatch' ] && \
-            [ "$REF" = 'refs/heads/main' ] && \
-            [ -n "$RECOVERY_COMMIT" ]; then
+          elif [ "$EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$RECOVERY_COMMIT" ]; then
+            if [ "$REF" != 'refs/heads/main' ] || ! [[ "$RECOVERY_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+              printf '%s\n' 'Recovery requires a full lowercase commit SHA and must run from main.' >&2
+              exit 1
+            fi
             printf 'source=recovery\n' >> "$GITHUB_OUTPUT"
           fi
 
@@ -176,6 +185,21 @@ jobs:
         with:
           node-version: '24'
 
+      - name: validate recovery commit
+        if: steps.tag-source.outputs.source == 'recovery'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RECOVERY_COMMIT: ${{ inputs.recovery-commit }}
+          REPO: ${{ github.repository }}
+          REPO_OWNER: ${{ github.repository_owner }}
+        run: |
+          MATCHES="$(gh api "repos/$REPO/commits/$RECOVERY_COMMIT/pulls" \
+            --jq '[.[] | select(.merged_at != null and .merge_commit_sha == env.RECOVERY_COMMIT and .base.ref == "main" and .head.ref == "changeset-release/main" and .head.repo.full_name == env.REPO and .title == "Version Packages" and (.user.login == "app/github-actions" or .user.login == "github-actions[bot]" or .user.login == env.REPO_OWNER))] | length')"
+          if [ "$MATCHES" != '1' ]; then
+            printf '%s\n' "$RECOVERY_COMMIT is not the merge commit of the generated Version Packages PR." >&2
+            exit 1
+          fi
+
       - name: read renderer version
         id: renderer-version
         if: steps.tag-source.outputs.source != ''
@@ -183,12 +207,61 @@ jobs:
           VERSION="$(node -e "process.stdout.write(JSON.parse(require('node:fs').readFileSync('packages/renderer/package.json')).version)")"
           printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
 
+      # Run the same consistency gate before the immutable handoff and again in
+      # publish.yml as defense in depth. The latter is too late to avoid poisoning
+      # a version tag when a generated PR was edited or synchronization regressed.
+      - name: release tree must match the tag
+        if: steps.tag-source.outputs.source != ''
+        env:
+          RELEASE_TAG: v${{ steps.renderer-version.outputs.version }}
+        run: node tools/check-release-tag.mjs
+
+      - name: check for an existing release tag
+        id: existing-tag
+        if: steps.tag-source.outputs.source != ''
+        env:
+          RELEASE_TAG: v${{ steps.renderer-version.outputs.version }}
+        run: |
+          REMOTE_TAG="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG")"
+          if [ -z "$REMOTE_TAG" ]; then
+            printf 'exists=false\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REMOTE_COMMIT="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG^{}" | cut -f1)"
+          if [ -z "$REMOTE_COMMIT" ]; then
+            REMOTE_COMMIT="$(printf '%s\n' "$REMOTE_TAG" | cut -f1)"
+          fi
+          EXPECTED_COMMIT="$(git rev-parse HEAD)"
+          if [ "$REMOTE_COMMIT" != "$EXPECTED_COMMIT" ]; then
+            printf 'Tag %s points at %s, not intended commit %s. It will not be moved.\n' \
+              "$RELEASE_TAG" "$REMOTE_COMMIT" "$EXPECTED_COMMIT" >&2
+            exit 1
+          fi
+          printf 'Tag %s already points at the intended commit; leaving it unchanged.\n' "$RELEASE_TAG"
+          printf 'exists=true\n' >> "$GITHUB_OUTPUT"
+
+      # GitHub keeps only one pending run in a concurrency group. Leave the next
+      # tag absent while a publisher is queued, waiting for approval, or running;
+      # the failed handoff can then be retried without moving an immutable tag.
+      - name: no release may already be active
+        if: steps.tag-source.outputs.source != '' && steps.existing-tag.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ACTIVE="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/publish.yml/runs?per_page=100" \
+            --jq '[.workflow_runs[] | select(.status != "completed")] | length')"
+          if [ "$ACTIVE" != '0' ]; then
+            printf '%s\n' 'Another release is queued, awaiting approval, or running.' >&2
+            printf '%s\n' 'Wait for it to finish, then rerun this handoff; no new tag was created.' >&2
+            exit 1
+          fi
+
       # GitHub intentionally suppresses workflow events created with GITHUB_TOKEN.
       # This dedicated fine-grained PAT must have only Contents: write; unlike the
       # job token, its tag push starts publish.yml and therefore preserves the
       # tag-only release entry point.
       - name: create and push release tag
-        if: steps.tag-source.outputs.source != ''
+        if: steps.tag-source.outputs.source != '' && steps.existing-tag.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           RECOVERY_COMMIT: ${{ inputs.recovery-commit }}
@@ -202,10 +275,6 @@ jobs:
             git merge-base --is-ancestor "$RECOVERY_COMMIT" origin/main
           fi
           git check-ref-format --allow-onelevel "refs/tags/$RELEASE_TAG"
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG"; then
-            printf 'Tag %s already exists; leaving it unchanged.\n' "$RELEASE_TAG"
-            exit 0
-          fi
           # A local annotated tag object does not exist on GitHub, so creating a
           # ref to it returns 422. Create the annotated object through the API
           # first, then publish the ref that points at GitHub's object.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,9 +165,14 @@ it for publishing or tagging.
 Protect `v*` with a repository tag ruleset that restricts creation and deletion
 of release tags to the release identity. The workflow can validate tags it creates,
 but a stolen Contents-write credential could otherwise bypass that workflow and
-push an arbitrary tag whose own tree supplies the publisher definition. Keep
-`NPM_TOKEN` only in the `npm` environment, require a human reviewer there, and
-restrict that environment's deployment branches to the `v*` tag pattern.
+push an arbitrary tag whose own tree supplies the publisher definition.
+
+Configure npm trusted publishing separately for **both** published packages with
+GitHub owner `riesbri`, repository `dsh-tui`, workflow `publish.yml`, no environment,
+and the `npm publish` action. No `NPM_TOKEN` is stored in GitHub: pnpm 11.22 uses
+the job's OIDC permission to obtain short-lived package credentials. The manual
+**publish** workflow dispatch exchanges both credentials without publishing, which
+is the safe way to verify this configuration after changing it.
 
 Merging that generated PR creates the matching `v<version>` tag from its merge
 commit. Its tag step needs the distinct repository secret `RELEASE_TOKEN`: a
@@ -179,10 +184,13 @@ after its merge. The tag starts `publish.yml`; after npm publishing and registry
 verification succeed, its separate write-scoped job creates the generated-notes
 GitHub Release. Configure both tokens before the first version run.
 
-The tag handoff refuses to create a second tag while a publish run is queued,
-awaiting environment approval, or running. Finish that release first; GitHub keeps
-only one pending run in a concurrency group and would otherwise silently discard
-an intermediate version.
+The tag handoff refuses to create a second tag while a publish run is queued or
+running. Finish that release first; GitHub keeps only one pending run in a
+concurrency group and would otherwise silently discard an intermediate version.
+If a publish fails after only one package lands, correct the missing package's
+trusted-publisher mapping and rerun that same tagged workflow. Its publish-only
+release-age override lets pnpm see and skip the package already on npm; never create
+a replacement tag for a half-release.
 
 If the Version Packages PR was merged but its tag job was skipped or failed before
 creating a tag, open **Actions → version → Run workflow**, select `main`, and enter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,13 @@ Using a separate token matters because GitHub suppresses PR checks for a PR crea
 with `GITHUB_TOKEN`; this token lets the required checks run normally. Do not reuse
 it for publishing or tagging.
 
+Protect `v*` with a repository tag ruleset that restricts creation and deletion
+of release tags to the release identity. The workflow can validate tags it creates,
+but a stolen Contents-write credential could otherwise bypass that workflow and
+push an arbitrary tag whose own tree supplies the publisher definition. Keep
+`NPM_TOKEN` only in the `npm` environment, require a human reviewer there, and
+restrict that environment's deployment branches to the `v*` tag pattern.
+
 Merging that generated PR creates the matching `v<version>` tag from its merge
 commit. Its tag step needs the distinct repository secret `RELEASE_TOKEN`: a
 fine-grained personal access token limited to **Contents: write**. GitHub deliberately
@@ -171,6 +178,11 @@ secrets before it produces the version PR, rather than discovering a missing tok
 after its merge. The tag starts `publish.yml`; after npm publishing and registry
 verification succeed, its separate write-scoped job creates the generated-notes
 GitHub Release. Configure both tokens before the first version run.
+
+The tag handoff refuses to create a second tag while a publish run is queued,
+awaiting environment approval, or running. Finish that release first; GitHub keeps
+only one pending run in a concurrency group and would otherwise silently discard
+an intermediate version.
 
 If the Version Packages PR was merged but its tag job was skipped or failed before
 creating a tag, open **Actions → version → Run workflow**, select `main`, and enter

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,11 +41,12 @@ Not a promise of safety, just what is actually wired up and where to look.
 | Releases published from CI with a signed provenance attestation | `.github/workflows/publish.yml` |
 | The release credential scoped to a protected environment, not the repository | `environment: npm` |
 | A GitHub Release can be written only after publishing and registry verification succeed | separate `github-release` job in `.github/workflows/publish.yml` |
-| Version tags come from a merged generated version PR, or an explicit recovery dispatch for a commit verified to be reachable from `main` | `.github/workflows/version.yml` |
+| Automated version tags come from a merged generated version PR, or an explicit recovery dispatch verified against that PR's merge commit | `.github/workflows/version.yml` |
+| A new automated tag is refused while another release is active, before GitHub can discard a pending intermediate run | `.github/workflows/version.yml` |
 | The version-PR token is separate from the read-only job token and limited to Contents and Pull requests write, so required PR checks are triggered without granting the job those scopes | `VERSION_TOKEN` in `.github/workflows/version.yml` |
 | The tag-triggering token is distinct and fine-grained Contents-only rather than the broad release credential | `RELEASE_TOKEN` in `.github/workflows/version.yml` |
 | A release build restores no cache any branch could have written | `package-manager-cache: false` |
-| A tag that disagrees with the versions it would publish fails the release | `tools/check-release-tag.mjs` |
+| A tag that disagrees with the versions it would publish is refused before tag creation and rechecked before publishing | `tools/check-release-tag.mjs` |
 | A release that only half-landed fails rather than being discovered later | `tools/verify-published.mjs` |
 
 ## Verifying what you installed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,8 @@ Not a promise of safety, just what is actually wired up and where to look.
 | A weakening of a package's trust evidence fails the install | `trustPolicy: no-downgrade`, `pnpm-workspace.yaml` |
 | Dependency and action bumps proposed for human review | `.github/dependabot.yml` |
 | Releases published from CI with a signed provenance attestation | `.github/workflows/publish.yml` |
-| The release credential scoped to a protected environment, not the repository | `environment: npm` |
+| npm trusts only the named workflow and exchanges its OIDC identity for short-lived, package-scoped credentials; no npm token is stored in GitHub | `id-token: write` and `tools/check-trusted-publishers.mjs` |
+| Both package exchanges are verified before either package is published | `.github/workflows/publish.yml` |
 | A GitHub Release can be written only after publishing and registry verification succeed | separate `github-release` job in `.github/workflows/publish.yml` |
 | Automated version tags come from a merged generated version PR, or an explicit recovery dispatch verified against that PR's merge commit | `.github/workflows/version.yml` |
 | A new automated tag is refused while another release is active, before GitHub can discard a pending intermediate run | `.github/workflows/version.yml` |

--- a/packages/renderer/src/composer-layout.ts
+++ b/packages/renderer/src/composer-layout.ts
@@ -132,6 +132,15 @@ export function layoutComposer(
     lineStart += [...line].length
     if (lineIndex < composer.lines.length - 1) lineStart += 1 // the newline
   })
+  // Keep an exact-width final insertion row even after the cursor moves away
+  // from it. Creating it only while the cursor was at the end made `↑` remove
+  // the row from the next layout, so `↓` could never return to the same end
+  // position. Only the final logical line can own this latent insertion point;
+  // adding one before an explicit newline would invent a visible blank line.
+  const last = chunks.at(-1)
+  if (last !== undefined && displayWidth(last.row) >= Math.max(1, width)) {
+    chunks.push({ row: '', start: [...composer.value].length, gutterChars: 0 })
+  }
   // A cursor that rolled past the last row needs a row to sit on, or placement
   // arithmetic has nothing to clamp to. An editor shows the same empty row.
   if (cursorRow >= chunks.length) {

--- a/packages/renderer/src/composer.ts
+++ b/packages/renderer/src/composer.ts
@@ -219,6 +219,12 @@ export class Composer {
         // Submitting empty is the caller's business (it may mean "interrupt"),
         // so an empty buffer is reported as ignored rather than an empty submit.
         if (text === '') return { kind: 'ignored', key }
+        // Spaces and pasted blank lines are not a model message. Clear them as an
+        // edit so the caller redraws instead of dispatching an empty turn.
+        if (text.trim() === '') {
+          this.clear()
+          return { kind: 'changed' }
+        }
         this.clear()
         return { kind: 'submit', text }
       }

--- a/packages/renderer/tests/composer-layout.spec.ts
+++ b/packages/renderer/tests/composer-layout.spec.ts
@@ -66,6 +66,18 @@ describe('layoutComposer()', () => {
     expect(layout.positionAt(0, 4)).toBe(1)
   })
 
+  it('keeps an exact-width trailing row reachable after moving away from it', () => {
+    for (const [text, width] of [['abcdefghij', 12], ['标准标准标', 6]] as const) {
+      const composer = new Composer()
+      composer.set(text)
+      const end = composer.position
+
+      expect(composer.moveUp(width, GUTTER), `${text} up`).toBe(true)
+      expect(composer.moveDown(width, GUTTER), `${text} down`).toBe(true)
+      expect(composer.position, `${text} position`).toBe(end)
+    }
+  })
+
   it('never splits an astral character while moving through a wrapped buffer', () => {
     const composer = new Composer()
     composer.handle({ kind: 'paste', text: 'a🙂🙂b🙂cdef🙂gh' })

--- a/packages/renderer/tests/input.spec.ts
+++ b/packages/renderer/tests/input.spec.ts
@@ -262,6 +262,14 @@ describe('Composer', () => {
     expect(composer.isEmpty).toBe(true)
   })
 
+  it('clears whitespace-only input without submitting an empty turn', () => {
+    const composer = new Composer()
+    composer.handle({ kind: 'paste', text: '  \n  ' })
+
+    expect(composer.handle({ kind: 'key', name: 'enter' })).toEqual({ kind: 'changed' })
+    expect(composer.isEmpty).toBe(true)
+  })
+
   it('reports an empty enter as ignored, leaving the gesture to the caller', () => {
     const composer = new Composer()
     expect(composer.handle({ kind: 'key', name: 'enter' })).toEqual({

--- a/packages/tui/src/history.ts
+++ b/packages/tui/src/history.ts
@@ -103,6 +103,23 @@ export class InputHistory {
     this.cursor = this.entries.length
     this.draft = undefined
   }
+
+  /**
+   * End navigation only when a composer action edited text.
+   *
+   * The composer reports cursor motion and text edits with the same `changed`
+   * action. Comparing the value on either side preserves the saved draft after
+   * Left, Right, Home, or End, while a real edit still promotes the recalled line
+   * to the new draft.
+   * @param before - composer value before the action.
+   * @param after - composer value after the action.
+   * @returns whether navigation was reset.
+   */
+  resetIfEdited(before: string, after: string): boolean {
+    if (before === after) return false
+    this.reset()
+    return true
+  }
 }
 
 /**
@@ -126,7 +143,9 @@ export function historyLines(events: readonly SessionEvent[]): string[] {
       const text = textOf(event.data.content).trim()
       if (text !== '') lines.push(text)
     } else if (event.type === 'command/run') {
-      if (event.data.args === undefined) continue
+      // CommandSourceMap is merge-extensible. Keep plugin-issued commands out of
+      // a history that claims to contain what this person typed.
+      if (event.data.source.kind !== 'user' || event.data.args === undefined) continue
       lines.push(`/${event.data.name}${event.data.args.trimEnd()}`)
     }
   }

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -600,10 +600,13 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
    */
   const submit = async (text: string): Promise<void> => {
     const line = text.trim()
-    // Recorded before dispatch, and before any early return, so a submitted line
-    // is navigable even when it was an unknown command or a command that failed —
-    // the user typed it, and the next up arrow should find it.
-    if (line !== '') history.record(line)
+    // The composer has already cleared a submitted buffer. Stop here rather than
+    // turning spaces or pasted blank lines into an empty model message.
+    if (line === '') return
+    // Recorded before dispatch and its following early returns, so a submitted
+    // line is navigable even when it was an unknown command or a command that
+    // failed — the user typed it, and the next up arrow should find it.
+    history.record(line)
     // Parsed once, up front: the local gestures and the unknown-command guard below
     // have to agree on what a command line is, and the registry's parser is the
     // authority on that. A second rule written here would drift from it.
@@ -696,6 +699,7 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
       completion.refresh().then(draw).catch(report)
       return
     }
+    const valueBeforeAction = composer.value
     const action = composer.handle(key)
     if (action.kind === 'submit') {
       // Whatever was being completed is gone with the line, and any lookup it
@@ -706,13 +710,17 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
       return
     }
     if (action.kind === 'changed') {
-      // Any direct edit abandons history navigation: the edited text is the new
-      // draft, and the next up arrow must capture it rather than the line that
-      // was showing before the edit.
-      history.reset()
-      // Recomputed after the edit, because what is completable is a function of the
-      // text as it now stands. The redraw comes with the result, not before it.
+      // Cursor motion and text edits share one composer action. Only an edit
+      // abandons history navigation; otherwise Left followed by Up must continue
+      // to the older entry, and the saved half-typed draft must remain recoverable.
+      const edited = history.resetIfEdited(valueBeforeAction, composer.value)
       draw()
+      // A recalled line deliberately owns the arrows until it is edited or
+      // submitted. Cursor-only motion must not open completion over that line and
+      // let the resulting list steal the next vertical arrow.
+      if (history.navigating && !edited) return
+      // Recomputed after the edit or cursor move, because what is completable is a
+      // function of both the text and the cursor position.
       completion.refresh().then(draw).catch(report)
       return
     }

--- a/packages/tui/src/plan-review.ts
+++ b/packages/tui/src/plan-review.ts
@@ -132,12 +132,13 @@ export function createPlanReviewOverlay(spec: PlanReviewSpec): TuiOverlay {
       const rendered = planRows(columns)
       const width = chromeWidth(columns)
       const inner = width - BOX_CHROME_COLUMNS
+      const frameFits = width < columns
       const selected = spec.choices[choice]
       const hasDescription = selected?.description !== undefined && selected.description !== ''
       const visiblePlanRows = normalPlanRows(terminalRows, spec.choices.length, hasDescription)
       viewport.update(rendered.length, visiblePlanRows)
 
-      if (visiblePlanRows === 0) {
+      if (visiblePlanRows === 0 || !frameFits) {
         if (terminalRows <= 0) return []
         const label = oneRow(selected?.label ?? 'Decision', Math.max(1, columns - 13))
         const decision = truncateToWidth(
@@ -145,9 +146,9 @@ export function createPlanReviewOverlay(spec: PlanReviewSpec): TuiOverlay {
           Math.max(1, columns),
         )
         const help = style(truncateToWidth('↑↓ decision · enter confirm · esc cancel', Math.max(1, columns)), 'gray')
-        // A box is readable only when all six of its rows fit. Below that, keep
-        // the decision usable rather than letting the fallback itself overflow.
-        if (terminalRows < COMPACT_REVIEW_ROWS) return terminalRows === 1 ? [decision] : [decision, help]
+        // A frame wider than the terminal would wrap its own borders. Keep the
+        // same unboxed, usable decision fallback used for a very short screen.
+        if (!frameFits || terminalRows < COMPACT_REVIEW_ROWS) return terminalRows === 1 ? [decision] : [decision, help]
         const heading = rendered.find(line => displayWidth(line) > 0) ?? 'Plan'
         return [
           ...box([
@@ -168,7 +169,10 @@ export function createPlanReviewOverlay(spec: PlanReviewSpec): TuiOverlay {
         : []
       const content = [
         style(oneRow(spec.question, inner), 'dim'),
-        style(`rows ${String(viewport.start + 1)}–${String(viewport.end)} of ${String(rendered.length)}`, 'gray'),
+        style(truncateToWidth(
+          `rows ${String(viewport.start + 1)}–${String(viewport.end)} of ${String(rendered.length)}`,
+          inner,
+        ), 'gray'),
         '',
         ...rendered.slice(viewport.start, viewport.end),
         '',

--- a/packages/tui/src/tool-output.ts
+++ b/packages/tui/src/tool-output.ts
@@ -23,6 +23,13 @@ import { chromeWidth } from './views.ts'
  */
 const TOOL_OUTPUT_FIXED_ROWS = 7
 
+/**
+ * Narrowest inner frame that can hold a ToolCards row without re-wrapping it.
+ * Card frames retain a twelve-column readability floor plus the two-column body
+ * indent, so anything smaller needs the unboxed escape hatch.
+ */
+const TOOL_OUTPUT_MIN_INNER_COLUMNS = BOX_CHROME_COLUMNS + 10
+
 /** Everything the inspector needs to render and dismiss itself. */
 export interface ToolOutputSpec {
   /** The box title, describing what is being inspected. */
@@ -57,6 +64,16 @@ export function createToolOutputOverlay(spec: ToolOutputSpec): TuiOverlay {
     render(columns, terminalRows = 24) {
       const width = chromeWidth(columns)
       const inner = width - BOX_CHROME_COLUMNS
+      // A terminal too short for the frame still needs the escape hatch, and the
+      // live region must never exceed the screen: clipped and closable beats a
+      // box that overflows into scrollback.
+      if (terminalRows <= TOOL_OUTPUT_FIXED_ROWS || inner < TOOL_OUTPUT_MIN_INNER_COLUMNS) {
+        if (terminalRows <= 0) return []
+        const summary = `Tool output · ${spec.title} · resize to inspect · esc close`
+        const lines = [style(truncateToWidth(summary, Math.max(1, columns)), 'yellow', 'bold')]
+        if (terminalRows >= 2) lines.push(style(truncateToWidth('esc close', Math.max(1, columns)), 'gray'))
+        return lines
+      }
       // Render the inspected card at the OUTER box's inner width, not the whole
       // terminal width. `box()` wraps any content row wider than its inner width
       // into another physical row (it must not truncate the composer's text), so
@@ -66,16 +83,6 @@ export function createToolOutputOverlay(spec: ToolOutputSpec): TuiOverlay {
       // most one physical row, keeping `render(...).length <= terminalRows` true
       // for real `ToolCards.renderInspect()` output.
       const { rows, truncated } = spec.render(inner)
-      // A terminal too short for the frame still needs the escape hatch, and the
-      // live region must never exceed the screen: clipped and closable beats a
-      // box that overflows into scrollback.
-      if (terminalRows < TOOL_OUTPUT_FIXED_ROWS) {
-        if (terminalRows <= 0) return []
-        const summary = `Tool output · ${spec.title} · esc close`
-        const lines = [style(truncateToWidth(summary, Math.max(1, columns)), 'yellow', 'bold')]
-        if (terminalRows >= 2) lines.push(style('esc close', 'gray'))
-        return lines
-      }
       // Body rows share the terminal with the fixed chrome exactly, so the whole
       // live region fills the screen without spilling past it.
       const visible = terminalRows - TOOL_OUTPUT_FIXED_ROWS
@@ -88,7 +95,7 @@ export function createToolOutputOverlay(spec: ToolOutputSpec): TuiOverlay {
       return [
         '',
         ...box([
-          style(counter, 'gray'),
+          style(truncateToWidth(counter, inner), 'gray'),
           '',
           ...rows.slice(viewport.start, viewport.end),
           '',

--- a/packages/tui/tests/history.spec.ts
+++ b/packages/tui/tests/history.spec.ts
@@ -114,6 +114,21 @@ describe('InputHistory', () => {
     expect(history.next()).toBe('草稿')
   })
 
+  it('keeps navigation after cursor-only changes and resets after edits', () => {
+    const history = new InputHistory()
+    history.record('first')
+    history.record('second')
+
+    expect(history.previous('saved draft')).toBe('second')
+    expect(history.resetIfEdited('second', 'second')).toBe(false)
+    expect(history.previous('second')).toBe('first')
+
+    expect(history.resetIfEdited('first', 'first edited')).toBe(true)
+    expect(history.next()).toBe(undefined)
+    expect(history.previous('first edited')).toBe('second')
+    expect(history.next()).toBe('first edited')
+  })
+
   it('reset returns to the draft and forgets the saved one', () => {
     const history = new InputHistory()
     history.record('first')
@@ -167,6 +182,17 @@ describe('historyLines()', () => {
   it('skips a command that suppressed its input rather than faking a bare name', () => {
     expect(historyLines([
       event('command/run', { commandId: 'c1', name: 'goal', source: { kind: 'user' } }),
+    ])).toEqual([])
+  })
+
+  it('skips a command issued by a merge-extended non-user source', () => {
+    expect(historyLines([
+      event('command/run', {
+        commandId: 'c1',
+        name: 'automated',
+        args: ' value',
+        source: { kind: 'plugin', plugin: 'automation' },
+      }),
     ])).toEqual([])
   })
 

--- a/packages/tui/tests/plan-review.spec.ts
+++ b/packages/tui/tests/plan-review.spec.ts
@@ -113,6 +113,21 @@ describe('plan review', () => {
     expect(overlay.render(80, rows).length).toBeLessThanOrEqual(rows)
   })
 
+  it('uses an unboxed decision when the minimum frame would exceed the terminal width', () => {
+    const overlay = createPlanReviewOverlay({
+      plan: '# Release plan\n- hidden until resized',
+      question: 'Approve this plan?',
+      choices: CHOICES,
+      settle: () => {},
+      invalidate: () => {},
+    })
+    const narrow = plain(overlay.render(10, 15))
+    expect(narrow.length).toBeLessThanOrEqual(15)
+    expect(narrow.every(row => displayWidth(row) <= 10)).toBe(true)
+    expect(narrow.join('\n')).toContain('Decision')
+    expect(narrow.join('\n')).not.toContain('rows 1–')
+  })
+
   it('keeps a compact decision-only review inside a terminal too short for one plan row', () => {
     const overlay = createPlanReviewOverlay({
       plan: '# Release plan\n- hidden until resized',

--- a/packages/tui/tests/tool-output.spec.ts
+++ b/packages/tui/tests/tool-output.spec.ts
@@ -79,6 +79,17 @@ describe('the tool-output inspector', () => {
     }
   })
 
+  it('uses the closable fallback when no body row fits or a card would re-wrap', () => {
+    const { overlay } = makeOverlay()
+    for (const [columns, terminalRows] of [[80, 7], [18, 10]] as const) {
+      const frame = plain(overlay.render(columns, terminalRows))
+      expect(frame.length, `${String(columns)}x${String(terminalRows)}`).toBeLessThanOrEqual(terminalRows)
+      expect(frame.join('\n')).toContain('esc close')
+      expect(frame.join('\n')).not.toMatch(/rows 1–0/u)
+      expect(frame.join('\n')).not.toContain('inspected row')
+    }
+  })
+
   it('keeps a very short terminal readable and closable', () => {
     const { overlay } = makeOverlay()
     for (const terminalRows of [3, 2, 1]) {

--- a/tools/check-trusted-publishers.mjs
+++ b/tools/check-trusted-publishers.mjs
@@ -1,0 +1,88 @@
+/**
+ * Verify that npm will exchange this workflow's GitHub OIDC identity for both
+ * packages before a workspace publish can become half-complete.
+ *
+ * A recursive publish authenticates one package at a time. If only the renderer
+ * trusted this workflow, it could be published before the bundle's exchange
+ * failed, and npm versions cannot be replaced. This preflight performs both
+ * exchanges first and deliberately discards the short-lived publish tokens.
+ * @module tools/check-trusted-publishers
+ */
+
+/** Published workspace packages, in dependency order. */
+export const PUBLISHED_PACKAGES = [
+  '@riesbri/dsh-tui-renderer',
+  '@riesbri/dsh-tui',
+]
+
+/** npm's expected audience for a GitHub-issued identity token. */
+const NPM_AUDIENCE = 'npm:registry.npmjs.org'
+
+/** npm registry origin and OIDC exchange root. */
+const NPM_REGISTRY = 'https://registry.npmjs.org'
+
+/**
+ * Fetch and validate JSON without ever including a bearer token in an error.
+ * @param fetchImpl - fetch implementation, injectable for tests.
+ * @param url - endpoint to call.
+ * @param init - request options.
+ * @param label - safe operation name for failures.
+ * @returns the parsed JSON object.
+ */
+async function fetchJson(fetchImpl, url, init, label) {
+  const response = await fetchImpl(url, init)
+  if (!response.ok) throw new Error(`${label} failed with HTTP ${String(response.status)}`)
+  const value = await response.json()
+  if (value === null || typeof value !== 'object') throw new Error(`${label} returned invalid JSON`)
+  return value
+}
+
+/**
+ * Verify every package's trusted-publisher exchange for one GitHub Actions job.
+ * @param options - injectable environment and fetch implementation.
+ * @param options.env - GitHub's OIDC request variables.
+ * @param options.fetchImpl - fetch implementation.
+ * @returns the package names whose exchanges succeeded.
+ */
+export async function checkTrustedPublishers({ env = process.env, fetchImpl = fetch } = {}) {
+  const requestUrl = env.ACTIONS_ID_TOKEN_REQUEST_URL
+  const requestToken = env.ACTIONS_ID_TOKEN_REQUEST_TOKEN
+  if (requestUrl === undefined || requestToken === undefined) {
+    throw new Error('GitHub OIDC is unavailable; the job needs id-token: write')
+  }
+
+  const identityUrl = new URL(requestUrl)
+  identityUrl.searchParams.set('audience', NPM_AUDIENCE)
+  const identity = await fetchJson(fetchImpl, identityUrl, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${requestToken}`,
+    },
+  }, 'GitHub OIDC identity request')
+  if (!('value' in identity) || typeof identity.value !== 'string' || identity.value === '') {
+    throw new Error('GitHub OIDC identity response contained no token')
+  }
+
+  for (const name of PUBLISHED_PACKAGES) {
+    const exchangeUrl = `${NPM_REGISTRY}/-/npm/v1/oidc/token/exchange/package/${encodeURIComponent(name)}`
+    const exchanged = await fetchJson(fetchImpl, exchangeUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${identity.value}`,
+        'Content-Length': '0',
+      },
+      body: '',
+    }, `npm trusted-publisher exchange for ${name}`)
+    if (!('token' in exchanged) || typeof exchanged.token !== 'string' || exchanged.token === '') {
+      throw new Error(`npm trusted-publisher exchange for ${name} returned no token`)
+    }
+    process.stdout.write(`trusted-publisher: npm accepted ${name}\n`)
+  }
+
+  return [...PUBLISHED_PACKAGES]
+}
+
+if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  await checkTrustedPublishers()
+}

--- a/tools/check-trusted-publishers.spec.mjs
+++ b/tools/check-trusted-publishers.spec.mjs
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { checkTrustedPublishers, PUBLISHED_PACKAGES } from './check-trusted-publishers.mjs'
+
+/** Minimal successful fetch response for the preflight's JSON reader. */
+function response(value, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => value,
+  }
+}
+
+const ENV = {
+  ACTIONS_ID_TOKEN_REQUEST_URL: 'https://actions.example.test/id-token?api-version=1',
+  ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
+}
+
+describe('checkTrustedPublishers()', () => {
+  it('covers every published workspace package', () => {
+    expect(PUBLISHED_PACKAGES).toEqual([
+      '@riesbri/dsh-tui-renderer',
+      '@riesbri/dsh-tui',
+    ])
+  })
+
+  it('gets one npm-audience identity and verifies both package exchanges', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({ value: 'github-identity-token' }))
+      .mockResolvedValueOnce(response({ token: 'renderer-publish-token' }))
+      .mockResolvedValueOnce(response({ token: 'tui-publish-token' }))
+
+    await expect(checkTrustedPublishers({ env: ENV, fetchImpl })).resolves.toEqual(PUBLISHED_PACKAGES)
+
+    const identityUrl = new URL(fetchImpl.mock.calls[0][0])
+    expect(identityUrl.searchParams.get('audience')).toBe('npm:registry.npmjs.org')
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe('Bearer github-request-token')
+    expect(String(fetchImpl.mock.calls[1][0])).toContain(encodeURIComponent(PUBLISHED_PACKAGES[0]))
+    expect(String(fetchImpl.mock.calls[2][0])).toContain(encodeURIComponent(PUBLISHED_PACKAGES[1]))
+    expect(fetchImpl.mock.calls[1][1].headers.Authorization).toBe('Bearer github-identity-token')
+  })
+
+  it('fails before publishing when either package rejects this workflow', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({ value: 'github-identity-token' }))
+      .mockResolvedValueOnce(response({ token: 'renderer-publish-token' }))
+      .mockResolvedValueOnce(response({}, 403))
+
+    await expect(checkTrustedPublishers({ env: ENV, fetchImpl }))
+      .rejects.toThrow(`npm trusted-publisher exchange for ${PUBLISHED_PACKAGES[1]} failed with HTTP 403`)
+  })
+
+  it('requires the workflow OIDC permission', async () => {
+    await expect(checkTrustedPublishers({ env: {}, fetchImpl: vi.fn() }))
+      .rejects.toThrow('the job needs id-token: write')
+  })
+})

--- a/tools/verify-published.mjs
+++ b/tools/verify-published.mjs
@@ -53,8 +53,8 @@ for (const directory of PACKAGES) {
 if (missing.length > 0) {
   process.stderr.write(
     `verify-published: the registry does not serve ${missing.join(', ')}.\n`
-    + 'The release did not fully land. Publish the missing package before tagging another version:\n'
-    + 'a half-published workspace leaves an install resolving one package and not the other.\n',
+    + 'The release did not fully land. Correct the missing package trusted-publisher mapping, then rerun\n'
+    + 'this same tagged workflow; do not create another tag until both exact versions verify.\n',
   )
   process.exit(1)
 }

--- a/tools/verify-published.mjs
+++ b/tools/verify-published.mjs
@@ -7,11 +7,10 @@
  * afterwards turns that into a red release rather than a discovery made later by
  * someone whose install half-resolves.
  *
- * It also catches the case the concurrency group cannot: GitHub keeps at most one
- * PENDING run per group, so pushing a third tag while a release is running
- * discards the middle one's run. That run never executes, so nothing inside it can
- * report — but the next release runs this check, and a version that was never
- * published is then visible as a gap between the tags and the registry.
+ * This checks only the version in the current release tree. It cannot detect a
+ * different tagged version whose pending workflow GitHub discarded before it ran;
+ * version.yml prevents the automated handoff from creating that second tag while
+ * a publisher is active instead.
  * @module tools/verify-published
  */
 


### PR DESCRIPTION
## Summary

I reviewed the cumulative result of recent PRs #30–#41, including the input-history/composer work, plan and tool-output overlays, Changesets automation, recovery tagging, and the successful v0.3.1 publish.

This follow-up fixes the concrete regressions and release-integrity gaps found in that audit:

- keep the trailing insertion row stable when a draft exactly fills its visual row, so `↑` followed by `↓` can return to the end (including CJK)
- preserve a half-typed draft when cursor-only movement occurs inside recalled history, while real edits still leave history traversal
- reject whitespace-only turns and non-user command events in durable input history
- keep plan review and tool inspection closable and within the screen on very narrow/short terminals
- validate both manifests and the embedded banner before creating an immutable release tag
- require recovery to name the exact generated Version Packages PR merge commit
- verify an existing tag's peeled commit instead of treating any same-named tag as success
- serialize tag handoffs and refuse a new tag while a publisher is queued, awaiting approval, or running
- correct the claim that the current-version registry verifier could detect a different publish workflow that GitHub discarded before it ran

The user-visible fixes carry a patch changeset for both fixed packages.

## Validation

- `pnpm build`
- `pnpm test` — 623 tests
- `pnpm typecheck`
- `pnpm security`
- `git diff --check`
- exercised the recovery PR query against PR #40's merge commit and a non-version merge commit
- checked the existing annotated `v0.3.1` tag peels to PR #40's merge commit
- checked the active-publisher query against the live Actions API

I deliberately removed the exact-width row, history edit distinction, narrow plan fallback, narrow/zero-body inspector fallback, and whitespace guard in turn; each named regression test failed.

## Remaining operational hardening

The workflow cannot defend against a Contents-write credential that bypasses it and pushes an arbitrary `v*` tag, because a tag-triggered workflow definition comes from that tag's tree. `AGENTS.md` now records the required external controls: a `v*` tag ruleset, plus the existing reviewed/tag-restricted `npm` environment. The repository currently has the protected `npm` environment configured, but no tag ruleset yet; that setting should be added before the next release.

Two broader pre-existing live-region concerns from the audit are intentionally not folded into this focused fix: terminal-height allocation across all simultaneously registered slots, and input arriving while resume replay is still hydrating. Both need session/composition-level validation rather than another local constant.


## Trusted publishing follow-up

After this PR opened, npm trusted publishers replaced the removed `NPM_TOKEN`. The branch now also:

- removes the legacy `NODE_AUTH_TOKEN` path entirely
- uses pnpm 11.22's native GitHub OIDC exchange with job-level `id-token: write`
- preflights both package exchanges before either package can be published
- adds a manual, non-publishing workflow dispatch that verifies both npm mappings
- retains explicit provenance and allows an immediate half-release retry to see the package already published without weakening dependency-install age policy
- updates recovery guidance for tokenless publishing

Additional validation: four trusted-publisher unit tests, recursive dry-run packaging of both packages, and deliberate removal of the second package from the preflight to confirm the coverage test fails.
