### PR TITLE
docs: refresh README around Harness plugin architecture

### DIFF
--- a/.github/assets/dsh-tui-architecture.svg
+++ b/.github/assets/dsh-tui-architecture.svg
@@ -100,16 +100,16 @@
 <rect x="369" y="224" width="541" height="36" rx="6" fill="#080f13"/>
 <text x="640" y="248" fill="#28d8d2" font-family="monospace" font-size="23" font-weight="700" text-anchor="middle">Standard Harness capability surfaces</text>
 
-<!-- generic adapters -->
+<!-- presentation adapters -->
 <rect x="18" y="372" width="1244" height="128" rx="10" fill="none" stroke="#25c9c6" stroke-width="2"/>
 
 <g font-family="monospace" font-size="15" font-weight="600" text-anchor="middle">
-  <g><rect x="39" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="123" y="455" fill="#f4f7f8">↔  Adapter</text></g>
-  <g><rect x="247" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="331" y="455" fill="#f4f7f8">↔  Adapter</text></g>
-  <g><rect x="455" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="539" y="455" fill="#f4f7f8">↔  Adapter</text></g>
-  <g><rect x="663" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="747" y="455" fill="#f4f7f8">↔  Adapter</text></g>
-  <g><rect x="871" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="955" y="455" fill="#f4f7f8">↔  Adapter</text></g>
-  <g><rect x="1079" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="1163" y="455" fill="#f4f7f8">↔  Adapter</text></g>
+  <g><rect x="39" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="123" y="455" fill="#f4f7f8">Work adapter</text></g>
+  <g><rect x="247" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="331" y="455" fill="#f4f7f8">Work adapter</text></g>
+  <g><rect x="455" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="539" y="455" fill="#f4f7f8">Todo adapter</text></g>
+  <g><rect x="663" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="747" y="455" fill="#f4f7f8">Tool adapter</text></g>
+  <g><rect x="871" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="955" y="455" fill="#f4f7f8">Command adapter</text></g>
+  <g><rect x="1079" y="426" width="168" height="46" rx="8" fill="#0a1015" stroke="#344149" stroke-width="1.5"/><text x="1163" y="455" fill="#f4f7f8">Model adapter</text></g>
 </g>
 
 <!-- surface-to-adapter connectors: neutral gray (not the adapters' teal) so the lines read clearly against the box border/title, e.g. the ctx.tools arrow -->
@@ -130,7 +130,7 @@
 
 <!-- row3 title rendered after its connectors, with a small backing chip, so the crossing lines duck behind the label -->
 <rect x="382" y="381" width="517" height="34" rx="6" fill="#080f13"/>
-<text x="640" y="404" fill="#28d8d2" font-family="monospace" font-size="22" font-weight="700" text-anchor="middle">dsh-tui capability adapters (generic)</text>
+<text x="640" y="404" fill="#28d8d2" font-family="monospace" font-size="22" font-weight="700" text-anchor="middle">dsh-tui presentation adapters</text>
 
 <!-- TuiSlots / Screen -->
 <rect x="18" y="526" width="1244" height="80" rx="10" fill="#081016" stroke="#25c9c6" stroke-width="2"/>
@@ -157,7 +157,7 @@
   </g>
   <g>
     <rect x="294" y="739" width="220" height="128" rx="7" fill="#0a1015" stroke="#2c3840" stroke-width="1.5"/>
-    <text x="308" y="766" fill="#28d8d2" font-size="14" font-weight="700">/jobs</text>
+    <text x="308" y="766" fill="#28d8d2" font-size="14" font-weight="700">/work</text>
     <text x="308" y="789" fill="#aeb9bf" font-size="12">Jobs</text>
     <text x="308" y="817" fill="#f4f7f8" font-size="12">#128 ingest-repo</text><text x="452" y="817" fill="#f5bd4f" font-size="12">running</text>
   </g>
@@ -169,8 +169,8 @@
   </g>
   <g>
     <rect x="758" y="739" width="220" height="128" rx="7" fill="#0a1015" stroke="#2c3840" stroke-width="1.5"/>
-    <text x="772" y="766" fill="#28d8d2" font-size="14" font-weight="700">/tools</text>
-    <text x="772" y="789" fill="#aeb9bf" font-size="12">Tools</text>
+    <text x="772" y="766" fill="#28d8d2" font-size="14" font-weight="700">Tool card</text>
+    <text x="772" y="789" fill="#aeb9bf" font-size="12">Tool output</text>
     <text x="772" y="817" fill="#f4f7f8" font-size="12">&gt; search_code</text>
   </g>
   <g>
@@ -205,8 +205,8 @@
 <g font-family="monospace" font-size="13" fill="#aeb9bf">
   <text x="1294" y="470" fill="#28d8d2" font-size="15" font-weight="700">✓</text><text x="1318" y="470">Plugin-native</text>
   <text x="1294" y="510" fill="#28d8d2" font-size="15" font-weight="700">✓</text><text x="1318" y="510">Provider-neutral</text>
-  <text x="1294" y="550" fill="#28d8d2" font-size="15" font-weight="700">✓</text><text x="1318" y="550">No provider-specific</text>
-  <text x="1318" y="574">integrations</text>
+  <text x="1294" y="550" fill="#28d8d2" font-size="15" font-weight="700">✓</text><text x="1318" y="550">Prefer generic adapters</text>
+  <text x="1318" y="574">where seams exist</text>
   <text x="1294" y="614" fill="#28d8d2" font-size="15" font-weight="700">✓</text><text x="1318" y="614">Real terminal</text>
   <text x="1318" y="636">scrollback</text>
   <text x="1294" y="676" fill="#28d8d2" font-size="15" font-weight="700">✓</text><text x="1318" y="676">Bounded live region</text>

--- a/.github/assets/dsh-tui-hero.svg
+++ b/.github/assets/dsh-tui-hero.svg
@@ -77,10 +77,10 @@
 <text x="1392" y="295" class="mono cyan" font-size="18" font-weight="700" text-anchor="start" letter-spacing="0">dsh-tui</text>
 <circle cx="1552" cy="291" r="4" fill="#59d68b"/><text x="1562" y="295" class="mono dim" font-size="10" font-weight="400" text-anchor="start" letter-spacing="0">connected</text>
 <line x1="1392" y1="312" x2="1616" y2="312" stroke="#1c2b31" stroke-width="1"/>
-<text x="1392" y="344" class="mono muted" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">&gt; ls subagents</text>
-<text x="1392" y="488" class="mono muted" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">&gt; jobs</text>
-<text x="1392" y="518" class="mono muted" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">&gt; session projections</text>
-<text x="1392" y="548" class="mono muted" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">&gt; logs (scrollback)</text>
+<text x="1392" y="344" class="mono muted" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">Subagents</text>
+<text x="1392" y="488" class="mono muted" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">Jobs</text>
+<text x="1392" y="518" class="mono muted" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">Session projections</text>
+<text x="1392" y="548" class="mono muted" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">Native scrollback</text>
 <text x="1410" y="372" class="mono dim" font-size="11" font-weight="400" text-anchor="start" letter-spacing="0">ID</text>
 <text x="1536" y="372" class="mono dim" font-size="11" font-weight="400" text-anchor="start" letter-spacing="0">STATUS</text>
 <text x="1410" y="399" class="mono white" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">researcher</text>

--- a/.github/assets/dsh-tui-hero.svg
+++ b/.github/assets/dsh-tui-hero.svg
@@ -34,34 +34,33 @@
 <rect x="720" y="124" width="958" height="510" rx="18" fill="url(#panel)" stroke="#303b43" stroke-width="2"/>
 <line x1="720" y1="186" x2="1678" y2="186" stroke="#303b43" stroke-width="2"/>
 <circle cx="752" cy="156" r="9" fill="#ef655d"/><circle cx="781" cy="156" r="9" fill="#efb54c"/><circle cx="810" cy="156" r="9" fill="#59c56f"/><text x="1200" y="165" class="mono cyan" font-size="24" font-weight="700" text-anchor="middle" letter-spacing="0">dsh-tui</text>
-<text x="806" y="231" class="mono dim" font-size="17" font-weight="700" text-anchor="start" letter-spacing="0">HARNESS PLUGINS</text>
-<text x="1090" y="231" class="mono dim" font-size="17" font-weight="700" text-anchor="start" letter-spacing="0">CAPABILITY CONTRACTS</text>
+<text x="806" y="231" class="mono dim" font-size="17" font-weight="700" text-anchor="start" letter-spacing="0">HARNESS SURFACES</text>
+<text x="1090" y="231" class="mono dim" font-size="17" font-weight="700" text-anchor="start" letter-spacing="0">PRESENTATION ADAPTERS</text>
 <text x="1427" y="231" class="mono dim" font-size="17" font-weight="700" text-anchor="start" letter-spacing="0">NATIVE TERMINAL UI</text>
 <rect x="744" y="264" width="258" height="96" rx="10" fill="#0b1116" stroke="#29343b" stroke-width="2"/>
 <text x="766" y="302" class="mono cyan" font-size="25" font-weight="700" text-anchor="start" letter-spacing="0">♙</text>
 <text x="811" y="300" class="mono cyan" font-size="16" font-weight="700" text-anchor="start" letter-spacing="0">ctx.subagents</text>
-<text x="811" y="328" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">list · create · run</text>
+<text x="811" y="328" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">children · lifecycle</text>
 <rect x="744" y="383" width="258" height="96" rx="10" fill="#0b1116" stroke="#29343b" stroke-width="2"/>
 <text x="766" y="421" class="mono cyan" font-size="25" font-weight="700" text-anchor="start" letter-spacing="0">≡</text>
 <text x="811" y="419" class="mono cyan" font-size="16" font-weight="700" text-anchor="start" letter-spacing="0">ctx.jobs</text>
-<text x="811" y="447" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">list · logs · control</text>
+<text x="811" y="447" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">list · observe · changes</text>
 <rect x="744" y="502" width="258" height="96" rx="10" fill="#0b1116" stroke="#29343b" stroke-width="2"/>
 <text x="766" y="540" class="mono cyan" font-size="25" font-weight="700" text-anchor="start" letter-spacing="0">◉</text>
 <text x="811" y="538" class="mono cyan" font-size="14" font-weight="700" text-anchor="start" letter-spacing="0" textLength="186" lengthAdjust="spacingAndGlyphs">ctx.sessionProjections</text>
-<text x="811" y="566" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">list · inspect · stream</text>
+<text x="811" y="566" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">snapshot · changes</text>
 <rect x="1059" y="264" width="258" height="96" rx="10" fill="#0b1116" stroke="#29343b" stroke-width="2"/>
 <text x="1080" y="303" class="mono amber" font-size="25" font-weight="700" text-anchor="start" letter-spacing="0">{}</text>
-<text x="1120" y="301" class="mono white" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">SubagentCapability</text>
-<text x="1120" y="328" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">v1</text>
+<text x="1120" y="301" class="mono white" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">Work adapter</text>
+<text x="1120" y="328" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">subagents</text>
 <rect x="1059" y="383" width="258" height="96" rx="10" fill="#0b1116" stroke="#29343b" stroke-width="2"/>
 <text x="1080" y="422" class="mono amber" font-size="25" font-weight="700" text-anchor="start" letter-spacing="0">{}</text>
-<text x="1120" y="420" class="mono white" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">JobCapability</text>
-<text x="1120" y="447" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">v1</text>
+<text x="1120" y="420" class="mono white" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">Work adapter</text>
+<text x="1120" y="447" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">jobs</text>
 <rect x="1059" y="502" width="258" height="96" rx="10" fill="#0b1116" stroke="#29343b" stroke-width="2"/>
 <text x="1080" y="541" class="mono amber" font-size="25" font-weight="700" text-anchor="start" letter-spacing="0">{}</text>
-<text x="1120" y="532" class="mono white" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">SessionProjection</text>
-<text x="1120" y="550" class="mono white" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">Capability</text>
-<text x="1120" y="577" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">v1</text>
+<text x="1120" y="541" class="mono white" font-size="14" font-weight="600" text-anchor="start" letter-spacing="0">Todo adapter</text>
+<text x="1120" y="568" class="mono dim" font-size="13" font-weight="400" text-anchor="start" letter-spacing="0">known projection</text>
 <line x1="1002" y1="312" x2="1058" y2="312" stroke="#25c9c6" stroke-width="2"/>
 <polyline points="1050,307 1058,312 1050,317" fill="none" stroke="#25c9c6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <line x1="1318" y1="312" x2="1370" y2="312" stroke="#f2b94b" stroke-width="2"/>

--- a/README.md
+++ b/README.md
@@ -1,218 +1,119 @@
-<div align="center">
+<p align="center">
+  <img src=".github/assets/dsh-tui-hero.svg" alt="dsh-tui: a terminal-native frontend for DeepSeek Harness. Harness plugins flow through capability contracts into native terminal UI." />
+</p>
 
 # dsh-tui
 
-**A terminal-native interface for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), built as a plugin that runs inside the agent instead of connecting to it over a network.**
+**The terminal-native frontend for the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) plugin ecosystem.**
 
-It presents Harness capabilities through their standard contracts instead of reimplementing providers. It prints into your terminal's normal scroll history instead of taking over the screen. It adds no third-party packages. One command installs it.
-
-[![ci](https://img.shields.io/github/actions/workflow/status/riesbri/dsh-tui/ci.yml?branch=main&color=369eff&labelColor=black&logo=github&style=flat-square&label=ci)](https://github.com/riesbri/dsh-tui/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@riesbri/dsh-tui?color=ff6b35&labelColor=black&style=flat-square)](https://www.npmjs.com/package/@riesbri/dsh-tui)
+[![CI](https://img.shields.io/github/actions/workflow/status/riesbri/dsh-tui/ci.yml?branch=main&color=369eff&labelColor=black&logo=github&style=flat-square&label=ci)](https://github.com/riesbri/dsh-tui/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/riesbri/dsh-tui?color=c4f042&labelColor=black&style=flat-square&label=scorecard)](https://scorecard.dev/viewer/?uri=github.com/riesbri/dsh-tui)
-[![dependencies](https://img.shields.io/badge/dependencies-0-8ae8ff?labelColor=black&style=flat-square)](docs/comparison.md#it-adds-no-third-party-packages)
-[![node](https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-ffcb47?labelColor=black&style=flat-square&logo=node.js&logoColor=white)](docs/install.md#requirements)
 [![license](https://img.shields.io/badge/license-MIT-white?labelColor=black&style=flat-square)](LICENSE)
 
-<!-- Add these two once the package is published:
-[![npm](https://img.shields.io/npm/v/@riesbri/dsh-tui?color=ff6b35&labelColor=black&style=flat-square)](https://www.npmjs.com/package/@riesbri/dsh-tui)
-[![downloads](https://img.shields.io/npm/dm/@riesbri/dsh-tui?color=ff80eb&labelColor=black&style=flat-square)](https://www.npmjs.com/package/@riesbri/dsh-tui)
--->
+Harness plugins expose capabilities. dsh-tui presents supported capabilities natively in the terminal. It runs inside Harness and consumes the contracts Harness already owns instead of building separate runtimes for providers, jobs, subagents, Todo state, models, commands, or persistence.
 
-</div>
+The goal is not to port every Harness plugin. When a plugin participates in a standard capability surface that dsh-tui understands, the terminal frontend can present it generically rather than adding a provider-specific implementation.
 
-> [!WARNING]
-> **This is alpha software.** It works, it is tested, and it is used daily by its author — but it is young. Expect rough edges, expect features to be missing, and expect small breaking changes before 1.0. Two things to know before you point it at code you care about:
->
-> 1. **Tool calls are not reviewed before they run.** In a standard setup, the agent can edit files and run shell commands inside your working folder without asking you first. That is how the harness is configured by default, not a choice this interface makes. [How to change that →](docs/usage.md#permissions-and-the-sandbox)
-> 2. **Three other terminal interfaces for the harness exist, and one of them has more features than this one.** [An honest comparison →](docs/comparison.md)
+<p align="center">
+  <img src=".github/assets/dsh-tui-architecture.svg" alt="Capability flow from DeepSeek Harness plugins through standard capability surfaces and dsh-tui adapters to a native terminal UI with real scrollback." />
+</p>
 
-## Contents
-
-- [What it looks like](#what-it-looks-like)
-- [Getting started](#getting-started)
-- [Keys and commands](#keys-and-commands)
-- [How it works](#how-it-works)
-- [Why choose this one](#why-choose-this-one)
-- [Documentation](#documentation)
-- [Security](#security)
-- [Contributing](#contributing)
-
-## What it looks like
-
-```
-╭──────────────────────────────────────────────────────────────────╮
-│ dsh-tui <version>                                                │
-│ ~/code/my-project                                                │
-│ deepseek-official / deepseek-v4-flash                            │
-╰──────────────────────────────────────────────────────────────────╯
-
-───────────────────────────────────────────────────────────────────
-› Read the LICENSE file and name the license. Use the read tool.
-
-⏺ read file_path=~/code/my-project/LICENSE
-  ⎿ <path>~/code/my-project/LICENSE</path>
-    <type>file</type>
-    1: MIT License
-    … 21 more lines
-
-● The LICENSE file is the MIT License.
-
-╭─ my-project ─────────────────────────────────────────────────────╮
-│ › ask anything                                                   │
-╰──────────────────────────────────────────────────────────────────╯
-  ● ready · deepseek-v4-flash · ↑8.8k ↓1.6k $0.018 · ▏░░░░░░░ 14k/1.0M
-```
-
-The status line carries what the session has used — every prompt token, everything generated, and a dollar figure — beside how full the context window is. On a pay-as-you-go route that figure estimates money spent; on OpenCode Go it is the dollar-denominated usage counted against the subscription allowance. The tokens come from the provider's own accounting, and the routes this interface is built against — DeepSeek's own and OpenCode's (Zen and Go) — are priced out of the box, each message charged at the peak or off-peak rate that applied when it ran. A route nobody has priced shows its tokens and no money rather than guessing.
-
-When plan mode is on, or a goal is taking rounds by itself, the status line says so — those are the two states that change what a turn *does* rather than what it says, and a transcript hides both.
-
-Questions from the agent, approval requests, and the model picker all use the same framed box. While the agent is working, the status line shows a spinner and how long it has been running, and gives up whatever the width no longer fits — the bar first, then the model name, then the totals. The context reading goes after those, and the two modes above go last of all, because what a turn will do outranks what it costs:
-
-```
-╭─ Indentation: Do you prefer tabs or spaces? ─────────────────────╮
-│ ❯ Tabs                                                           │
-│   Indent with tab characters.                                    │
-│   Spaces                                                         │
-╰──────────────────────────────────────────────────────────────────╯
-  ↑↓ move · enter confirm · esc cancel
-
-  ⠙ working 4s · deepseek-v4-flash · ↑8.8k ↓1.6k $0.018 · 13k/1.0M
-```
-
-## Getting started
-
-You need two things: Node.js `^22.19 || >=24`, and a working DeepSeek Harness installation with a model configured. If `dsh web` starts and answers a prompt, you are ready.
+## Install
 
 ```sh
 dsh plugin --profile tui add @riesbri/dsh-tui
 dsh --profile tui
 ```
 
-The first command creates a harness *profile* named `tui` and installs this interface into it. A profile is a named set of plugins; yours is now the harness's standard set plus this one. The second command starts a session in your current folder.
+See [Install](docs/install.md) for requirements, verification, the `dshtui` launcher, and source installs.
 
-<details>
-<summary><b>If you do not have a <code>dsh</code> command yet, or you want to install from source</b></summary>
+> [!NOTE]
+> dsh-tui is pre-1.0 and moving quickly. DeepSeek Harness is also in developer preview, so compatibility changes can happen.
 
-Install the harness command globally:
+> [!WARNING]
+> Tool permissions and sandbox policy come from the active Harness profile. In a standard setup, ordinary tool calls can run in the working folder without review. Read [Permissions and the sandbox](docs/usage.md#permissions-and-the-sandbox) before using it on code you care about.
 
-```sh
-npm install -g @deepseek-ai/dsh
-```
+## Why dsh-tui?
 
-If you work from a harness source checkout instead, `pnpm dsh` does the same job. One difference: a relative path is then resolved against the harness folder, so give an absolute path:
+### Built for the Harness plugin ecosystem
 
-```sh
-pnpm dsh plugin --profile tui add ~/path/to/dsh-tui/packages/tui
-```
+DeepSeek Harness is built around plugins and capability seams; dsh-tui follows that architecture:
 
-To run unreleased changes from a clone of this repository:
+`Harness plugin → standard capability → dsh-tui adapter → native terminal UI`
 
-```sh
-git clone https://github.com/riesbri/dsh-tui && cd dsh-tui
-pnpm install && pnpm build
-dsh plugin --profile tui add ./packages/tui
-```
+A supported generic seam such as `ctx.subagents` or `ctx.jobs` can be presented without a dedicated provider runtime. The intended provider-neutral model is for providers such as Codex, Claude Code, and spawn/fork to participate through those Harness surfaces rather than through dsh-tui-specific runtimes. The goal is capability integration, not plugin-by-plugin ports.
 
-The full procedure, how to check it worked, and how to uninstall: [`docs/install.md`](docs/install.md).
+### Your terminal stays your terminal
 
-</details>
+Finished output enters real terminal scrollback and is never rewritten. Normal terminal scrolling, selecting, and copying continue to work; only a bounded live region is redrawn. dsh-tui does not replace the transcript with an alternate screen.
 
-**If you are an AI agent installing this,** the install page is written to be followed step by step:
+### Small, provider-neutral presentation core
 
-```sh
-curl -s https://raw.githubusercontent.com/riesbri/dsh-tui/main/docs/install.md
-```
+Harness owns capabilities, providers, persistence, agent state, and policy semantics. dsh-tui owns terminal rendering, navigation, overlays, and presentation. Its renderer remains Harness-independent and has no runtime dependencies of its own. See [Architecture](docs/architecture.md) and [Design](docs/design.md).
 
-If you are changing this repository rather than using it, start at [`AGENTS.md`](AGENTS.md).
+## Harness capabilities
 
-## Keys and commands
-
-| | |
+| Harness surface | dsh-tui presentation |
 | --- | --- |
-| `enter` | Send |
-| `shift-enter`, `alt-enter` | Start a new line without sending |
-| `tab` | Accept the highlighted suggestion |
-| `ctrl-c` | Stop the agent; if it is not running, quit |
-| `ctrl-d` | Quit, from anywhere — including a picker, a question, or an approval prompt |
-| `ctrl-l` | Clear the display |
-| `ctrl-o` | Inspect the most recent truncated tool output; otherwise cycle how much tool output is shown: compact, full, hidden |
-| `↑` `↓` `enter` `esc` | Move, confirm, and close a box or a suggestion list |
+| `ctx.tools` | Harness-driven tool cards and results |
+| `ctx.jobs` | Generic background work in `/work` |
+| `ctx.subagents` | Generic delegated work in `/work` |
+| `ctx.sessionProjections` (`todos`) | `/todos` and compact status |
+| `ctx.commands` | Harness command discovery and execution |
+| `ctx.llm` | Model discovery and `/model` |
+| `ctx.userQuestions` | Native question UI |
+| Approval requests | Native interaction; Harness-owned policy |
+| Harness goal and plan capabilities | Terminal state over Harness-owned behavior |
+| `ctx.sessionQuery` | Resume today; richer Sessions UX planned |
 
-Type `/` to see the commands your agent actually has, and keep typing past one to see the values it takes — `/reasoning ` offers `off`, `high`, `max`. `/model`, `/reasoning`, `/usage`, `/profile`, `/work`, `/todos` and `/exit` are handled by this interface; each of the first three takes its value directly or opens a picker when typed alone. The model and reasoning level you choose are stored where the web interface reads them, so the two stay in step. `/compact`, `/plan`, `/goal`, `/permission` and `/feedback` come from the harness, so which ones appear depends on your setup. Every command prints its result. A name that matches nothing is reported as unknown instead of being sent to the model as a question.
+A standard Harness seam maps to a generic adapter; a known projection or domain can have a native presentation adapter. A novel capability may need a new adapter. dsh-tui does not aim to give every plugin bespoke UI, and it does not yet offer a stable public TUI plugin SDK.
 
-```sh
-dshtui                    # open the folder you are standing in
-dshtui -C ~/code/api      # open a different folder
-dshtui "run the tests"    # send a first message on startup
-dshtui --resume           # reopen one of your recent sessions
+`/work` is one example of the generic path:
+
+```text
+╭─ Work ───────────────────────────────────────────╮
+│ Subagents                                        │
+│ ❯ ● reviewer  checking renderer             18s  │
+│                                                  │
+│ Jobs                                             │
+│   ● test  pnpm test                          7s  │
+╰──────────────────────────────────────────────────╯
 ```
 
-Text-editing keys, the `shift-enter` caveat, how to tell it what your models cost, a warning about `/goal`, and the permission presets are all in [`docs/usage.md`](docs/usage.md).
+## Commands
 
-## How it works
+Type `/` in dsh-tui to discover what is currently available. Local commands include `/work`, `/todos`, `/model`, `/reasoning`, `/usage`, `/profile`, and `/exit`.
 
-There are two packages. [`@riesbri/dsh-tui-renderer`](packages/renderer) does the drawing: character widths, keyboard decoding, the input line, boxes, and the screen. It knows nothing about agents. [`@riesbri/dsh-tui`](packages/tui) is the plugin: the session loop, turning session events into transcript lines, and its internal view registry.
-
-- **It never switches to a separate screen.** Finished output goes into your terminal's own scroll history and is never redrawn. Only a small area at the bottom is updated in place. Scrolling, selecting text, and copying work exactly as they do for any other command.
-- **A reply is printed line by line as it arrives**, so drawing cost does not grow with the length of the answer, and a long reply scrolls normally instead of being cut down to fit.
-- **Markdown is styled as it streams.** An unfinished line that fits the bounded live region is drawn through the same inline formatter as the committed transcript, so `**bold**` appears bold the moment its markers arrive instead of flipping when the line completes.
-- **Tool output is drawn the way each tool asks to be drawn.** A shell command becomes a framed box with its exit code. A file edit becomes a red-and-green diff. A search groups its matches under each file. Tools that say nothing about presentation still display correctly.
-- **Model reasoning is shown while it happens**, dimmed, so a model that thinks for a long time looks busy rather than stuck.
-- **Text from a model, a tool, or a paste is made safe before it is drawn.** A terminal treats some characters as commands, so untrusted text is converted to a visible form first, and colors are added only afterwards.
-- **Character widths follow the Unicode standard for East Asian text**, because one mismeasured character shifts every following row.
-- **Keyboard input is decoded in both formats terminals use**, so a shortcut cannot work in one terminal and be dead in another.
-- **The banner, input line, status line, and every box are separate internal views** registered into experimental pre-1.0 `ctx.tuiSlots` vocabulary. It is not yet a supported public extension API.
-
-Each of those had an obvious alternative that turned out to be wrong. The reasons are written down in [`docs/design.md`](docs/design.md).
-
-## Why choose this one
-
-| | Runs as | Drawing code | Install |
-| --- | --- | --- | --- |
-| `@dsh-tui/dsh-tui` | plugin inside the agent | `@earendil-works/pi-tui` | one command, from npm |
-| `@xmoon76/dsh-pi-tui` | plugin inside the agent | its own copy of `pi-tui` | one command, from npm |
-| `dsh-tui` (no scope) | connects to a running server | Ink + React | one command, needs `dsh web` running |
-| **`@riesbri/dsh-tui`** (this one) | plugin inside the agent | its own, no dependencies | one command, from npm |
-
-**`@dsh-tui/dsh-tui` has the most features of the four.** If you want the richest terminal experience today, install that one. Choose this one for three specific reasons instead:
-
-1. **It adds no third-party packages** to your setup, so installing it cannot pull in anything unexpected.
-2. **It never takes over the screen**, so your scroll history, text selection, and copying keep working.
-3. **It can answer the agent's questions.** That connection point accepts only one provider at a time, and the web interface claims it — so only an interface running inside the agent can offer it.
-
-The full comparison, including the disadvantages: [`docs/comparison.md`](docs/comparison.md).
-
-## Documentation
-
-| | |
-| --- | --- |
-| [Install](docs/install.md) | Requirements, profiles, checking it worked, uninstalling |
-| [Usage](docs/usage.md) | Keys, commands, sessions, permissions and the sandbox |
-| [Design](docs/design.md) | How it is built, and the reason behind each decision |
-| [Architecture](docs/architecture.md) | Harness capability seams, adapters, and terminal presentation |
-| [Comparison](docs/comparison.md) | The four interfaces, and where this one stands |
-| [Roadmap](ROADMAP.md) | Architectural direction, planned capability areas, and non-goals |
-| [Contributing](CONTRIBUTING.md) | How to report a bug or send a change |
-| [`AGENTS.md`](AGENTS.md) | Working on this repository: commands, rules, conventions |
-| [`SECURITY.md`](SECURITY.md) | Reporting a vulnerability, and how releases are protected |
-
-## Security
-
-Handling untrusted text is the most important part of this project. Everything on screen came from a model, a tool, a file, or a paste — and a terminal treats certain byte sequences as commands rather than as text. Without care, a reply could move your cursor, repaint lines you already read, or on some terminals insert text into your input. So everything that reaches the screen is converted to a visible, harmless form first, and colors are applied only to text that is already safe.
-
-The repository also protects itself: dependency and license checks on every pull request, a scan of the full history for leaked secrets, static analysis with CodeQL, a check on the workflow files themselves, and an OpenSSF Scorecard rating. Two install-time rules matter most for a package like this one. Nothing published in the last 24 hours is installed, and an install fails if a package's publishing evidence becomes *weaker* than in its previous version — a common sign of a stolen maintainer account.
-
-Releases are built and published by GitHub Actions from a tag, never from a laptop, so every published file carries a signature linking it to the exact commit it was built from. You can run the same checks locally with `pnpm run security`. To report a vulnerability privately, see [`SECURITY.md`](SECURITY.md).
+Harness commands such as `/plan`, `/goal`, `/permission`, `/compact`, and `/feedback` appear according to the active Harness profile. See [Usage](docs/usage.md) for keys, sessions, command details, and permission guidance.
 
 ## Contributing
 
+Contributions are welcome, especially Harness capability adapters; Goal presentation; richer Sessions UX; attachments; macOS and Windows terminal testing; resize and terminal-geometry robustness; Unicode/CJK correctness; and small UX improvements that preserve native scrollback.
+
 ```sh
 pnpm install
-pnpm build && pnpm test      # the full suite; no terminal and no model needed
+pnpm build
+pnpm test
 ```
 
-Nothing outside this repository is required. Bug reports are especially useful right now — this is alpha software and the author cannot test every terminal. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md), and read [`AGENTS.md`](AGENTS.md) before changing code.
+Start with [CONTRIBUTING.md](CONTRIBUTING.md), then read [AGENTS.md](AGENTS.md) and the [Roadmap](ROADMAP.md).
+
+## Project status
+
+Other DeepSeek Harness terminal interfaces exist, and some expose more features today. dsh-tui is deliberately optimizing for Harness-native capability integration, real terminal scrollback, and a small auditable presentation core. See [Comparison](docs/comparison.md) for the trade-offs.
+
+## Documentation
+
+- [Install](docs/install.md)
+- [Usage](docs/usage.md)
+- [Architecture](docs/architecture.md)
+- [Design](docs/design.md)
+- [Roadmap](ROADMAP.md)
+- [Comparison](docs/comparison.md)
+- [Contributing](CONTRIBUTING.md)
+- [Security](SECURITY.md)
 
 ## License
 
-[MIT](LICENSE). Not affiliated with, or endorsed by, DeepSeek.
+[MIT](LICENSE). Not affiliated with or endorsed by DeepSeek.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ DeepSeek Harness is built around plugins and capability seams; dsh-tui follows t
 
 `Harness plugin → standard capability → dsh-tui adapter → native terminal UI`
 
-A supported generic seam such as `ctx.subagents` or `ctx.jobs` can be presented without a dedicated provider runtime. The intended provider-neutral model is for providers such as Codex, Claude Code, and spawn/fork to participate through those Harness surfaces rather than through dsh-tui-specific runtimes. The goal is capability integration, not plugin-by-plugin ports.
+A supported generic seam such as `ctx.subagents` or `ctx.jobs` can be presented without a dedicated provider runtime. The provider-neutral model is for subagent providers such as Codex or Claude Code, and Harness spawn/fork flows, to surface through the same generic `ctx.subagents` / `ctx.jobs` contracts rather than through dsh-tui-specific runtimes. The goal is capability integration, not plugin-by-plugin ports.
 
 ### Your terminal stays your terminal
 


### PR DESCRIPTION
## Summary
- position dsh-tui as the terminal-native frontend for the DeepSeek Harness plugin ecosystem
- lead with the new hero and capability-flow SVGs, an install-first path, and the supported Harness capability story
- replace the long walkthrough, keyboard reference, and comparison prose with links to the existing docs

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm test` (670 passed)
- `git diff --check`