### PR TITLE
chore: queue 0.5.0 release

### DIFF
--- a/.changeset/bright-birds-explain.md
+++ b/.changeset/bright-birds-explain.md
@@ -1,0 +1,6 @@
+---
+"@riesbri/dsh-tui": minor
+"@riesbri/dsh-tui-renderer": minor
+---
+
+Refresh dsh-tui's plugin-native project positioning and terminal architecture visuals.


### PR DESCRIPTION
Queues the requested 0.5.0 minor release through the repository’s normal Changesets and Version Packages workflow.

Merging this PR opens the generated version PR; merging that PR creates `v0.5.0` and starts the tag-only publisher.