### PR TITLE
fix(tui): count what the suggestion list is actually hiding

### DIFF
--- a/.changeset/olive-pugs-argue.md
+++ b/.changeset/olive-pugs-argue.md
@@ -1,0 +1,16 @@
+---
+"@riesbri/dsh-tui": patch
+---
+
+Count what the suggestion list is actually hiding, and bound it to the screen.
+
+The `… N more` row reported `candidates.length - shown.length`, which is the same
+number at every scroll position: fifteen commands showed `… 9 more` with the first
+highlighted and still `… 9 more` with the last. It now counts the rows below the
+window, so it reaches zero at the bottom, and the help line carries the position
+(`10/15`) so the rows scrolled off above are accounted for without a second marker.
+
+The list also ignored the terminal height the slot contract passes it, so on a short
+terminal it pushed the composer out of the live region — where `Screen` can no longer
+erase it, and the next redraw left a duplicate frame in scrollback. It now takes at
+most the rows the screen has room for.

--- a/.changeset/olive-pugs-argue.md
+++ b/.changeset/olive-pugs-argue.md
@@ -10,7 +10,10 @@ highlighted and still `… 9 more` with the last. It now counts the rows below t
 window, so it reaches zero at the bottom, and the help line carries the position
 (`10/15`) so the rows scrolled off above are accounted for without a second marker.
 
-The list also ignored the terminal height the slot contract passes it, so on a short
-terminal it pushed the composer out of the live region — where `Screen` can no longer
-erase it, and the next redraw left a duplicate frame in scrollback. It now takes at
-most the rows the screen has room for.
+The list also ignored the height the slot contract passes it, so on a short terminal
+it pushed the composer out of the live region — where `Screen` can no longer erase it,
+and the next redraw left a duplicate frame in scrollback. `TuiSlots.compose()` now
+hands each slot view the rows the views above it have NOT spent, rather than the
+terminal's own height, so a ten-row prompt shrinks the list instead of overflowing the
+screen. Where nothing is left, the list renders nothing rather than chrome with every
+candidate hidden.

--- a/packages/tui/src/completion.ts
+++ b/packages/tui/src/completion.ts
@@ -14,12 +14,24 @@
  */
 
 import type { Composer, Key } from '@riesbri/dsh-tui-renderer'
-import { escapeControls, style, truncateToWidth } from '@riesbri/dsh-tui-renderer'
+import { displayWidth, escapeControls, style, truncateToWidth } from '@riesbri/dsh-tui-renderer'
 import type { TuiSlotView } from './slots.ts'
 import { chromeWidth } from './views.ts'
 
-/** Rows of the list shown at once. */
+/** Rows of the list shown at once, when the terminal has room for them. */
 const VISIBLE_ROWS = 6
+
+/**
+ * Live-region rows this view must leave for everything below and around it.
+ *
+ * Its own two chrome rows (the elision marker and the help line), plus a floor for
+ * the composer's frame and the status line. Without this the list is a fixed six
+ * rows on a terminal that cannot hold them, and the live region grows past the
+ * screen — the failure `COMPOSER_ROWS` and `LIVE_ROWS` already guard against, where
+ * rows that scrolled off can no longer be erased and the next redraw leaves
+ * duplicates in scrollback.
+ */
+const RESERVED_ROWS = 8
 
 /** Marker on the highlighted row. */
 const CURSOR = '›'
@@ -232,14 +244,18 @@ export function createCompletion(
 
   return {
     view: {
-      render(columns) {
+      render(columns, terminalRows = 24) {
         if (candidates.length === 0) return []
         const width = chromeWidth(columns)
+        // Six rows are what this list WANTS; the screen decides what it gets. One
+        // row is the floor rather than zero: a list that renders its chrome and no
+        // candidates would say a completion exists while hiding every one of them.
+        const capacity = Math.max(1, Math.min(VISIBLE_ROWS, terminalRows - RESERVED_ROWS))
         const start = Math.min(
-          Math.max(0, cursor - VISIBLE_ROWS + 1),
-          Math.max(0, candidates.length - VISIBLE_ROWS),
+          Math.max(0, cursor - capacity + 1),
+          Math.max(0, candidates.length - capacity),
         )
-        const shown = candidates.slice(start, start + VISIBLE_ROWS)
+        const shown = candidates.slice(start, start + capacity)
         const rows = shown.map((candidate, index) => {
           const selected = start + index === cursor
           const mark = selected ? style(CURSOR, 'cyan') : ' '
@@ -251,9 +267,15 @@ export function createCompletion(
             : ` ${style(escapeControls(candidate.note), 'gray')}`
           return `  ${mark} ${truncateToWidth(`${label}${note}`, Math.max(8, width - 4))}`
         })
-        const hidden = candidates.length - shown.length
-        if (hidden > 0) rows.push(`    ${style(`… ${String(hidden)} more`, 'gray')}`)
-        rows.push(`    ${style('tab/enter complete · esc dismiss', 'gray')}`)
+        // What is BELOW the window, not what the window omits. `candidates.length -
+        // shown.length` is the same number at every scroll position — nine of
+        // fifteen commands, still nine with the last one highlighted — which reads
+        // as a list that never ends. The rows above are accounted for by the
+        // position in the help line rather than by a second marker row, because a
+        // completion list shares the live region with the composer.
+        const below = candidates.length - (start + shown.length)
+        if (below > 0) rows.push(`    ${style(`… ${String(below)} more`, 'gray')}`)
+        rows.push(`    ${style(helpLine(cursor, candidates.length, Math.max(1, width - 4)), 'gray')}`)
         return rows
       },
     },
@@ -308,6 +330,29 @@ export function createCompletion(
       clear()
     },
   }
+}
+
+/**
+ * The list's position and its gestures, dropping whole segments when narrow.
+ *
+ * The position is what tells a reader that rows scrolled off ABOVE the window: the
+ * `… N more` marker below can only speak for the rows under it, and a second marker
+ * row would cost the composer a line. It leads the line and is the first thing given
+ * up, by the rule `select.ts` already follows — the way out of a list outranks
+ * knowing where you are in it.
+ * @param cursor - the highlighted candidate, zero-based.
+ * @param total - how many candidates are offered.
+ * @param columns - room available for the line.
+ * @returns the help text that fits.
+ */
+function helpLine(cursor: number, total: number, columns: number): string {
+  const position = `${String(cursor + 1)}/${String(total)}`
+  const parts = [position, 'tab/enter complete', 'esc dismiss']
+  for (let from = 0; from < parts.length; from += 1) {
+    const line = parts.slice(from).join(' \u00b7 ')
+    if (displayWidth(line) <= columns) return line
+  }
+  return truncateToWidth('esc dismiss', columns)
 }
 
 /**

--- a/packages/tui/src/completion.ts
+++ b/packages/tui/src/completion.ts
@@ -29,6 +29,13 @@ const VISIBLE_ROWS = 6
  * `status`, and a status line is exactly one row at every width by construction.
  * What is above this view is not counted here at all: `TuiSlots.compose()` has
  * already subtracted it from the rows it passes in.
+ *
+ * So this constant is deliberately coupled to two facts that hold today: that
+ * slot order is closed, and that exactly one row follows this view. Neither is
+ * promised beyond pre-1.0. The moment third-party persistent rows exist — the
+ * global live-region layout budget the roadmap makes a precondition for them —
+ * knowing what comes below stops being a view's business, and this reservation
+ * belongs in that budget rather than here.
  */
 const ROWS_BELOW = 1
 

--- a/packages/tui/src/completion.ts
+++ b/packages/tui/src/completion.ts
@@ -22,16 +22,25 @@ import { chromeWidth } from './views.ts'
 const VISIBLE_ROWS = 6
 
 /**
- * Live-region rows this view must leave for everything below and around it.
+ * Rows this view must leave for the live region BELOW it: the status line.
  *
- * Its own two chrome rows (the elision marker and the help line), plus a floor for
- * the composer's frame and the status line. Without this the list is a fixed six
- * rows on a terminal that cannot hold them, and the live region grows past the
- * screen — the failure `COMPOSER_ROWS` and `LIVE_ROWS` already guard against, where
- * rows that scrolled off can no longer be erased and the next redraw leaves
- * duplicates in scrollback.
+ * Known here rather than negotiated because `SLOT_ORDER` is a fixed list of four
+ * names in `slots.ts`, not an open registry — `completion` is followed by
+ * `status`, and a status line is exactly one row at every width by construction.
+ * What is above this view is not counted here at all: `TuiSlots.compose()` has
+ * already subtracted it from the rows it passes in.
  */
-const RESERVED_ROWS = 8
+const ROWS_BELOW = 1
+
+/**
+ * Rows this view spends on its own chrome: the elision marker and the help line.
+ *
+ * Both are reserved even when the marker will not be drawn. Whether it is drawn
+ * depends on how many candidates fit, which is the number being computed — so
+ * spending the row unconditionally is what keeps that from being circular, at a
+ * cost of one row on a terminal short enough to notice.
+ */
+const CHROME_ROWS = 2
 
 /** Marker on the highlighted row. */
 const CURSOR = '›'
@@ -247,10 +256,18 @@ export function createCompletion(
       render(columns, terminalRows = 24) {
         if (candidates.length === 0) return []
         const width = chromeWidth(columns)
-        // Six rows are what this list WANTS; the screen decides what it gets. One
-        // row is the floor rather than zero: a list that renders its chrome and no
-        // candidates would say a completion exists while hiding every one of them.
-        const capacity = Math.max(1, Math.min(VISIBLE_ROWS, terminalRows - RESERVED_ROWS))
+        // Six rows are what this list WANTS; what is left of the screen decides
+        // what it gets. `terminalRows` is already net of the stream and the
+        // composer above, so a ten-row prompt shrinks this list rather than
+        // pushing the prompt off the top.
+        const capacity = Math.min(VISIBLE_ROWS, terminalRows - ROWS_BELOW - CHROME_ROWS)
+        // Nothing at all rather than a row or two of chrome. When the composer has
+        // taken the screen, the prompt is what the keystrokes are going to and a
+        // list that cannot show a single candidate is not worth a row of it — and
+        // one row over budget is not a smaller version of this list, it is the
+        // duplicate-frame bug. Typing one more character narrows the candidates
+        // and, on a short terminal, that is how the list comes back.
+        if (capacity < 1) return []
         const start = Math.min(
           Math.max(0, cursor - capacity + 1),
           Math.max(0, candidates.length - capacity),
@@ -347,12 +364,15 @@ export function createCompletion(
  */
 function helpLine(cursor: number, total: number, columns: number): string {
   const position = `${String(cursor + 1)}/${String(total)}`
+  // Whole words all the way down, ending at the bare key name. `esc dism` is not
+  // a shorter hint, it is a rendering fault — the same rule the status line
+  // follows when it drops a hint rather than cutting one.
   const parts = [position, 'tab/enter complete', 'esc dismiss']
   for (let from = 0; from < parts.length; from += 1) {
     const line = parts.slice(from).join(' \u00b7 ')
     if (displayWidth(line) <= columns) return line
   }
-  return truncateToWidth('esc dismiss', columns)
+  return displayWidth('esc') <= columns ? 'esc' : ''
 }
 
 /**

--- a/packages/tui/src/slots.ts
+++ b/packages/tui/src/slots.ts
@@ -44,8 +44,16 @@ const SLOT_ORDER: readonly TuiSlotName[] = ['stream', 'composer', 'completion', 
 export interface TuiSlotView {
   /**
    * Lines this view contributes right now.
+   *
+   * `rows` is what is LEFT of the terminal at this point in the composition, not
+   * the terminal's own height: the views above this one have already been
+   * rendered and their lines subtracted. A view that bounds itself against the
+   * whole screen would be budgeting against space another view has already
+   * spent — which is how a tall composer plus a suggestion list grew the live
+   * region past the screen.
    * @param columns - the terminal's current width, for views that fit content.
-   * @param rows - the terminal's current height, when the view bounds itself.
+   * @param rows - the rows still unspent below this point, when the view bounds
+   *   itself. What remains below THIS view is still its own to account for.
    * @returns logical lines; the screen wraps them.
    */
   render(columns: number, rows?: number): readonly string[]
@@ -158,6 +166,12 @@ export class TuiSlots extends Service {
    * An overlay replaces the whole region and takes every key, so it contributes
    * no cursor: text entry belongs to the composer, which is not on screen while
    * an overlay is up.
+   *
+   * Each slot view is asked for its lines with the rows the views above it have
+   * NOT already spent. The live region must never exceed the screen — rows that
+   * have scrolled off cannot be climbed back to and erased — and no single view
+   * can enforce that alone, because none of them knows how tall the others are.
+   * Subtracting as it goes is what makes a self-bounding view's budget true.
    * @param columns - the terminal's current width.
    * @param rows - the terminal's current height; defaults for older callers.
    * @returns the lines to draw top to bottom, and where the cursor belongs.
@@ -169,7 +183,7 @@ export class TuiSlots extends Service {
     let cursor: LiveCursor | undefined
     for (const name of SLOT_ORDER) {
       for (const entry of this.slots.get(name) ?? []) {
-        const own = entry.view.render(columns, rows)
+        const own = entry.view.render(columns, Math.max(0, rows - lines.length))
         const placement = cursor === undefined ? entry.view.cursor?.(columns) : undefined
         // Translate the view-relative row into the composed region's row space.
         if (placement !== undefined) cursor = { row: lines.length + placement.row, column: placement.column }

--- a/packages/tui/tests/completion-frames.spec.ts
+++ b/packages/tui/tests/completion-frames.spec.ts
@@ -10,9 +10,11 @@
  */
 
 import { describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
 import { Composer, Screen } from '@riesbri/dsh-tui-renderer'
 import { createEmulator } from '../../../tests/emulator.ts'
 import { createCompletion } from '../src/completion.ts'
+import { TuiSlots } from '../src/slots.ts'
 import { createComposerView, createStatusView } from '../src/views.ts'
 
 /** The width used by the real-terminal regression frames. */
@@ -26,10 +28,15 @@ const COMMANDS = Array.from({ length: 15 }, (_unused, index) => ({
 
 /**
  * Mount the whole live region — composer, completion, status — over an emulator.
+ *
+ * Composed through the REAL `TuiSlots`, not a hand-rolled concatenation. The
+ * budget under test is the one `compose()` hands each view, so a test that did
+ * that arithmetic itself would pass with the arithmetic removed from the source.
  * @param rows - the emulator's height.
+ * @param typed - what is in the composer, which decides how tall it is.
  * @returns the emulator, the completion, and a repaint of the live region.
  */
-async function terminal(rows: number): Promise<{
+async function terminal(rows: number, typed = '/command'): Promise<{
   emulator: ReturnType<typeof createEmulator>
   completion: ReturnType<typeof createCompletion>
   draw: () => void
@@ -38,7 +45,7 @@ async function terminal(rows: number): Promise<{
   const screen = new Screen(emulator.target)
   screen.commit(['TRANSCRIPT above list A', 'TRANSCRIPT above list B'])
   const composer = new Composer()
-  composer.handle({ kind: 'text', text: '/command' })
+  composer.handle({ kind: 'text', text: typed })
   const composerView = createComposerView(composer, '/work')
   const status = createStatusView(() => ({
     busy: false,
@@ -61,13 +68,11 @@ async function terminal(rows: number): Promise<{
     paths: async () => [],
   }, () => {})
   await completion.refresh()
-  const draw = (): void => {
-    screen.setLive([
-      ...composerView.render(COLUMNS, rows),
-      ...completion.view.render(COLUMNS, rows),
-      ...status.render(COLUMNS, rows),
-    ])
-  }
+  const slots = new TuiSlots(new Context())
+  slots.register('composer', composerView)
+  slots.register('completion', completion.view)
+  slots.register('status', status)
+  const draw = (): void => { screen.setLive(slots.compose(COLUMNS, rows).lines) }
   return { emulator, completion, draw }
 }
 
@@ -94,6 +99,42 @@ describe('the suggestion list on a real terminal', () => {
     // next redraw climbs too few rows and writes a SECOND copy below the first —
     // which is what a reader on a short terminal actually sees go wrong.
     expect(history.filter(line => line.includes('\u256d\u2500 work'))).toHaveLength(1)
+  })
+
+  it.each([24, 20, 18, 16, 14])('yields to a full-height composer in a %i-row terminal', async rows => {
+    // The composer is allowed ten content rows plus its frame and separating
+    // blank — thirteen — and the status line takes another. A list that budgets
+    // against the terminal's own height instead of what is left of it fits none
+    // of that, and the live region grows past the screen.
+    const tall = `${Array.from({ length: 14 }, (_unused, i) => `line ${String(i)}`).join('\n')}\n/command`
+    const { emulator, completion, draw } = await terminal(rows, tall)
+    draw()
+    const screen = await emulator.screen()
+    expect(screen.length, `${String(rows)} rows`).toBeLessThanOrEqual(rows)
+    // The prompt is where the keystrokes are going. It is never the thing that
+    // gets pushed off to make room for a list about it.
+    expect(screen.join('\n')).toContain('/command')
+    for (let press = 0; press < 20; press += 1) {
+      completion.handleKey({ kind: 'key', name: 'down' })
+      draw()
+    }
+    expect((await emulator.screen()).length, `${String(rows)} rows after scrolling`).toBeLessThanOrEqual(rows)
+    const history = await emulator.scrollback()
+    expect(history.filter(line => line.includes('╭─ work'))).toHaveLength(1)
+    expect(history.filter(line => line.includes('TRANSCRIPT above list A'))).toHaveLength(1)
+  })
+
+  it('gives up entirely rather than crowd a composer that fills the screen', async () => {
+    // Two rows of chrome and no candidate is not a smaller list, it is a claim
+    // that completions exist with every one of them hidden. Typing one more
+    // character narrows the candidates; that is how it comes back.
+    const tall = `${Array.from({ length: 14 }, (_unused, i) => `line ${String(i)}`).join('\n')}\n/command`
+    const { emulator, draw } = await terminal(15, tall)
+    draw()
+    const screen = (await emulator.screen()).join('\n')
+    expect(screen).not.toContain('complete · esc dismiss')
+    expect(screen).toContain('/command')
+    expect((await emulator.screen()).length).toBeLessThanOrEqual(15)
   })
 
   it('empties its count as the highlight reaches the end', async () => {

--- a/packages/tui/tests/completion-frames.spec.ts
+++ b/packages/tui/tests/completion-frames.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * A long suggestion list on a real terminal.
+ *
+ * Completion is not an overlay: it shares the live region with the composer and
+ * the status line, and `Screen` erases that region by climbing rows. A list that
+ * renders more rows than the terminal has therefore pushes the composer off the
+ * top, where the next redraw can no longer reach it — and the transcript above
+ * gains a duplicate copy of the chrome. Read as plain text every one of those
+ * frames looks correct, so the assertions here are about what the terminal HOLDS.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Composer, Screen } from '@riesbri/dsh-tui-renderer'
+import { createEmulator } from '../../../tests/emulator.ts'
+import { createCompletion } from '../src/completion.ts'
+import { createComposerView, createStatusView } from '../src/views.ts'
+
+/** The width used by the real-terminal regression frames. */
+const COLUMNS = 80
+
+/** More commands than a short terminal can show at once. */
+const COMMANDS = Array.from({ length: 15 }, (_unused, index) => ({
+  name: index === 14 ? 'command-last-sentinel' : `command-${String(index).padStart(2, '0')}`,
+  description: 'what this one does',
+}))
+
+/**
+ * Mount the whole live region — composer, completion, status — over an emulator.
+ * @param rows - the emulator's height.
+ * @returns the emulator, the completion, and a repaint of the live region.
+ */
+async function terminal(rows: number): Promise<{
+  emulator: ReturnType<typeof createEmulator>
+  completion: ReturnType<typeof createCompletion>
+  draw: () => void
+}> {
+  const emulator = createEmulator(COLUMNS, rows)
+  const screen = new Screen(emulator.target)
+  screen.commit(['TRANSCRIPT above list A', 'TRANSCRIPT above list B'])
+  const composer = new Composer()
+  composer.handle({ kind: 'text', text: '/command' })
+  const composerView = createComposerView(composer, '/work')
+  const status = createStatusView(() => ({
+    busy: false,
+    tick: 0,
+    elapsedMs: undefined,
+    model: 'deepseek-v4-flash',
+    effort: undefined,
+    usage: undefined,
+    tokens: undefined,
+    contextWindow: undefined,
+    detail: 'compact',
+    work: undefined,
+    todo: undefined,
+    plan: false,
+    goal: undefined,
+  }))
+  const completion = createCompletion(composer, {
+    commands: () => COMMANDS,
+    commandArguments: async () => [],
+    paths: async () => [],
+  }, () => {})
+  await completion.refresh()
+  const draw = (): void => {
+    screen.setLive([
+      ...composerView.render(COLUMNS, rows),
+      ...completion.view.render(COLUMNS, rows),
+      ...status.render(COLUMNS, rows),
+    ])
+  }
+  return { emulator, completion, draw }
+}
+
+describe('the suggestion list on a real terminal', () => {
+  it.each([24, 14, 10, 8])('keeps the composer on screen in a %i-row terminal', async rows => {
+    const { emulator, completion, draw } = await terminal(rows)
+    draw()
+    expect((await emulator.screen()).length).toBeLessThanOrEqual(rows)
+    // The prompt the list is completing must never be the thing scrolled away:
+    // it is where the keystrokes are going.
+    expect((await emulator.screen()).join('\n')).toContain('/command')
+
+    // Walk the whole list, twice over the wrap-around.
+    for (let press = 0; press < 32; press += 1) {
+      completion.handleKey({ kind: 'key', name: 'down' })
+      draw()
+    }
+    expect((await emulator.screen()).length).toBeLessThanOrEqual(rows)
+    const history = await emulator.scrollback()
+    expect(history.filter(line => line.includes('TRANSCRIPT above list A'))).toHaveLength(1)
+    expect(history.filter(line => line.includes('TRANSCRIPT above list B'))).toHaveLength(1)
+    // The composer's frame appears once, wherever the live region currently sits.
+    // A list taller than the screen scrolls that top border out of reach, and the
+    // next redraw climbs too few rows and writes a SECOND copy below the first —
+    // which is what a reader on a short terminal actually sees go wrong.
+    expect(history.filter(line => line.includes('\u256d\u2500 work'))).toHaveLength(1)
+  })
+
+  it('empties its count as the highlight reaches the end', async () => {
+    const { emulator, completion, draw } = await terminal(24)
+    draw()
+    expect((await emulator.screen()).join('\n')).toContain('9 more')
+    for (let press = 0; press < 14; press += 1) completion.handleKey({ kind: 'key', name: 'down' })
+    draw()
+    const screen = (await emulator.screen()).join('\n')
+    expect(screen).toContain('command-last-sentinel')
+    expect(screen).toContain('15/15')
+    expect(screen).not.toContain('more')
+  })
+})

--- a/packages/tui/tests/completion.spec.ts
+++ b/packages/tui/tests/completion.spec.ts
@@ -89,13 +89,36 @@ async function settled(): Promise<void> {
 }
 
 /** A thing with a renderable view, which is all these helpers need. */
-type Rendered = { view: { render(columns: number): readonly string[] } }
+type Rendered = { view: { render(columns: number, rows?: number): readonly string[] } }
 
 /** The candidate rows, styling and selection marker removed, hint line dropped. */
 function rows(completion: Rendered): string[] {
   return completion.view.render(80).map(stripAnsi).map(row => row.trim())
     .filter(row => row !== '' && !row.endsWith('complete · esc dismiss') && !row.startsWith('…'))
     .map(row => (row.startsWith('\u203a ') ? row.slice(2) : row))
+}
+
+/** Every rendered row at a comfortable width, styling removed. */
+function render(completion: Rendered): string[] {
+  return completion.view.render(80).map(stripAnsi).map(row => row.trim())
+}
+
+/**
+ * A live completion over `count` files, for the windowing assertions.
+ * @param count - how many candidates to offer.
+ * @returns the refreshed completion.
+ */
+async function manyFiles(count: number): Promise<ReturnType<typeof createCompletion>> {
+  const many = Array.from({ length: count }, (_, i) => ({ name: `file${String(i)}.ts`, directory: false }))
+  const composer = new Composer()
+  composer.handle({ kind: 'text', text: '@file' })
+  const completion = createCompletion(composer, {
+    commands: () => [],
+    commandArguments: async () => [],
+    paths: async () => many,
+  }, () => {})
+  await completion.refresh()
+  return completion
 }
 
 /** The highlighted row, so a move through the list is observable. */
@@ -440,6 +463,44 @@ describe('the rendered list', () => {
     const shown = completion.view.render(80).map(stripAnsi)
     expect(shown.filter(row => row.includes('file')).length).toBe(6)
     expect(shown.join('\n')).toContain('14 more')
+  })
+
+  it('counts down as the highlight walks off the bottom', async () => {
+    // The count is about the rows BELOW the window, not about the rows the window
+    // omits. Computing it as `candidates.length - shown.length` gave the same
+    // fourteen at every position — including with the last of twenty highlighted,
+    // where nothing at all is hidden below.
+    const completion = await manyFiles(20)
+    expect(render(completion).join('\n')).toContain('14 more')
+    for (let step = 0; step < 6; step += 1) completion.handleKey({ kind: 'key', name: 'down' })
+    expect(render(completion).join('\n')).toContain('13 more')
+    for (let step = 0; step < 13; step += 1) completion.handleKey({ kind: 'key', name: 'down' })
+    expect(render(completion).join('\n')).not.toContain('more')
+  })
+
+  it('says where in the list the highlight is', async () => {
+    // The rows scrolled off ABOVE the window are otherwise unaccounted for: the
+    // elision marker sits below the list and can only speak for what is under it.
+    const completion = await manyFiles(20)
+    expect(render(completion).join('\n')).toContain('1/20')
+    for (let step = 0; step < 9; step += 1) completion.handleKey({ kind: 'key', name: 'down' })
+    expect(render(completion).join('\n')).toContain('10/20')
+  })
+
+  it('gives up the position before the way out when the terminal is narrow', async () => {
+    const completion = await manyFiles(20)
+    const narrow = completion.view.render(24).map(stripAnsi).map(row => row.trim())
+    expect(narrow.some(row => row === 'esc dismiss')).toBe(true)
+  })
+
+  it('shrinks to the rows a short terminal has, keeping both chrome rows', async () => {
+    // A fixed six rows on a ten-row terminal pushes the composer out of the live
+    // region, and rows that have scrolled off can no longer be erased.
+    const completion = await manyFiles(20)
+    const short = completion.view.render(80, 12).map(stripAnsi)
+    expect(short.filter(row => row.includes('file')).length).toBe(4)
+    expect(short.join('\n')).toContain('16 more')
+    expect(short.join('\n')).toContain('complete · esc dismiss')
   })
 
   it('escapes a control sequence in a file name', async () => {

--- a/packages/tui/tests/completion.spec.ts
+++ b/packages/tui/tests/completion.spec.ts
@@ -493,14 +493,38 @@ describe('the rendered list', () => {
     expect(narrow.some(row => row === 'esc dismiss')).toBe(true)
   })
 
-  it('shrinks to the rows a short terminal has, keeping both chrome rows', async () => {
-    // A fixed six rows on a ten-row terminal pushes the composer out of the live
-    // region, and rows that have scrolled off can no longer be erased.
+  it('shrinks to the rows it was left, keeping both chrome rows', async () => {
+    // `render`'s second argument is what the views ABOVE this one did not spend,
+    // not the terminal's height — see TuiSlots.compose(). A fixed six rows here
+    // pushes the composer out of the live region, and rows that have scrolled off
+    // can no longer be erased.
     const completion = await manyFiles(20)
-    const short = completion.view.render(80, 12).map(stripAnsi)
+    const short = completion.view.render(80, 7).map(stripAnsi)
     expect(short.filter(row => row.includes('file')).length).toBe(4)
     expect(short.join('\n')).toContain('16 more')
     expect(short.join('\n')).toContain('complete · esc dismiss')
+  })
+
+  it('renders nothing at all when it was left no room for a candidate', async () => {
+    // Chrome with no candidates says completions exist while hiding every one of
+    // them, and one row over budget is the duplicate-frame bug rather than a
+    // smaller list.
+    const completion = await manyFiles(20)
+    for (const left of [3, 2, 1, 0]) {
+      expect(completion.view.render(80, left), `${String(left)} rows left`).toEqual([])
+    }
+    expect(completion.view.render(80, 4).length).toBe(3)
+  })
+
+  it('ends the help line on a whole word, never half a key name', async () => {
+    // `esc dism` reads as a rendering fault, not as a shorter hint.
+    const completion = await manyFiles(20)
+    for (const columns of [80, 40, 30, 24, 20, 16, 12, 10, 8, 6]) {
+      const help = completion.view.render(columns).map(stripAnsi).map(row => row.trim())
+        .find(row => row.startsWith('esc') || row.includes('dismiss') || row.includes('/20'))
+      expect(help === undefined || /^(\d+\/20 · )?(tab\/enter complete · )?(esc dismiss|esc)$/u.test(help),
+        `${String(columns)} columns: ${JSON.stringify(help)}`).toBe(true)
+    }
   })
 
   it('escapes a control sequence in a file name', async () => {


### PR DESCRIPTION
## What a person saw

Typing `/` and arrowing down the command list showed `… 9 more` at the top of the list and `… 9 more` at the bottom, with nothing below it.

## Why

`completion.ts` computed the count as `candidates.length - shown.length`. `shown.length` is `min(VISIBLE_ROWS, candidates.length)` — a constant 6 for any list longer than the window — so the number was `total - 6` for the entire life of the list, whatever the highlight was doing. It reads as a list that never ends.

It now counts the rows actually below the window. The rows scrolled off **above** are the other half of the question, and the obvious answer — a second `↑ N more` marker row — is the wrong one: this view shares the live region with the composer, so a row spent here is a row the prompt does not get. The position goes in the help line instead, which was already on screen:

```
  › /command-06 what this one does
    /command-07 what this one does
    … 3 more
    12/15 · tab/enter complete · esc dismiss
```

## The second half

The same `render` ignored the terminal height `TuiSlots.compose()` hands every slot view (`slots.ts:44-51`). It was the only live-region view that did not bound itself, so on a ten-row terminal the six candidate rows plus two chrome rows pushed the composer's top border off the screen — past where `Screen` climbs to erase it — and the next redraw wrote a second copy of the frame below the first.

Verified in the emulator: at `rows=10` and `rows=8` the scrollback holds two `╭─ work` frames before this change and one after. No string assertion catches that; only the cells do.

## Tests

`packages/tui/tests/completion.spec.ts` gains four cases (counting down to zero, the position, the narrow-terminal drop order, the short-terminal capacity) and `packages/tui/tests/completion-frames.spec.ts` is new — it mounts composer + completion + status over a real emulator at 24, 14, 10 and 8 rows.

Broken on purpose, both halves separately:

| Reverted | Caught by |
| --- | --- |
| `candidates.length - shown.length` | `counts down as the highlight walks off the bottom` |
| fixed `VISIBLE_ROWS` capacity | frames test at `rows=10` and `rows=8` only |
| the position in the help line | `says where in the list the highlight is` |

`pnpm build && pnpm typecheck && pnpm test` — 963 passed, 1 skipped. Changeset: `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)