### PR TITLE
fix(release): wait for npm registry propagation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,10 +81,6 @@ jobs:
           # which is precisely the guarantee the attestation below is supposed to be
           # making. Twenty seconds of download is the right price.
           package-manager-cache: false
-          #
-          # Keep the public registry explicit. pnpm 11.22 exchanges this job's
-          # GitHub OIDC identity before considering any static npmrc credential.
-          registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile --ignore-scripts
 

--- a/tools/verify-published.mjs
+++ b/tools/verify-published.mjs
@@ -18,7 +18,16 @@ import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 
 /** Workspace packages that get published, in dependency order. */
-const PACKAGES = ['packages/renderer', 'packages/tui']
+export const PACKAGE_DIRECTORIES = ['packages/renderer', 'packages/tui']
+
+/**
+ * npm's read API can trail a successful publish briefly. One minute distinguishes
+ * ordinary propagation from a real half-release without making recovery opaque.
+ */
+const VERIFY_ATTEMPTS = 12
+
+/** Five seconds avoids hammering npm while keeping a normal release prompt. */
+const VERIFY_DELAY_MS = 5_000
 
 /**
  * Whether the registry serves an exact version of a package.
@@ -40,21 +49,66 @@ function published(name, version) {
   }
 }
 
-const missing = []
-for (const directory of PACKAGES) {
-  const { name, version } = JSON.parse(readFileSync(`${directory}/package.json`, 'utf8'))
-  if (published(name, version)) {
-    process.stdout.write(`verify-published: ${name}@${version} is on the registry\n`)
-    continue
-  }
-  missing.push(`${name}@${version}`)
+/**
+ * Pause between registry reads.
+ * @param milliseconds - delay before the next attempt.
+ * @returns a promise settled after the delay.
+ */
+function delay(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
 }
 
-if (missing.length > 0) {
-  process.stderr.write(
-    `verify-published: the registry does not serve ${missing.join(', ')}.\n`
-    + 'The release did not fully land. Correct the missing package trusted-publisher mapping, then rerun\n'
-    + 'this same tagged workflow; do not create another tag until both exact versions verify.\n',
-  )
-  process.exit(1)
+/**
+ * Wait for every exact package version to become visible on npm.
+ *
+ * Versions already observed are not queried again. This both shortens retries and
+ * makes the log say exactly when each half of the workspace became visible.
+ * @param packages - package names and exact versions expected from this release.
+ * @param options - injectable registry reader, delay and logger for tests.
+ * @param options.isPublished - exact-version registry reader.
+ * @param options.sleep - delay between attempts.
+ * @param options.write - successful-observation logger.
+ * @param options.attempts - maximum registry reads per package.
+ * @returns exact `name@version` strings still missing after all attempts.
+ */
+export async function waitForPublished(packages, {
+  isPublished = published,
+  sleep = delay,
+  write = text => process.stdout.write(text),
+  attempts = VERIFY_ATTEMPTS,
+} = {}) {
+  let pending = [...packages]
+  const limit = Math.max(1, attempts)
+  for (let attempt = 1; attempt <= limit; attempt += 1) {
+    const missing = []
+    for (const item of pending) {
+      if (isPublished(item.name, item.version)) {
+        write(`verify-published: ${item.name}@${item.version} is on the registry\n`)
+      } else {
+        missing.push(item)
+      }
+    }
+    pending = missing
+    if (pending.length === 0) break
+    if (attempt < limit) await sleep(VERIFY_DELAY_MS)
+  }
+  return pending.map(item => `${item.name}@${item.version}`)
+}
+
+/** Read the release tree's package identities once before polling npm. */
+const packages = PACKAGE_DIRECTORIES.map(directory => {
+  const { name, version } = JSON.parse(readFileSync(`${directory}/package.json`, 'utf8'))
+  return { name, version }
+})
+
+if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  const missing = await waitForPublished(packages)
+  if (missing.length > 0) {
+    process.stderr.write(
+      `verify-published: the registry does not serve ${missing.join(', ')}.\n`
+      + 'The release did not fully land. Correct the missing package trusted-publisher mapping, then rerun\n'
+      + 'this same tagged workflow; do not create another tag until both exact versions verify.\n',
+    )
+    process.exit(1)
+  }
 }

--- a/tools/verify-published.spec.mjs
+++ b/tools/verify-published.spec.mjs
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import { PACKAGE_DIRECTORIES, waitForPublished } from './verify-published.mjs'
+
+const PACKAGES = [
+  { name: '@riesbri/dsh-tui-renderer', version: '0.3.2' },
+  { name: '@riesbri/dsh-tui', version: '0.3.2' },
+]
+
+describe('waitForPublished()', () => {
+  it('covers every published workspace package', () => {
+    expect(PACKAGE_DIRECTORIES).toEqual(['packages/renderer', 'packages/tui'])
+  })
+
+  it('waits for a package that appears after its publish request returns', async () => {
+    const seen = new Map([
+      [PACKAGES[0].name, 0],
+      [PACKAGES[1].name, 0],
+    ])
+    const isPublished = vi.fn(name => {
+      const count = (seen.get(name) ?? 0) + 1
+      seen.set(name, count)
+      return name === PACKAGES[0].name || count >= 2
+    })
+    const sleep = vi.fn(async () => {})
+    const write = vi.fn()
+
+    await expect(waitForPublished(PACKAGES, { isPublished, sleep, write, attempts: 3 }))
+      .resolves.toEqual([])
+    expect(sleep).toHaveBeenCalledTimes(1)
+    expect(isPublished.mock.calls.map(call => call[0])).toEqual([
+      PACKAGES[0].name,
+      PACKAGES[1].name,
+      PACKAGES[1].name,
+    ])
+    expect(write).toHaveBeenCalledWith(expect.stringContaining(`${PACKAGES[1].name}@0.3.2`))
+  })
+
+  it('returns a persistent half-release after the retry budget', async () => {
+    const sleep = vi.fn(async () => {})
+    const missing = await waitForPublished(PACKAGES, {
+      isPublished: item => item === PACKAGES[0].name,
+      sleep,
+      write: () => {},
+      attempts: 3,
+    })
+
+    expect(missing).toEqual([`${PACKAGES[1].name}@0.3.2`])
+    expect(sleep).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary

The first trusted-publisher release did publish both v0.3.2 packages successfully, but npm's read API exposed the renderer a few seconds before the TUI package. The immediate verification step saw that transient split and marked the run red. Rerunning the same tagged workflow then saw both existing packages, skipped republishing them, verified the registry, and created the GitHub Release.

This follow-up:

- retries exact-version registry reads for up to one minute
- stops rechecking a package once it is visible
- still fails with the half-release recovery instructions when a package remains absent
- removes setup-node's unused `NODE_AUTH_TOKEN` npmrc placeholder, eliminating warnings from the tokenless OIDC workflow

No changeset: this changes release verification only and does not alter either published package.

## Validation

- `pnpm build`
- `pnpm test` — 630 tests
- `pnpm typecheck`
- `pnpm security`
- live v0.3.2 metadata for both packages
- `npm audit signatures` after installing both exact v0.3.2 packages in a scratch directory
- deliberate one-attempt regression: the new propagation test failed by name
