### PR TITLE
fix(tui): keep interleaved reasoning from splitting an unfinished answer

### DIFF
--- a/.changeset/calm-streams-stay-ordered.md
+++ b/.changeset/calm-streams-stay-ordered.md
@@ -1,0 +1,5 @@
+---
+"@riesbri/dsh-tui": patch
+---
+
+Keep streamed reasoning from splitting an unfinished final-answer line.

--- a/packages/tui/src/stream.ts
+++ b/packages/tui/src/stream.ts
@@ -146,9 +146,11 @@ export class StreamBuffer {
    */
   push(channel: StreamChannel, delta: string, columns: number): string[] {
     const out: string[] = []
-    // A delta on a new channel means the previous one is finished: the model
-    // stopped reasoning the moment it began answering.
-    if (this.current !== undefined && this.current !== channel) out.push(...this.flush(this.current, columns))
+    // Answering closes reasoning, but a reasoning delta arriving between answer
+    // deltas must not close the answer. Flushing in both directions commits an
+    // unfinished answer prefix before the reasoning, so the resumed suffix lands
+    // below it and the two channels visibly interlace.
+    if (channel === 'text' && this.current === 'reasoning') out.push(...this.flush('reasoning', columns))
     this.current = channel
     const state = this.channels[channel]
     state.pushed += delta

--- a/packages/tui/tests/streaming-frames.spec.ts
+++ b/packages/tui/tests/streaming-frames.spec.ts
@@ -149,4 +149,30 @@ describe('a streaming reply on a real terminal', () => {
     expect(await visible(emulator))
       .toEqual(['✻ let me check the file', '● It is empty.', '>', 'idle'])
   })
+
+  it('does not split an unfinished answer around an interleaved reasoning delta', async () => {
+    const emulator = createEmulator(40, 24)
+    const screen = new Screen(emulator.target)
+    const buffer = new StreamBuffer()
+    const commit = (lines: readonly string[]): void => { if (lines.length > 0) screen.commit(lines) }
+
+    commit(buffer.push('text', 'Backgro', COLUMNS))
+    screen.setLive([...buffer.live(COLUMNS), ...CHROME])
+    commit(buffer.push('reasoning', 'out implementing or collecting.', COLUMNS))
+    screen.setLive([...buffer.live(COLUMNS), ...CHROME])
+    commit(buffer.push('text', 'und job subagent-1 has completed...', COLUMNS))
+    commit(buffer.settle([
+      { type: 'reasoning', text: 'out implementing or collecting.' },
+      { type: 'text', text: 'Background job subagent-1 has completed...' },
+    ], COLUMNS))
+    screen.setLive(CHROME)
+
+    expect(await visible(emulator)).toEqual([
+      '✻ out implementing or collecting.',
+      '● Background job subagent-1 has',
+      '  completed...',
+      '>',
+      'idle',
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

Fixes a transcript rendering bug where streamed **reasoning** and **final-answer** text could visibly interlace.

- **Example 1:** a reasoning sentence (`The user wants me to reply only with the`) incorrectly continued *after* the final-answer row.
- **Example 2:** the final answer itself appeared split around reasoning output (`● Backgro … ✻ … und job subagent-1 has completed...`).

## Root cause

`StreamBuffer.push()` flushed the previous channel on **every** channel switch. For the event sequence:

`text("Backgro") → reasoning(...) → text("und…")`

it permanently committed the unfinished answer prefix `Backgro` to native scrollback, then the reasoning, then the suffix. `Screen` correctly preserved that erroneous order in real scrollback, producing the interlacing.

## Fix

`push()` now closes a channel only in the direction that is actually meaningful: **answering closes reasoning** (`reasoning` → `text`), but a reasoning delta arriving between answer deltas no longer flushes an unfinished answer prefix. No full-response buffering and no provider-specific behavior were added; the finished-output-to-scrollback / bounded-live-redraw invariant is unchanged.

## Verification

- Added an emulator regression test in `packages/tui/tests/streaming-frames.spec.ts` reproducing the exact split; it fails against the previous transition logic.
- `packages/tui/tests/stream.spec.ts` (40) and `packages/tui/tests/streaming-frames.spec.ts` (9) pass.
- `pnpm typecheck` and `git diff --check` pass.
- Added a `patch` changeset (`@riesbri/dsh-tui`).

No unrelated refactors. No commit beyond this fix.