### PR TITLE
fix(tui): window the shared picker, and let a long one be searched

### DIFF
--- a/.changeset/tidy-pickers-window.md
+++ b/.changeset/tidy-pickers-window.md
@@ -1,0 +1,25 @@
+---
+"@riesbri/dsh-tui": minor
+"@riesbri/dsh-tui-renderer": minor
+---
+
+Bound the shared picker to the terminal, and let it be searched when it is long.
+
+`/model` over a gateway route offers whatever the provider advertises, which for
+OpenRouter or opencode is hundreds of models. The picker drew a row per choice,
+so it handed `Screen` a live region taller than the screen — and rows that have
+scrolled off cannot be reached or erased, which left duplicates in real
+scrollback and could clear output the picker never owned. The list is now a
+viewport over its rows, exactly as Work, Sessions, and Connect are.
+
+Past twelve choices it also grows a query box and filters as you type, with a
+counter that reports what the query left and what was offered separately. Below
+that nothing changes: a three-choice approval spends no row on a search box and
+typed characters stay meaningless there. A terminal too small to hold the frame
+now falls back to the selected choice and its keys rather than an unanswerable
+list, because an approval can arrive in any geometry.
+
+`/model`'s rows are now spelled `provider/model` — the argument the command
+accepts — with the provider's own display name under the selection when it adds
+something beyond the id. Filtering matches the label, so what you type is what
+you can see.

--- a/.changeset/tidy-pickers-window.md
+++ b/.changeset/tidy-pickers-window.md
@@ -1,6 +1,6 @@
 ---
-"@riesbri/dsh-tui": minor
-"@riesbri/dsh-tui-renderer": minor
+"@riesbri/dsh-tui": patch
+"@riesbri/dsh-tui-renderer": patch
 ---
 
 Bound the shared picker to the terminal, and let it be searched when it is long.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,7 +74,7 @@ Type `/` to see the commands your agent actually has. They come from two places.
 
 | | |
 | --- | --- |
-| `/model` | Change the model. Takes a name (`/model deepseek-v4-pro`) or opens a picker |
+| `/model` | Change the model. Takes a name (`/model deepseek-v4-pro`) or opens a picker you can type in |
 | `/reasoning` | Change how hard the model thinks. Takes a level (`/reasoning max`) or opens a picker |
 | `/connect` | Configure and authenticate the providers Harness can talk to. Takes a route name (`/connect openai`) to open filtered on it |
 | `/usage` | Choose what the status line reports: `cost`, `tokens`, or `off`. Opens a picker with no argument |
@@ -310,6 +310,36 @@ Neither is given up when the terminal narrows. They are dropped only after the m
 The change applies from the next step, so pressing it mid-turn does not split a request across two settings, and it is remembered — see below.
 
 The status line names the level next to the model, but only while it differs from the one your setup already defaults to — otherwise it would spend columns every frame on a fact you did not choose.
+
+### Choosing from a long list
+
+A gateway route advertises whatever the gateway serves. OpenRouter and opencode
+offer hundreds of models, so `/model` opens a list that no terminal could show
+at once — and one you should not have to scroll through.
+
+The picker windows itself to the terminal and grows a query box once there is
+more than a screenful to choose from:
+
+```
+┌ Select a model ──────────────────────────────────────────────────────────┐
+│ ⌕ sonnet                                                    6 of 412     │
+│ current: deepseek-official/deepseek-v4-flash                             │
+│                                                                          │
+│ ❯ openrouter/anthropic/claude-sonnet-4                                   │
+│   openrouter/anthropic/claude-sonnet-4-thinking                          │
+│   opencode/claude-sonnet-4                                               │
+└──────────────────────────────────────────────────────────────────────────┘
+  ↑↓ move · type to filter · enter confirm · esc clear
+```
+
+Every row is spelled the way `/model` takes it — `provider/model` — so what you
+filter on is what you could have typed after the command, and the provider's own
+display name sits under the selection where it disambiguates two similar models
+without being the text you have to match. `esc` clears the query, `esc` again
+closes the picker, and `home`/`end` jump to either end.
+
+A short list is unchanged: an approval or `/reasoning` has nothing to filter, so
+it spends no row on a search box and typed characters stay meaningless there.
 
 ### What you pick here is what the web interface opens with
 

--- a/packages/tui/src/model.ts
+++ b/packages/tui/src/model.ts
@@ -57,7 +57,21 @@ async function discover(ctx: Context): Promise<Discovery> {
     for (const model of models) {
       // The index is the choice value, so no id has to survive a round trip
       // through a delimiter that a provider or model name might contain.
-      choices.push({ value: String(options.length), label: `${provider.name} / ${model.name}` })
+      //
+      // The LABEL is the qualified route and model id — exactly the argument
+      // `/model` accepts — rather than the two display names it used to join.
+      // A gateway route advertises hundreds of models, so the list is filtered
+      // by typing, and a picker whose rows show a name while the command takes
+      // an id makes the reader translate between them. The display name goes
+      // under the selection, where it disambiguates without being the thing
+      // that has to be matched.
+      const label = `${provider.id}/${model.id}`
+      const named = model.name !== '' && model.name.toLowerCase() !== model.id.toLowerCase()
+      choices.push({
+        value: String(options.length),
+        label,
+        ...named ? { description: model.name } : {},
+      })
       options.push({ provider: provider.id, model: model.id })
     }
   }
@@ -134,7 +148,7 @@ export async function pickModel(
   }
   const picked = await promptSelect(ctx, {
     title: 'Select a model',
-    ...current === undefined ? {} : { detail: `current: ${current.provider} / ${current.model}` },
+    ...current === undefined ? {} : { detail: `current: ${current.provider}/${current.model}` },
     choices,
   })
   if (picked === undefined) return undefined

--- a/packages/tui/src/select.ts
+++ b/packages/tui/src/select.ts
@@ -116,6 +116,15 @@ export function filterChoices(
 interface Rendered {
   readonly rows: readonly string[]
   readonly selectedRow: number
+  /**
+   * Rows the selection occupies, which is two when it carries a description.
+   *
+   * The viewport has to follow the whole block rather than its first row: a
+   * description drawn only under the SELECTED choice is the one row that
+   * appears and disappears as the cursor moves, so tracking the label alone
+   * scrolls the explanation off exactly when it is being read.
+   */
+  readonly selectedHeight: number
 }
 
 /**
@@ -165,7 +174,15 @@ export function createSelectOverlay(spec: SelectSpec): TuiOverlay {
       const rendered = renderChoices(visible, cursor, inner)
       viewport.update(rendered.rows.length, capacity)
       if (rendered.selectedRow < viewport.start) viewport.move(rendered.selectedRow - viewport.start)
-      if (rendered.selectedRow >= viewport.end) viewport.move(rendered.selectedRow - viewport.end + 1)
+      // The selection's own rows are followed as a block, so a description does
+      // not fall out of the window the moment its label reaches the last visible
+      // row. When the window is too short to hold both, the LABEL wins: it is
+      // what identifies the choice about to be confirmed, and scrolling it away
+      // to show its explanation would leave the reader confirming a row they can
+      // no longer see.
+      const selectedEnd = rendered.selectedRow + rendered.selectedHeight
+      const overshoot = selectedEnd - viewport.end
+      if (overshoot > 0) viewport.move(Math.min(overshoot, rendered.selectedRow - viewport.start))
       const frame = [
         '',
         ...box([...heading, ...rendered.rows.slice(viewport.start, viewport.end)], {
@@ -326,10 +343,15 @@ function renderChoices(
     // An empty OFFER is a programming error and an empty result is an ordinary
     // one, but a picker cannot tell them apart at this point and does not need
     // to: either way there is nothing to confirm, and saying so is the answer.
-    return { rows: [style(truncateToWidth('Nothing to choose from.', inner), 'gray')], selectedRow: 0 }
+    return {
+      rows: [style(truncateToWidth('Nothing to choose from.', inner), 'gray')],
+      selectedRow: 0,
+      selectedHeight: 1,
+    }
   }
   const rows: string[] = []
   let selectedRow = 0
+  let selectedHeight = 1
   choices.forEach((choice, index) => {
     const selected = index === cursor
     if (selected) selectedRow = rows.length
@@ -337,9 +359,10 @@ function renderChoices(
     rows.push(selected ? style(`\u276f ${label}`, 'cyan', 'bold') : `  ${label}`)
     if (selected && choice.description !== undefined && choice.description !== '') {
       rows.push(style(`  ${truncateToWidth(escapeControls(choice.description), inner - 2)}`, 'gray'))
+      selectedHeight = 2
     }
   })
-  return { rows, selectedRow }
+  return { rows, selectedRow, selectedHeight }
 }
 
 /**

--- a/packages/tui/src/select.ts
+++ b/packages/tui/src/select.ts
@@ -1,19 +1,60 @@
 /**
- * A single-choice list overlay.
+ * A single-choice list overlay, bounded to the terminal and searchable when long.
  *
  * Approvals, `ask_user_question`, and the model picker are the same interaction
  * — read a prompt, move through choices, confirm one — so they share one
  * implementation and differ only in what they do with the result. Anything that
  * needs a different presentation registers its own overlay instead; the slot
  * registry does not privilege this one.
+ *
+ * Sharing that implementation is also why the list has to bound itself HERE.
+ * Every caller used to decide how many choices it offered, and one of them —
+ * `/model` over a gateway route — offers whatever the provider advertises,
+ * which for OpenRouter or opencode is hundreds. A picker that draws a row per
+ * choice then hands `Screen` a live region taller than the screen, and the rows
+ * that scrolled off can no longer be reached or erased: the next redraw leaves
+ * duplicates in real scrollback and can clear output the picker never owned.
+ * The list is therefore a viewport over its rows, exactly as Work, Sessions,
+ * and Connect are.
+ *
+ * A long list also has to be reachable, not merely drawable, so past
+ * {@link SEARCHABLE_CHOICES} the picker grows a query box and filters as you
+ * type. Below it nothing changes: a three-choice approval spends no row on a
+ * search box, and typed characters stay meaningless there.
  * @module @riesbri/dsh-tui/select
  */
 
 import type { Context } from '@deepseek-ai/cordis'
 import type { Key } from '@riesbri/dsh-tui-renderer'
-import { BOX_CHROME_COLUMNS, box, escapeControls, style, truncateToWidth } from '@riesbri/dsh-tui-renderer'
+import {
+  BOX_CHROME_COLUMNS,
+  box,
+  displayWidth,
+  escapeControls,
+  style,
+  tailToWidth,
+  truncateToWidth,
+  wrapToWidth,
+} from '@riesbri/dsh-tui-renderer'
+import { RowViewport } from './scroll.ts'
 import type { TuiOverlay } from './slots.ts'
 import { chromeWidth } from './views.ts'
+
+/**
+ * Choices past which the picker offers a query box.
+ *
+ * Twelve is about what the list can show on the shortest terminal anyone drives
+ * without scrolling, so below it a search box would cost a row to reach rows
+ * that are already on screen. Above it the list scrolls, and typing is how a
+ * reader gets to the end of it without holding a key down.
+ */
+export const SEARCHABLE_CHOICES = 12
+
+/** Rows outside the scrolling list: the leading blank, two borders, the help line. */
+const SELECT_FIXED_ROWS = 4
+
+/** Narrowest terminal that can hold the framed list rather than the bare answer. */
+const SELECT_MIN_COLUMNS = BOX_CHROME_COLUMNS + 16
 
 /** One selectable row. */
 export interface SelectChoice {
@@ -43,12 +84,54 @@ export interface SelectSpec {
 }
 
 /**
+ * Normalize text for matching: case-folded, with runs of space collapsed.
+ * @param value - raw text.
+ * @returns the comparable form.
+ */
+function normalize(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/gu, ' ')
+}
+
+/**
+ * Apply a query to the choices, preserving the caller's order.
+ *
+ * Matched against the LABEL alone, which is the only part of a choice every row
+ * shows. Matching a description that is drawn under the selection only would
+ * leave a reader unable to see why a row survived — and unable to trust the ones
+ * that did not.
+ * @param choices - the offered choices.
+ * @param query - raw query text.
+ * @returns the matching choices, in their original order.
+ */
+export function filterChoices(
+  choices: readonly SelectChoice[],
+  query: string,
+): readonly SelectChoice[] {
+  const needle = normalize(query)
+  if (needle === '') return choices
+  return choices.filter(choice => normalize(choice.label).includes(needle))
+}
+
+/** Rendered rows for a list, and which row holds the selection. */
+interface Rendered {
+  readonly rows: readonly string[]
+  readonly selectedRow: number
+}
+
+/**
  * Build a select overlay.
  * @param spec - the prompt, choices, and settlement callback.
  * @returns the overlay to push onto the slot registry.
  */
 export function createSelectOverlay(spec: SelectSpec): TuiOverlay {
+  const viewport = new RowViewport()
+  // Searchability is decided from the OFFER, not from what a query has left of
+  // it: a box that vanished once the list got short enough would take the query
+  // with it and put the rows it had hidden back.
+  const searchable = spec.choices.length > SEARCHABLE_CHOICES
+  let query = ''
   let cursor = 0
+  let visible: readonly SelectChoice[] = spec.choices
   let settled = false
   const settle = (value: string | undefined): void => {
     // The overlay is dismissed by whoever pushed it, and a stray keystroke can
@@ -57,52 +140,110 @@ export function createSelectOverlay(spec: SelectSpec): TuiOverlay {
     settled = true
     spec.settle(value)
   }
+  const move = (amount: number): void => {
+    if (visible.length === 0) return
+    cursor = (cursor + amount + visible.length) % visible.length
+    spec.invalidate()
+  }
+  const edit = (next: string): void => {
+    query = next
+    cursor = 0
+    viewport.first()
+    spec.invalidate()
+  }
   return {
-    render(columns) {
+    render(columns, terminalRows = 24) {
       const width = chromeWidth(columns)
       const inner = width - BOX_CHROME_COLUMNS
-      const content: string[] = []
-      if (spec.detail !== undefined && spec.detail !== '') {
-        for (const line of escapeControls(spec.detail).split('\n')) {
-          content.push(style(truncateToWidth(line, inner), 'dim'))
-        }
-        content.push('')
+      visible = searchable ? filterChoices(spec.choices, query) : spec.choices
+      cursor = Math.min(cursor, Math.max(0, visible.length - 1))
+      const heading = headingRows(spec, searchable, query, visible.length, inner)
+      const capacity = terminalRows - SELECT_FIXED_ROWS - heading.length
+      if (capacity <= 0 || columns < SELECT_MIN_COLUMNS) {
+        return compactFallback(visible[cursor], columns, terminalRows)
       }
-      spec.choices.forEach((choice, index) => {
-        const selected = index === cursor
-        const label = truncateToWidth(escapeControls(choice.label), inner - 2)
-        content.push(selected ? style(`\u276f ${label}`, 'cyan', 'bold') : `  ${label}`)
-        if (selected && choice.description !== undefined && choice.description !== '') {
-          content.push(style(`  ${truncateToWidth(escapeControls(choice.description), inner - 2)}`, 'gray'))
-        }
-      })
-      return [
+      const rendered = renderChoices(visible, cursor, inner)
+      viewport.update(rendered.rows.length, capacity)
+      if (rendered.selectedRow < viewport.start) viewport.move(rendered.selectedRow - viewport.start)
+      if (rendered.selectedRow >= viewport.end) viewport.move(rendered.selectedRow - viewport.end + 1)
+      const frame = [
         '',
-        ...box(content, {
+        ...box([...heading, ...rendered.rows.slice(viewport.start, viewport.end)], {
           width,
           title: style(truncateToWidth(escapeControls(spec.title), Math.max(4, inner - 2)), 'bold', 'yellow'),
           border: text => style(text, 'yellow'),
         }),
-        `  ${style('\u2191\u2193 move \u00b7 enter confirm \u00b7 esc cancel', 'gray')}`,
+        `  ${style(help(searchable, query, visible.length > 0, Math.max(1, columns - 2)), 'gray')}`,
       ]
+      // A backstop, not the primary bound: every content row above is already
+      // truncated to `inner`, so nothing here should wrap. `box()` WOULD wrap a
+      // row that forgot to be, and a frame one row too tall pushes a line into
+      // committed scrollback — which is the corruption this whole viewport
+      // exists to prevent, so it is checked rather than assumed.
+      return physicalRows(frame, columns).length <= terminalRows
+        ? frame
+        : compactFallback(visible[cursor], columns, terminalRows)
     },
     handleKey(key: Key) {
-      // A picker takes no text: typed characters and pasted content are both
-      // meaningless here, and inserting them nowhere would look like a hang.
-      if (key.kind !== 'key') return
+      if (key.kind === 'text') {
+        // Typed characters are meaningless in a short picker — inserting them
+        // nowhere would look like a hang — and are the whole point of a long one.
+        if (searchable) edit(query + key.text)
+        return
+      }
+      if (key.kind === 'paste') {
+        // A query is one line, and pasted newlines would collapse in the matcher
+        // anyway, so they collapse here where the reader can see it happen.
+        if (searchable) edit(query + key.text.replace(/\s+/gu, ' '))
+        return
+      }
       switch (key.name) {
         case 'up':
-          cursor = cursor === 0 ? spec.choices.length - 1 : cursor - 1
-          spec.invalidate()
+          move(-1)
           return
         case 'down':
-          cursor = cursor === spec.choices.length - 1 ? 0 : cursor + 1
+          move(1)
+          return
+        case 'home':
+        case 'ctrl-a':
+          cursor = 0
+          viewport.first()
           spec.invalidate()
           return
+        case 'end':
+        case 'ctrl-e':
+          cursor = Math.max(0, visible.length - 1)
+          viewport.last()
+          spec.invalidate()
+          return
+        case 'backspace':
+          // Code points, not UTF-16 units: one press deletes one character, an
+          // emoji or an ideograph outside the basic plane included.
+          if (searchable) edit([...query].slice(0, -1).join(''))
+          return
+        case 'ctrl-u':
+          if (searchable) edit('')
+          return
+        case 'ctrl-w':
+          if (searchable) edit(query.replace(/\s*\S*$/u, ''))
+          return
         case 'enter':
-          settle(spec.choices[cursor]?.value)
+          // Nothing is confirmed while a query has left nothing to confirm.
+          // Settling with undefined here would read as a cancellation the reader
+          // never asked for.
+          if (visible.length > 0) settle(visible[cursor]?.value)
           return
         case 'escape':
+          // Two stages while there is a query, as in the Sessions and Connect
+          // browsers: a typed query is what a reader most often wants to take
+          // back, and spending that keystroke on the whole question costs them
+          // the list as well.
+          if (searchable && query !== '') {
+            edit('')
+            return
+          }
+          settle(undefined)
+          return
         case 'ctrl-c':
           settle(undefined)
           return
@@ -111,6 +252,160 @@ export function createSelectOverlay(spec: SelectSpec): TuiOverlay {
       }
     },
   }
+}
+
+/**
+ * The rows above the list: the query box when there is one, then the detail.
+ * @param spec - the prompt being rendered.
+ * @param searchable - whether the picker offers a query box.
+ * @param query - the typed query.
+ * @param shown - choices the query left.
+ * @param inner - the frame's inner width in columns.
+ * @returns the heading rows, ending in a separator when there are any.
+ */
+function headingRows(
+  spec: SelectSpec,
+  searchable: boolean,
+  query: string,
+  shown: number,
+  inner: number,
+): string[] {
+  const rows: string[] = []
+  if (searchable) rows.push(queryRow(query, counter(shown, spec.choices.length), inner))
+  if (spec.detail !== undefined && spec.detail !== '') {
+    for (const line of escapeControls(spec.detail).split('\n')) {
+      rows.push(style(truncateToWidth(line, inner), 'dim'))
+    }
+  }
+  if (rows.length > 0) rows.push('')
+  return rows
+}
+
+/**
+ * The query line: a prompt, the typed text, a cursor block, and the counter.
+ * @param query - the typed query.
+ * @param right - the counter text.
+ * @param inner - the frame's inner width.
+ * @returns one row.
+ */
+function queryRow(query: string, right: string, inner: number): string {
+  const prompt = '\u2315 '
+  const rightWidth = Math.min(displayWidth(right), Math.max(0, inner - 4))
+  const room = Math.max(1, inner - displayWidth(prompt) - rightWidth - 1)
+  // The TAIL, so a long query scrolls from the left and the characters being
+  // typed stay in view; one column is held back for the cursor block.
+  const typed = `${tailToWidth(escapeControls(query), Math.max(1, room - 1))}\u2588`
+  const gap = Math.max(1, inner - displayWidth(prompt) - displayWidth(typed) - rightWidth)
+  return `${style(prompt, 'yellow')}${typed}${' '.repeat(gap)}${style(truncateToWidth(right, rightWidth), 'gray')}`
+}
+
+/**
+ * What the counter says: how many choices, and how many were offered.
+ * @param shown - choices the query left.
+ * @param offered - choices before the query.
+ * @returns the counter text.
+ */
+function counter(shown: number, offered: number): string {
+  if (shown === offered) return `${String(offered)} choices`
+  return `${String(shown)} of ${String(offered)}`
+}
+
+/**
+ * Draw the choices at a known width.
+ * @param choices - the choices the query left.
+ * @param cursor - the selected index among them.
+ * @param inner - the frame's inner width.
+ * @returns the rows and the selection's row index among them.
+ */
+function renderChoices(
+  choices: readonly SelectChoice[],
+  cursor: number,
+  inner: number,
+): Rendered {
+  if (choices.length === 0) {
+    // An empty OFFER is a programming error and an empty result is an ordinary
+    // one, but a picker cannot tell them apart at this point and does not need
+    // to: either way there is nothing to confirm, and saying so is the answer.
+    return { rows: [style(truncateToWidth('Nothing to choose from.', inner), 'gray')], selectedRow: 0 }
+  }
+  const rows: string[] = []
+  let selectedRow = 0
+  choices.forEach((choice, index) => {
+    const selected = index === cursor
+    if (selected) selectedRow = rows.length
+    const label = truncateToWidth(escapeControls(choice.label), inner - 2)
+    rows.push(selected ? style(`\u276f ${label}`, 'cyan', 'bold') : `  ${label}`)
+    if (selected && choice.description !== undefined && choice.description !== '') {
+      rows.push(style(`  ${truncateToWidth(escapeControls(choice.description), inner - 2)}`, 'gray'))
+    }
+  })
+  return { rows, selectedRow }
+}
+
+/**
+ * The help line, truthful for the current mode and query.
+ *
+ * Whole segments are dropped rather than the line being cut, for the reason the
+ * status line gives up whole segments. The way out is named last and surrendered
+ * last: it is the only thing here a reader cannot guess.
+ * @param searchable - whether the picker offers a query box.
+ * @param query - the typed query.
+ * @param selectable - whether any row can be confirmed.
+ * @param columns - room available for the line.
+ * @returns the help text that fits.
+ */
+function help(searchable: boolean, query: string, selectable: boolean, columns: number): string {
+  const leave = searchable && query !== '' ? 'esc clear' : 'esc cancel'
+  const parts = [
+    ...selectable ? ['\u2191\u2193 move'] : [],
+    ...searchable ? ['type to filter'] : [],
+    ...selectable ? ['enter confirm'] : [],
+    leave,
+  ]
+  for (let from = 0; from < parts.length; from += 1) {
+    const line = parts.slice(from).join(' \u00b7 ')
+    if (displayWidth(line) <= columns) return line
+  }
+  return truncateToWidth(leave, columns)
+}
+
+/**
+ * Count the physical rows Screen will draw for candidate live-region lines.
+ * @param lines - the candidate logical lines.
+ * @param columns - the terminal's width.
+ * @returns the wrapped physical rows.
+ */
+function physicalRows(lines: readonly string[], columns: number): string[] {
+  return lines.flatMap(line => wrapToWidth(line, Math.max(1, columns)))
+}
+
+/**
+ * An answerable picker for a terminal too small to hold the frame.
+ *
+ * The selected choice is kept rather than a count, because this is a QUESTION:
+ * an approval or a tool's own prompt can arrive in any geometry, and a reader
+ * who cannot see what they are about to confirm cannot answer it. The frame is
+ * what is given up, never the decision.
+ * @param choice - the selected choice, when there is one.
+ * @param columns - the terminal's width.
+ * @param rows - the terminal's height.
+ * @returns at most `rows` lines.
+ */
+function compactFallback(
+  choice: SelectChoice | undefined,
+  columns: number,
+  rows: number,
+): string[] {
+  if (rows <= 0) return []
+  const width = Math.max(1, columns)
+  const label = choice === undefined ? 'nothing to choose from' : escapeControls(choice.label)
+  const lines = [style(truncateToWidth(`\u276f ${label}`, width), 'cyan', 'bold')]
+  if (rows > 1) {
+    const hint = ['\u2191\u2193 \u00b7 enter \u00b7 esc', 'enter \u00b7 esc', 'esc']
+      .find(candidate => displayWidth(candidate) <= width)
+    if (hint !== undefined) lines.push(style(hint, 'gray'))
+  }
+  return lines.slice(0, rows)
 }
 
 /**

--- a/packages/tui/tests/model.spec.ts
+++ b/packages/tui/tests/model.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Context } from '@deepseek-ai/cordis'
+import { stripAnsi } from '@riesbri/dsh-tui-renderer'
+import type { TuiOverlay } from '../src/slots.ts'
 import type { ModelSelection, ModelSelectionRef } from '@deepseek-ai/dsh-agent'
 import type { ModelOption } from '../src/model.ts'
 import { listModelOptions, pickModel, resolveModel } from '../src/model.ts'
@@ -22,10 +24,16 @@ const OPTIONS: readonly ModelOption[] = [
 
 /**
  * A context offering the llm registry and a slot registry that records pushes.
- * @returns the context, and whether an overlay was ever pushed.
+ * @returns the context, whether an overlay was pushed, and the one that was.
  */
-function llmContext(): { ctx: Context; pushed: () => boolean; saved: ModelSelection[] } {
+function llmContext(): {
+  ctx: Context
+  pushed: () => boolean
+  overlay: () => TuiOverlay | undefined
+  saved: ModelSelection[]
+} {
   let opened = false
+  let mounted: TuiOverlay | undefined
   const saved: ModelSelection[] = []
   const services: Record<string, unknown> = {
     agentDefaultModel: { saveSelection: async (next: ModelSelection) => { saved.push(next) } },
@@ -37,15 +45,16 @@ function llmContext(): { ctx: Context; pushed: () => boolean; saved: ModelSelect
       listModels: async (provider: string) => CATALOG[provider] ?? [],
     },
     tuiSlots: {
-      pushOverlay: () => {
+      pushOverlay: (overlay: TuiOverlay) => {
         opened = true
-        return (): void => {}
+        mounted = overlay
+        return (): void => { mounted = undefined }
       },
       invalidate: (): void => {},
     },
     get: (name: string) => services[name],
   } as unknown as Context
-  return { ctx, pushed: () => opened, saved }
+  return { ctx, pushed: () => opened, overlay: () => mounted, saved }
 }
 
 /**
@@ -90,6 +99,42 @@ describe('listModelOptions()', () => {
   it('lists every route and model, for completing the argument', async () => {
     const { ctx } = llmContext()
     expect(await listModelOptions(ctx)).toEqual(OPTIONS)
+  })
+})
+
+describe('what the picker offers', () => {
+  it('labels every row with the argument /model accepts', async () => {
+    // A gateway route advertises hundreds of models and the list is reached by
+    // typing, so a row that showed a display name while the command took an id
+    // would make the reader translate between the two.
+    const { ctx, overlay } = llmContext()
+    const running = pickModel(ctx, selectionOn())
+    // Discovery awaits `listModels` per route, so the overlay is not mounted
+    // until those have landed.
+    await vi.waitFor(() => { expect(overlay()).toBeDefined() })
+    const shown = stripAnsi(overlay()?.render(80, 24).join('\n') ?? '')
+    expect(shown).toContain('deepseek-official/deepseek-v4-flash')
+    expect(shown).toContain('opencode/deepseek-v4-pro')
+    expect(shown).toContain('current: deepseek-official/deepseek-v4-flash')
+    overlay()?.handleKey({ kind: 'key', name: 'escape' })
+    expect(await running).toBeUndefined()
+  })
+
+  it('puts a display name under the selection only when it adds something', async () => {
+    // `DeepSeek-V4-Flash` is its own id with different capitals, so repeating it
+    // under the row would spend a line saying nothing. `DeepSeek V4 Pro` is not,
+    // so it earns one.
+    const { ctx, overlay } = llmContext()
+    const running = pickModel(ctx, selectionOn())
+    await vi.waitFor(() => { expect(overlay()).toBeDefined() })
+    const first = stripAnsi(overlay()?.render(80, 24).join('\n') ?? '')
+    expect(first).toContain('deepseek-official/deepseek-v4-flash')
+    expect(first).not.toContain('DeepSeek-V4-Flash')
+    // Walk to the opencode row, whose name differs by more than its capitals.
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    expect(stripAnsi(overlay()?.render(80, 24).join('\n') ?? '')).toContain('DeepSeek V4 Pro')
+    overlay()?.handleKey({ kind: 'key', name: 'escape' })
+    await running
   })
 })
 

--- a/packages/tui/tests/select-frames.spec.ts
+++ b/packages/tui/tests/select-frames.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * A four-hundred-model picker on a real terminal.
+ *
+ * Read as plain text a too-tall frame looks fine, which is exactly why this is
+ * an emulator test: the failure is that `Screen` climbs rows to erase the live
+ * region, and rows that have scrolled off cannot be reached. So the assertions
+ * are about what the terminal HOLDS — the transcript above the picker, still
+ * there, still written once — rather than about the lines the overlay returned.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Screen } from '@riesbri/dsh-tui-renderer'
+import { createEmulator } from '../../../tests/emulator.ts'
+import type { SelectChoice } from '../src/select.ts'
+import { createSelectOverlay } from '../src/select.ts'
+
+/** The width used by the real-terminal regression frames. */
+const COLUMNS = 80
+
+/** More models than any terminal under test can show, as a gateway route offers. */
+const CHOICES: SelectChoice[] = Array.from({ length: 400 }, (_unused, index) => ({
+  value: String(index),
+  label: index === 0
+    ? 'openrouter/FIRST-SENTINEL'
+    : index === 399 ? 'openrouter/LAST-SENTINEL' : `openrouter/model-${String(index)}`,
+}))
+
+/**
+ * Mount the picker over a real terminal emulator.
+ * @param rows - the emulator's height.
+ * @returns the emulator, the overlay, the screen, and a repaint.
+ */
+function terminal(rows: number): {
+  emulator: ReturnType<typeof createEmulator>
+  overlay: ReturnType<typeof createSelectOverlay>
+  screen: Screen
+  draw: () => void
+} {
+  const emulator = createEmulator(COLUMNS, rows)
+  const screen = new Screen(emulator.target)
+  screen.commit(['TRANSCRIPT above picker A', 'TRANSCRIPT above picker B'])
+  let overlay!: ReturnType<typeof createSelectOverlay>
+  const draw = (): void => { screen.setLive(overlay.render(COLUMNS, rows)) }
+  overlay = createSelectOverlay({
+    title: 'Select a model',
+    detail: 'current: deepseek-official/deepseek-v4-flash',
+    choices: CHOICES,
+    settle: () => {},
+    invalidate: draw,
+  })
+  return { emulator, overlay, screen, draw }
+}
+
+describe('the shared picker on a real terminal', () => {
+  it.each([24, 14])('keeps four hundred choices inside a %i-row terminal', async rows => {
+    const { emulator, overlay, draw } = terminal(rows)
+    draw()
+    expect((await emulator.screen()).length).toBeLessThanOrEqual(rows)
+
+    // Walk past the end of a list far longer than the window, twice over.
+    for (let press = 0; press < 450; press += 1) {
+      overlay.handleKey({ kind: 'key', name: 'down' })
+      draw()
+    }
+    expect((await emulator.screen()).length).toBeLessThanOrEqual(rows)
+    // The transcript committed before the picker opened is still exactly where
+    // it was, and written once. An unbounded picker duplicated it here.
+    const history = await emulator.scrollback()
+    expect(history.filter(line => line.includes('TRANSCRIPT above picker A'))).toHaveLength(1)
+    expect(history.filter(line => line.includes('TRANSCRIPT above picker B'))).toHaveLength(1)
+  })
+
+  it('leaves nothing behind when it is answered', async () => {
+    const { emulator, screen, draw } = terminal(24)
+    draw()
+    expect((await emulator.screen()).join('\n')).toContain('Select a model')
+    screen.setLive([])
+    expect((await emulator.screen()).join('\n')).not.toContain('openrouter/model-')
+    const history = await emulator.scrollback()
+    expect(history.filter(line => line.includes('TRANSCRIPT above picker A'))).toHaveLength(1)
+  })
+
+  it('reaches the end of the list by typing rather than by scrolling', async () => {
+    const { emulator, overlay, draw } = terminal(14)
+    draw()
+    for (const character of 'LAST-SENTINEL') {
+      overlay.handleKey({ kind: 'text', text: character })
+      draw()
+    }
+    const screen = (await emulator.screen()).join('\n')
+    expect(screen).toContain('openrouter/LAST-SENTINEL')
+    expect(screen).toContain('1 of 400')
+    expect((await emulator.screen()).length).toBeLessThanOrEqual(14)
+  })
+
+  it('shows an escape sequence in a choice label instead of obeying it', async () => {
+    // A label can carry a provider's own model name, which is untrusted text.
+    const emulator = createEmulator(COLUMNS, 24)
+    const screen = new Screen(emulator.target)
+    screen.commit(['TRANSCRIPT above picker A'])
+    const overlay = createSelectOverlay({
+      title: 'Select a model',
+      choices: [{ value: '0', label: 'openrouter/evil\u001b[2Jmodel' }],
+      settle: () => {},
+      invalidate: () => {},
+    })
+    screen.setLive(overlay.render(COLUMNS, 24))
+    const history = (await emulator.scrollback()).join('\n')
+    expect(history).toContain('^[[2J')
+    expect(history).toContain('TRANSCRIPT above picker A')
+  })
+})

--- a/packages/tui/tests/select.spec.ts
+++ b/packages/tui/tests/select.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * The shared picker: bounded to the terminal, and searchable once it is long.
+ *
+ * The bound is the regression that matters. A gateway route advertises hundreds
+ * of models, and a picker that drew a row per choice handed `Screen` a live
+ * region taller than the screen — after which the rows that scrolled off can no
+ * longer be erased, and the next redraw corrupts committed scrollback.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { Key } from '@riesbri/dsh-tui-renderer'
+import { displayWidth, stripAnsi } from '@riesbri/dsh-tui-renderer'
+import type { SelectChoice } from '../src/select.ts'
+import { createSelectOverlay, filterChoices, SEARCHABLE_CHOICES } from '../src/select.ts'
+
+/** Width and height of a comfortable terminal. */
+const COLUMNS = 80
+const ROWS = 24
+
+/** A short list, the shape an approval or `/reasoning` offers. */
+const SHORT: SelectChoice[] = [
+  { value: 'allowed-once', label: 'Allow once', description: 'Run this call and ask again.' },
+  { value: 'rejected', label: 'Reject' },
+]
+
+/**
+ * A list longer than any terminal can show, the shape `/model` offers over a
+ * gateway route.
+ * @param count - how many choices.
+ * @returns the choices, each labelled the way the model picker labels one.
+ */
+function many(count: number): SelectChoice[] {
+  return Array.from({ length: count }, (_unused, index) => ({
+    value: String(index),
+    label: index === 0
+      ? 'openrouter/first-sentinel'
+      : index === count - 1 ? 'openrouter/last-sentinel' : `openrouter/model-${String(index)}`,
+  }))
+}
+
+/** An overlay under test, plus what it settled with. */
+interface Mounted {
+  render(columns?: number, rows?: number): string[]
+  text(columns?: number, rows?: number): string
+  press(...keys: Key[]): void
+  readonly settled: () => { value: string | undefined } | undefined
+}
+
+/**
+ * Mount a picker over a fixed list.
+ * @param choices - the offered choices.
+ * @param detail - the optional supporting line.
+ * @returns the overlay and its settlement.
+ */
+function mount(choices: readonly SelectChoice[], detail?: string): Mounted {
+  let settled: { value: string | undefined } | undefined
+  const overlay = createSelectOverlay({
+    title: 'Select a model',
+    ...detail === undefined ? {} : { detail },
+    choices,
+    settle: value => { settled = { value } },
+    invalidate: () => {},
+  })
+  const render = (columns = COLUMNS, rows = ROWS): string[] => [...overlay.render(columns, rows)]
+  return {
+    render,
+    text: (columns = COLUMNS, rows = ROWS) => stripAnsi(render(columns, rows).join('\n')),
+    press: (...keys) => { for (const key of keys) overlay.handleKey(key) },
+    settled: () => settled,
+  }
+}
+
+/**
+ * One decoded key press.
+ * @param name - the key.
+ * @returns the key event.
+ */
+function key(name: Extract<Key, { kind: 'key' }>['name']): Key {
+  return { kind: 'key', name }
+}
+
+describe('a picker short enough to read', () => {
+  it('shows every choice, with no query box', () => {
+    const shown = mount(SHORT).text()
+    expect(shown).toContain('Allow once')
+    expect(shown).toContain('Reject')
+    expect(shown).not.toContain('⌕')
+    expect(shown).not.toContain('type to filter')
+  })
+
+  it('ignores typed text, which would otherwise insert nowhere', () => {
+    // An approval with two choices has nothing to filter, and a keystroke that
+    // appeared to do nothing would read as a hang.
+    const view = mount(SHORT)
+    view.press({ kind: 'text', text: 'y' }, { kind: 'paste', text: 'yes' })
+    expect(view.text()).not.toContain('y⌕')
+    view.press(key('enter'))
+    expect(view.settled()).toEqual({ value: 'allowed-once' })
+  })
+
+  it('cancels on the first escape, with no query to clear first', () => {
+    const view = mount(SHORT)
+    view.press(key('escape'))
+    expect(view.settled()).toEqual({ value: undefined })
+  })
+
+  it('shows the description of the selected choice only', () => {
+    const view = mount(SHORT)
+    expect(view.text()).toContain('Run this call and ask again.')
+    view.press(key('down'))
+    expect(view.text()).toContain('Reject')
+  })
+
+  it('keeps the detail line its caller supplied', () => {
+    expect(mount(SHORT, 'current: deepseek-official/deepseek-v4-flash').text())
+      .toContain('current: deepseek-official/deepseek-v4-flash')
+  })
+})
+
+describe('a picker long enough to need searching', () => {
+  it('offers a query box and counts the offer', () => {
+    const shown = mount(many(400)).text()
+    expect(shown).toContain('⌕')
+    expect(shown).toContain('400 choices')
+    expect(shown).toContain('type to filter')
+  })
+
+  it('turns the box on just past the threshold, and not at it', () => {
+    expect(mount(many(SEARCHABLE_CHOICES)).text()).not.toContain('⌕')
+    expect(mount(many(SEARCHABLE_CHOICES + 1)).text()).toContain('⌕')
+  })
+
+  it('filters as you type and says how much is left', () => {
+    const view = mount(many(400))
+    view.render()
+    view.press({ kind: 'text', text: 'model-370' })
+    const shown = view.text()
+    expect(shown).toContain('openrouter/model-370')
+    expect(shown).not.toContain('openrouter/model-120')
+    // The counter reports the two numbers separately: what the query left, and
+    // what was offered. Conflating them is how a counter starts lying.
+    expect(shown).toContain('1 of 400')
+  })
+
+  it('confirms the choice the query left selected, not the one behind it', () => {
+    const view = mount(many(400))
+    view.render()
+    view.press({ kind: 'text', text: 'last-sentinel' })
+    view.render()
+    view.press(key('enter'))
+    expect(view.settled()).toEqual({ value: '399' })
+  })
+
+  it('confirms nothing while a query has left nothing to confirm', () => {
+    // Settling with undefined here would read as a cancellation the reader never
+    // asked for.
+    const view = mount(many(400))
+    view.render()
+    view.press({ kind: 'text', text: 'nothing-matches-this' })
+    view.render()
+    view.press(key('enter'))
+    expect(view.settled()).toBeUndefined()
+    expect(view.text()).toContain('Nothing to choose from.')
+  })
+
+  it('clears the query on the first escape and cancels on the second', () => {
+    const view = mount(many(400))
+    view.render()
+    view.press({ kind: 'text', text: 'x' })
+    view.press(key('escape'))
+    expect(view.settled()).toBeUndefined()
+    expect(view.text()).toContain('400 choices')
+    view.press(key('escape'))
+    expect(view.settled()).toEqual({ value: undefined })
+  })
+
+  it('says which escape is armed', () => {
+    const view = mount(many(400))
+    expect(view.text()).toContain('esc cancel')
+    view.press({ kind: 'text', text: 'x' })
+    expect(view.text()).toContain('esc clear')
+  })
+
+  it('deletes one character per press, and clears the line', () => {
+    const view = mount(many(400))
+    view.render()
+    view.press({ kind: 'text', text: 'model-1' }, key('backspace'))
+    expect(view.text()).toContain('⌕ model-')
+    view.press(key('ctrl-u'))
+    expect(view.text()).toContain('400 choices')
+  })
+
+  it('collapses a pasted newline into the one line a query is', () => {
+    const view = mount(many(400))
+    view.render()
+    view.press({ kind: 'paste', text: 'open\nrouter' })
+    expect(view.text()).toContain('⌕ open router')
+  })
+})
+
+describe('staying inside the terminal', () => {
+  it.each([[24], [12], [6]])('draws no more than %i rows for four hundred choices', rows => {
+    const view = mount(many(400))
+    expect(view.render(COLUMNS, rows).length).toBeLessThanOrEqual(rows)
+  })
+
+  it('still draws a framed list at fourteen rows, rather than giving up on one', () => {
+    // The row count alone cannot tell a windowed list from the bare fallback, and
+    // only one of those is a usable picker. The frame is the evidence the list
+    // was WINDOWED to fit rather than abandoned.
+    const view = mount(many(400))
+    const lines = view.render(COLUMNS, 14)
+    expect(lines.length).toBeLessThanOrEqual(14)
+    expect(stripAnsi(lines.join('\n'))).toContain('╭')
+  })
+
+  it('stays inside the terminal while the selection walks past the window', () => {
+    const view = mount(many(400))
+    for (let press = 0; press < 450; press += 1) {
+      view.press(key('down'))
+      expect(view.render(COLUMNS, 14).length).toBeLessThanOrEqual(14)
+    }
+  })
+
+  it('scrolls the window forward so a walked-to selection stays drawn', () => {
+    // Stepping down past the last visible row has to move the window with it;
+    // a list that stopped following would leave the reader moving a selection
+    // they can no longer see.
+    const view = mount(many(400))
+    view.render(COLUMNS, 14)
+    for (let press = 0; press < 30; press += 1) {
+      view.press(key('down'))
+      view.render(COLUMNS, 14)
+    }
+    expect(view.text(COLUMNS, 14)).toContain('openrouter/model-30')
+  })
+
+  it('jumps to either end of the list', () => {
+    const view = mount(many(400))
+    view.render(COLUMNS, 14)
+    view.press(key('end'))
+    expect(view.text(COLUMNS, 14)).toContain('openrouter/last-sentinel')
+    view.press(key('home'))
+    expect(view.text(COLUMNS, 14)).toContain('openrouter/first-sentinel')
+  })
+
+  it('never draws a row wider than the terminal', () => {
+    const view = mount([{ value: 'x', label: `openrouter/${'long-'.repeat(40)}model` }, ...many(20)])
+    for (const line of view.render(50, ROWS)) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(50)
+    }
+  })
+
+  it('keeps the question answerable in a terminal too narrow to frame', () => {
+    // The frame is what is given up, never the decision: an approval can arrive
+    // in any geometry, and a reader who cannot see what they are confirming
+    // cannot answer it. Narrow but TALL, so the height leaves room for a frame
+    // and only the width rules one out.
+    const view = mount(SHORT)
+    const lines = view.render(12, 24)
+    expect(stripAnsi(lines.join('\n'))).toContain('Allow once')
+    expect(stripAnsi(lines.join('\n'))).not.toContain('╭')
+  })
+
+  it('keeps it answerable in a terminal too short to frame', () => {
+    const view = mount(SHORT)
+    const lines = view.render(COLUMNS, 2)
+    expect(lines.length).toBeLessThanOrEqual(2)
+    expect(stripAnsi(lines.join('\n'))).toContain('Allow once')
+  })
+
+  it('shows the selected choice in that fallback, not the first one', () => {
+    const view = mount(SHORT)
+    view.press(key('down'))
+    expect(stripAnsi(mountedFallback(view))).toContain('Reject')
+  })
+})
+
+describe('filterChoices()', () => {
+  it('matches the label, case-folded, and keeps the order it was given', () => {
+    const choices = [{ value: '0', label: 'B/one' }, { value: '1', label: 'A/One' }]
+    expect(filterChoices(choices, ' ONE ').map(choice => choice.value)).toEqual(['0', '1'])
+  })
+
+  it('returns the same list for an empty query', () => {
+    expect(filterChoices(SHORT, '  ')).toBe(SHORT)
+  })
+
+  it('does not match a description, which only the selected row shows', () => {
+    // A reader who cannot see why a row matched cannot trust the ones that did not.
+    expect(filterChoices(SHORT, 'ask again')).toEqual([])
+  })
+})
+
+/**
+ * The compact fallback for a mounted picker, as plain text.
+ * @param view - the mounted picker.
+ * @returns the joined lines.
+ */
+function mountedFallback(view: Mounted): string {
+  return view.render(COLUMNS, 2).join('\n')
+}

--- a/packages/tui/tests/select.spec.ts
+++ b/packages/tui/tests/select.spec.ts
@@ -235,6 +235,25 @@ describe('staying inside the terminal', () => {
     expect(view.text(COLUMNS, 14)).toContain('openrouter/model-30')
   })
 
+  it('keeps the description of a selected choice in the window beside its label', () => {
+    // The description is drawn under the SELECTED row only, so it is the one row
+    // that appears as the cursor arrives — and following the label alone scrolled
+    // it off exactly when the label reached the last visible row.
+    const described = many(400).map(choice => ({
+      ...choice,
+      description: `about ${choice.label}.`,
+    }))
+    const view = mount(described)
+    view.render(COLUMNS, 14)
+    for (let index = 1; index < 40; index += 1) {
+      view.press(key('down'))
+      const shown = view.text(COLUMNS, 14)
+      const label = described[index]?.label ?? ''
+      expect(shown).toContain(`❯ ${label}`)
+      expect(shown).toContain(`about ${label}.`)
+    }
+  })
+
   it('jumps to either end of the list', () => {
     const view = mount(many(400))
     view.render(COLUMNS, 14)


### PR DESCRIPTION
`/connect` made it easy to add a gateway route, and a gateway route advertises
whatever the gateway serves — OpenRouter and opencode each offer several hundred
models. `/model` then opened a list nobody could use, and one the terminal could
not survive.

## The bug

`createSelectOverlay` drew one row per choice and ignored the terminal height
entirely. With four hundred models it handed `Screen` a live region taller than
the screen, and rows that have scrolled off the top can no longer be reached or
erased: the next redraw climbs into rows it does not own, leaving duplicate
frames in real scrollback and clearing output the picker never wrote.

That is the exact failure the composer's row cap exists to prevent, and the
reason every other bounded view here — Work, Sessions, Connect — is a viewport
over its rows rather than a list of them. The picker is now one too: same
`RowViewport`, same follow-the-selection rule, same `physicalRows` backstop for a
row that forgot to truncate itself.

## Reachable, not just drawable

Past twelve choices the picker grows a query box and filters as you type:

```
┌ Select a model ──────────────────────────────────────────────────────────┐
│ ⌕ sonnet                                                    6 of 412     │
│ current: deepseek-official/deepseek-v4-flash                             │
│                                                                          │
│ ❯ openrouter/anthropic/claude-sonnet-4                                   │
│   openrouter/anthropic/claude-sonnet-4-thinking                          │
│   opencode/claude-sonnet-4                                               │
└──────────────────────────────────────────────────────────────────────────┘
  ↑↓ move · type to filter · enter confirm · esc clear
```

Twelve is about what the list shows on the shortest terminal anyone drives, so
below it a search box would cost a row to reach rows already on screen.
Searchability is decided from the **offer**, not from what the query has left of
it — a box that vanished once the list got short enough would take the query with
it and put the rows it had just hidden back.

The counter keeps "what the query left" and "what was offered" apart, because
conflating them is how a counter starts lying.

## Nothing changes below the threshold

Which is what lets one implementation keep serving approvals,
`ask_user_question`, `/reasoning`, `/usage`, and the Connect action pickers. A
three-choice approval spends no row on a search box, and its typed characters
stay meaningless — inserting them nowhere would read as a hang.

Two behaviours only a long list can reach are new: `enter` confirms nothing while
a query has left nothing to confirm (settling with `undefined` would read as a
cancellation nobody asked for), and the first `escape` clears the query before
the second cancels, as the Sessions and Connect browsers already do.

## The fallback keeps the decision, not the count

Every other bounded view here is a browser, and a browser that cannot fit says
how many rows it is hiding. This is a **question**. An approval or a tool's own
prompt arrives in whatever geometry the terminal happens to have, and a reader
who cannot see what they are about to confirm cannot answer it — so a terminal
too small to frame shows the selected choice and its keys. The frame is what is
given up, never the decision.

## `/model`'s labels

Search made the old label wrong. Rows were the provider's display name joined to
the model's, while the command takes `provider/model` — so the text you filtered
on was not the text you could have typed. Each row is now the qualified id, and
the display name moves under the selection, where it disambiguates two similar
models without being what has to be matched. A name that is only its own id with
different capitals is dropped rather than repeated.

Filtering matches the label alone, deliberately: a description is drawn under the
selection only, so matching it would leave a reader unable to see why a row
survived — and unable to trust the ones that did not.

## Tests and validation

`pnpm build`, `pnpm typecheck`, `pnpm test` (952 passing, was 917), and
`pnpm security` all pass. New suites: `select.spec.ts` for the two regimes, the
bound, the viewport, and the fallback; `select-frames.spec.ts` drives four
hundred choices through `@xterm/headless` and asserts the transcript above the
picker is still there, written once.

Each claim was broken on purpose and the named test confirmed to fail — the
viewport slice, both fallback guards, the forward follow, the threshold, typed
filtering, confirming the filtered selection, label-only matching, the qualified
label, and the redundant-name rule. Three first passed against the broken version
and were the tests at fault: two asserted a row count the `physicalRows` backstop
satisfied either way, and one reached the list's end with `end` rather than by
walking into it. They now assert that a fourteen-row terminal still draws a
*frame*, that a narrow but tall one does not, and that stepping down past the
last visible row moves the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
