### PR TITLE
docs: record real Harness provider acceptance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,13 +6,15 @@ capabilities instead of reimplementing them.** Its architectural rule is:
 
 > **Harness owns capabilities; dsh-tui owns terminal presentation.**
 
-The proof we want is simple: install a new Harness provider or plugin; it
-publishes an existing standard capability surface; dsh-tui already knows how
-to present that surface. A Codex provider flowing through `ctx.subagents` and
-`ctx.jobs` into generic Work, without Codex-specific dsh-tui integration, is
-the model example. Native terminal scrollback is the other differentiator.
-This does not claim that other TUIs cannot be extensible; it describes the
-architecture this frontend is choosing.
+The proof is simple: install a new Harness provider or plugin; it publishes an
+existing standard capability surface; dsh-tui already knows how to present that
+surface. A real Codex provider has now passed that acceptance through
+`ctx.subagents` and `ctx.jobs` into generic Work, without Codex-specific
+dsh-tui integration. [Provider acceptance](docs/provider-acceptance.md)
+records the evidence, configuration boundary, and the next target. Native
+terminal scrollback is the other differentiator. This does not claim that other
+TUIs cannot be extensible; it describes the architecture this frontend is
+choosing.
 
 ## Product principles
 
@@ -49,16 +51,19 @@ and delegated activity from `ctx.subagents` through bounded Work UI.
 
 - observe jobs without consuming their output cursor
 - observe subagents and preserve Harness's provider-neutral lifecycle facts
-- accept real providers through the same seams: spawn/fork, Codex, and Claude
-  Code
-- treat provider support as an upstream-contract acceptance test, not a
+- treat real-provider support as an upstream-contract acceptance test, not a
   provider-specific dsh-tui integration
+- record the completed Codex acceptance separately from the unvalidated Claude
+  Code target; neither requires provider-specific dsh-tui production code
 
 Jobs and subagents remain separate until Harness publishes an authoritative
-correlation. Work also establishes the broader control rule: it does not expose
-`ctx.jobs.kill()` because that method has model-facing reported-delivery
-semantics; a continuable subagent can expose a user-authorized interrupt only
-where `ctx.subagents` explicitly models it.
+correlation. The Codex acceptance is complete; Claude Code through
+`@deepseek-ai/dsh-subagent-claude-code`, `ctx.subagents`, and `ctx.jobs` is the
+next acceptance target, not a manually validated integration. See [Provider
+acceptance](docs/provider-acceptance.md). Work also establishes the broader
+control rule: it does not expose `ctx.jobs.kill()` because that method has
+model-facing reported-delivery semantics; a continuable subagent can expose a
+user-authorized interrupt only where `ctx.subagents` explicitly models it.
 
 ### 2. Session projections and agent state
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,11 +67,12 @@ Prefer a standard Harness surface over a concrete package or provider:
 
 A new subagent provider should appear through `ctx.subagents`; a background
 producer through `ctx.jobs`; an LLM adapter through `ctx.llm`; and a command
-or tool through its standard registry. Codex is the intended proof: a Codex
-provider that publishes `ctx.subagents` / `ctx.jobs` is shown by generic Work,
-not by Codex-specific dsh-tui code. If a required fact is absent from the
-surface, improve the upstream contract rather than parse text or connect to a
-provider privately.
+or tool through its standard registry. The real Codex acceptance has proven
+that a provider publishing `ctx.subagents` / `ctx.jobs` is shown by generic
+Work, not by Codex-specific dsh-tui code. [Provider acceptance](provider-acceptance.md)
+records that evidence and its configuration boundary. If a required fact is
+absent from the surface, improve the upstream contract rather than parse text
+or connect to a provider privately.
 
 ### 2. Known projection domains
 
@@ -154,8 +155,11 @@ lifecycle edges and enriches only from `listChildren()` facts that Harness
 publishes. It neither merges jobs and subagents without an authoritative
 correlation id nor invents labels or active runs that a provider did not expose.
 
-Providers including spawn/fork, Codex, and Claude Code are acceptance targets
-for the generic contracts, not direct dsh-tui integrations.
+The manually validated Codex provider is an acceptance proof for these generic
+contracts, not a direct dsh-tui integration. Claude Code through
+`@deepseek-ai/dsh-subagent-claude-code`, `ctx.subagents`, and `ctx.jobs` is the
+logical next target, but has not been manually validated. The required path for
+both and future providers is documented in [Provider acceptance](provider-acceptance.md).
 
 ## Observation is not control
 
@@ -170,7 +174,10 @@ model-facing control semantic. Work therefore observes jobs but does not offer
 human cancellation. `ctx.subagents.interrupt(..., { kind: 'user',
 parentSessionId })` is the contrasting case: the seam explicitly models human
 authority to stop a live continuable child. This rule applies to every future
-capability, not only Work.
+capability, not only Work. Likewise, Work presents lifecycle and job state,
+not provider reasoning, commands, tool activity, progress, or diffs unless
+Harness exposes those facts through a generic contract; it must never scrape
+provider output.
 
 ## Upstream compatibility
 

--- a/docs/provider-acceptance.md
+++ b/docs/provider-acceptance.md
@@ -1,0 +1,59 @@
+# Provider acceptance
+
+A provider is accepted by dsh-tui when Harness can expose its ordinary capability
+contracts and the existing terminal presentation shows them unchanged.
+
+> **Harness owns capabilities; dsh-tui owns terminal presentation.**
+
+This is not a provider-integration guide. dsh-tui neither starts a provider
+runtime nor maintains provider configuration, state, permissions, or output
+parsers.
+
+## Codex acceptance: manually proven
+
+A real `@deepseek-ai/dsh-subagent-codex` provider ran through Harness. The
+existing generic `/work` UI observed the active provider through
+`ctx.subagents` and its background task through `ctx.jobs`; both disappeared
+from Work after completion. The delegated run then performed real repository
+work that became [PR #54](https://github.com/riesbri/dsh-tui/pull/54), so this
+was more than a synthetic lifecycle test.
+
+[PR #53](https://github.com/riesbri/dsh-tui/pull/53) also adds the opt-in
+`pnpm test:codex` acceptance fixture. It composes the real provider with
+Harness and verifies the provider-neutral subagent lifecycle in the existing
+Work projection and overlay. Neither acceptance added Codex-specific dsh-tui
+production code, configuration, or a `/work` branch.
+
+### Configuration boundary
+
+Installing a provider makes it available to Harness. Making it available to an
+Agent is a separate permission and tool-binding decision made through generic
+Harness mechanisms. The temporary YAML used for the manual acceptance was test
+profile configuration, not a desired dsh-tui provider-integration workflow.
+
+dsh-tui must not maintain Codex-, Claude-, or provider-specific configuration,
+and this document does not prescribe how a Harness deployment grants an Agent
+provider access.
+
+## Next acceptance target: Claude Code
+
+`@deepseek-ai/dsh-subagent-claude-code` is the logical next target: installed
+and configured in Harness, it should publish through `ctx.subagents` and
+`ctx.jobs` for the same generic `/work` presentation. Claude Code has **not**
+been manually validated in dsh-tui yet.
+
+The acceptance criterion for Claude Code and every future provider is:
+
+```
+provider installed/configured in Harness
+        → standard Harness capability contracts
+        → generic /work
+        → zero provider-specific dsh-tui production code
+```
+
+## Observation limit
+
+`/work` presents lifecycle and job state that Harness publishes. It does not
+see provider reasoning, commands, tool activity, progress, or diffs. Those
+facts can become terminal presentation input only if Harness exposes them
+through a generic capability contract; dsh-tui must not scrape provider output.


### PR DESCRIPTION
Document the manually proven provider-neutral Codex acceptance through ctx.subagents, ctx.jobs, and generic Work. Clarify that provider installation and Agent tool binding remain generic Harness concerns, rather than a dsh-tui provider configuration workflow.\n\nName Claude Code as the next unvalidated acceptance target and record Work's generic observation boundary. No changeset: documentation-only change.\n\nCo-Authored-By: OpenAI <noreply@openai.com>