### PR TITLE
feat(tui): say what the goal is, and what a long turn is doing

### DIFF
--- a/.changeset/lazy-cats-wonder.md
+++ b/.changeset/lazy-cats-wonder.md
@@ -1,0 +1,23 @@
+---
+"@riesbri/dsh-tui": minor
+---
+
+Say what the goal is, and what a long turn is doing.
+
+The goal segment read `goal 0/256` — a round cap the reader never chose, against a
+count that had not moved, for an objective it never named. It now leads with the
+objective (`goal armed · ship the release`) and reports the count only once a round
+has actually been taken. This matters because a goal is not always something the user
+set: the harness publishes `create_goal` as a model-callable tool and tells the model
+it may infer a long-running objective without being asked, so a session can acquire
+automatic continuation authority that was never typed. The status line is where that
+becomes visible, and it now says what it is.
+
+The objective is the one part of a mode that may be surrendered on its own as the
+terminal narrows — it is prose, so a shorter one is still true, where a shortened
+round count would be a different number. Everything else about the drop order is
+unchanged.
+
+The working segment also names the tool the turn is waiting on
+(`⠙ working 14m 26s · run_shell_command`). Elapsed time alone reads the same whether a
+command is running or the session has hung.

--- a/.changeset/lazy-cats-wonder.md
+++ b/.changeset/lazy-cats-wonder.md
@@ -19,5 +19,8 @@ round count would be a different number. Everything else about the drop order is
 unchanged.
 
 The working segment also names the tool the turn is waiting on
-(`⠙ working 14m 26s · run_shell_command`). Elapsed time alone reads the same whether a
-command is running or the session has hung.
+(`⠙ working 14m 26s · run_shell_command +2`). Elapsed time alone reads the same whether
+a command is running or the session has hung. The harness dispatches concurrency-safe
+calls in parallel, so the count says how many others are outstanding rather than
+naming one of them as though it were the only one. The elapsed time stays the turn's:
+nothing claims a duration for any single call, because the harness publishes none.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -241,8 +241,11 @@ conscious update or support decision.
   model to read; it does not attach its content.
 - **Tool calls are not reviewed by default.** The Harness deployment decides
   sandbox and approval policy; see [Usage → Permissions and the sandbox](docs/usage.md#permissions-and-the-sandbox).
-- **`/goal <objective>` starts an automatic run.** It is a Harness goal-driver
-  action; inspect or pause a goal before using it with care.
+- **A goal can start without a `/goal` command.** `/goal <objective>` starts a
+  Harness goal-driver run, and the harness also publishes `create_goal` as a
+  model-callable tool that may infer the intent from an ordinary request. Either
+  way the status line names the objective for as long as one is live; inspect or
+  pause a goal before leaving one running.
 - **One session at a time per window.** `/sessions` reopens a session in place
   rather than beside the current one; there are no tabs, split panes, or
   side-by-side agents.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,7 +116,9 @@ Every command prints its result into the transcript: a `·` line for normal outp
 The check uses the harness's own rule for what a command line looks like, so the name must either end the line or be followed by a space. This means `/etc/hosts is missing` is treated as an ordinary message and reaches the model unchanged, while `/tmp is full` is treated as a command and reported as unknown. That trade-off is deliberate: a mistyped command is far more common than a message starting with a folder name.
 
 > [!WARNING]
-> **`/goal <objective>` does more than record a goal.** It starts the harness's goal driver, which immediately begins working on that objective by itself, for up to 256 rounds, using tools in your folder. Use `/goal` with no text to just view the current goal, and `/goal pause` or `/goal clear` to stop one. Nothing warns you before it begins — but once it has, the status line says so for as long as it runs. See [What the session is about to do](#what-the-session-is-about-to-do).
+> **`/goal <objective>` does more than record a goal.** It starts the harness's goal driver, which immediately begins working on that objective by itself, for up to 256 rounds, using tools in your folder. Use `/goal` with no text to just view the current goal, and `/goal pause` or `/goal clear` to stop one. Nothing warns you before it begins — but once it has, the status line says so, by name, for as long as it runs.
+>
+> **A goal can also start without you.** The harness gives the model a `create_goal` tool and tells it that it may infer a long-running objective from what you asked, without you saying the word "goal". The status line is how you find out; `/goal` shows it in full and `/goal pause` stops it. See [What the session is about to do](#what-the-session-is-about-to-do).
 
 ### Connect
 
@@ -303,13 +305,18 @@ Two things change what a turn *does* rather than what it says, and both are invi
 | | |
 | --- | --- |
 | `plan` | Plan mode is in force. The agent will propose rather than act |
-| `goal 3/256` | A goal is running by itself: three rounds taken of a cap of 256 |
-| `goal 3/256 idle` | A goal is set, but this session will not continue it. `/goal resume` arms it |
+| `goal armed · ship the release` | A goal is set and will continue by itself. No round has been taken yet |
+| `goal 3/256 · ship the release` | Three rounds taken, of a cap of 256 |
+| `goal idle · ship the release` | A goal is set, but this session will not continue it. `/goal resume` arms it |
 | `goal paused`, `goal blocked`, `goal complete` | A goal that is not running, and why |
+
+The objective is there because **a goal is not always something you set.** The harness publishes `create_goal` as a tool the model itself may call, and its own description says the model may infer that a request is long-running without being asked to create anything. So a session can acquire the authority to keep going on its own, and the status line is where that becomes visible. `/goal` shows the whole objective; `/goal pause` stops it.
+
+`256` is the deployment's cap on automatic continuation rounds, not a target — which is why the count appears only once a round has actually been taken. `goal 0/256` reads as a meter stuck at zero; `goal armed` says the same thing truthfully.
 
 `idle` is what every **reopened** session shows for an active goal. Whether a process may continue a goal is deliberately not saved with the goal, so resuming a conversation does not restart a run you left — the goal is still there, and picking it up again is a thing you ask for.
 
-Neither is given up when the terminal narrows. They are dropped only after the model name, the totals, the bar and the context reading have gone, and a running goal is the very last thing to go — after the key hints. A mode is dropped whole rather than shortened: `goal 12/25` is not a smaller truth than `goal 12/256`, it is a different one.
+Neither mode is given up when the terminal narrows. They are dropped only after the model name, the totals, the bar and the context reading have gone, and a running goal is the very last thing to go — after the key hints. A mode is dropped whole rather than shortened: `goal 12/25` is not a smaller truth than `goal 12/256`, it is a different one. The objective is the one exception, and only because it is prose: a shortened objective is still an objective, so it is surrendered on its own before anything else about the goal is.
 
 ### Reasoning levels
 
@@ -362,6 +369,14 @@ This is worth knowing before you use `/model` to try something for one question,
 The two are independent, in that order: the running session switches first and is never rolled back, so if the settings file cannot be written you are told, and the turn you are about to run still uses the model you asked for.
 
 The whole selection is stored together — route and reasoning level — because the section holds one selection. Saving a level without its model would leave a level applying to whichever model the next session happened to open on.
+
+### While a turn is running
+
+```
+⠙ working 14m 26s · run_shell_command · x-preview-f-free · ↑2.3M ↓21k · ▌░░░░░░░ 68k/1.0M · goal armed · todo 5/11 · ctrl-c interrupt
+```
+
+Beside the elapsed time is the tool the turn is currently waiting on. A long turn with nothing named beside it reads the same whether a command is running or the session has stopped responding, so the name is the difference between waiting and worrying. It is the first thing given up when the terminal narrows.
 
 ### Tokens and cost
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -373,10 +373,14 @@ The whole selection is stored together — route and reasoning level — because
 ### While a turn is running
 
 ```
-⠙ working 14m 26s · run_shell_command · x-preview-f-free · ↑2.3M ↓21k · ▌░░░░░░░ 68k/1.0M · goal armed · todo 5/11 · ctrl-c interrupt
+⠙ working 14m 26s · run_shell_command +2 · x-preview-f-free · ↑2.3M ↓21k · ▌░░░░░░░ 68k/1.0M · goal armed · todo 5/11 · ctrl-c interrupt
 ```
 
-Beside the elapsed time is the tool the turn is currently waiting on. A long turn with nothing named beside it reads the same whether a command is running or the session has stopped responding, so the name is the difference between waiting and worrying. It is the first thing given up when the terminal narrows.
+Beside the elapsed time is the tool the turn is waiting on. A long turn with nothing named beside it reads the same whether a command is running or the session has stopped responding, so the name is the difference between waiting and worrying. It is the first thing given up when the terminal narrows.
+
+`+2` means two more tools are running alongside it — the harness dispatches calls that are safe to run together in parallel, so several can be outstanding at once. The name is the most recently started of them.
+
+The time is the **turn's**, not that tool's. Nothing here claims how long any one call has been running, because the harness does not publish that.
 
 ### Tokens and cost
 

--- a/packages/tui/src/attachment.ts
+++ b/packages/tui/src/attachment.ts
@@ -389,6 +389,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     busy: agent.status === 'running',
     tick,
     elapsedMs: turnStartedAt === undefined ? undefined : Date.now() - turnStartedAt,
+    activity: cards.inFlight(),
     model: selection.current?.model,
     effort: effortLabel(selection.current?.reasoningEffort, w.modelInfo.reasoning),
     usage: formatUsage(usage.reading, prefs.usageMode),

--- a/packages/tui/src/cards.ts
+++ b/packages/tui/src/cards.ts
@@ -285,6 +285,22 @@ export class ToolCards {
   }
 
   /**
+   * The tool call still waiting for its result, or nothing.
+   *
+   * Read by the status line so a long turn says what it is doing rather than only
+   * how long it has been doing it — the difference between a slow command and a
+   * hung session, which `working 14m 26s` alone cannot express. The NEWEST pending
+   * call is the answer because a card's result is drawn when it arrives, so the
+   * last one still outstanding is the one whose output has not appeared yet.
+   * @returns the tool's name, or undefined when nothing is outstanding.
+   */
+  inFlight(): string | undefined {
+    let latest: string | undefined
+    for (const call of this.pending.values()) latest = call.name
+    return latest
+  }
+
+  /**
    * Consume the pending inspect opportunity, clearing it.
    *
    * Inspection is one-shot: an unseen truncated result is offered once by Ctrl+O,

--- a/packages/tui/src/cards.ts
+++ b/packages/tui/src/cards.ts
@@ -286,19 +286,25 @@ export class ToolCards {
   }
 
   /**
-   * The tool call still waiting for its result, or nothing.
+   * The tool calls still waiting for their results, or nothing.
    *
    * Read by the status line so a long turn says what it is doing rather than only
    * how long it has been doing it — the difference between a slow command and a
-   * hung session, which `working 14m 26s` alone cannot express. The NEWEST pending
-   * call is the answer because a card's result is drawn when it arrives, so the
-   * last one still outstanding is the one whose output has not appeared yet.
-   * @returns the tool's name, or undefined when nothing is outstanding.
+   * hung session, which `working 14m 26s` alone cannot express.
+   *
+   * Reported as a name AND a count because the harness runs concurrency-safe
+   * calls in parallel: several are legitimately outstanding at once, and naming
+   * one of them alone would say a batch of six is a single tool. `latest` is the
+   * most recently started, which is the only ordering a `Map` of pending calls
+   * can honestly claim — the harness publishes no per-call progress or duration,
+   * and this must not invent either.
+   * @returns the newest pending call's name and how many others are outstanding,
+   *   or undefined when nothing is.
    */
-  inFlight(): string | undefined {
+  inFlight(): { name: string; others: number } | undefined {
     let latest: string | undefined
     for (const call of this.pending.values()) latest = call.name
-    return latest
+    return latest === undefined ? undefined : { name: latest, others: this.pending.size - 1 }
   }
 
   /**

--- a/packages/tui/src/modes.ts
+++ b/packages/tui/src/modes.ts
@@ -19,11 +19,26 @@
 
 import type { GoalView } from '@deepseek-ai/dsh-goal'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { displayWidth, escapeControls, truncateToWidth } from '@riesbri/dsh-tui-renderer'
 
-/** Rounds a goal has taken, and whether anything is about to take another. */
+/**
+ * Columns an objective may occupy in the status line.
+ *
+ * Cut here rather than in the status line, which drops whole segments and never
+ * shortens one. An objective is prose a model wrote, so unlike a round count it
+ * has no length worth respecting and no smaller true form to fall back to — a
+ * shortened one is still an objective, where `goal 12/25` is a different fact
+ * from `goal 12/256`. Wide enough for a recognizable phrase, narrow enough that
+ * an eighty-column terminal still has room for the context reading.
+ */
+const OBJECTIVE_COLUMNS = 28
+
+/** What a goal is, how far in it is, and whether anything will continue it. */
 export interface GoalReading {
-  /** The text for the status line. */
+  /** The full text for the status line: the state, and what the goal is. */
   label: string
+  /** The state alone, for a terminal that cannot hold the objective. */
+  short: string
   /** Whether this session will continue the goal by itself. */
   running: boolean
 }
@@ -45,22 +60,55 @@ export function planModeAfter(active: boolean, event: SessionEvent): boolean {
 /**
  * How the status line reports a goal, or nothing when there is none.
  *
- * The count is shown while the goal is live, because "how far through" is the
- * question someone asks about a run they did not watch start. A phase that is
- * not `active` replaces it: the round number of a paused goal is history, not
- * progress.
+ * The OBJECTIVE leads the reading, because the first question about a goal is
+ * what it is — and a goal is not always something the reader set. The harness's
+ * `create_goal` tool is model-callable and documents that the model may infer the
+ * intent without being asked, so a session can acquire automatic continuation
+ * authority that was never typed. The round count is what says so; the objective
+ * is what makes that legible.
  *
- * `idle` marks the case the round count alone would misrepresent — a goal that
- * is durably active while this process holds no authority to continue it, which
- * is what every reopened session starts as. It reads as a goal that is set and
- * going nowhere, which is what it is.
+ * The count appears only once a round has been taken. Before then it is
+ * `roundsStarted` against a deployment's cap — `0/256` — which reads as a meter
+ * stuck at zero when it is really a safety limit that has not been approached.
+ * `armed` says the same thing in the words that are true.
+ *
+ * A phase that is not `active` replaces the count: the round number of a paused
+ * goal is history, not progress. `idle` marks the case the count alone would
+ * misrepresent — a goal that is durably active while this process holds no
+ * authority to continue it, which is what every reopened session starts as. It
+ * reads as a goal that is set and going nowhere, which is what it is.
  * @param goal - the service's view of the current goal, when there is one.
  * @returns the reading, or undefined when nothing is worth reporting.
  */
 export function goalReading(goal: GoalView | undefined): GoalReading | undefined {
   if (goal === undefined) return undefined
-  const rounds = `${String(goal.roundsStarted)}/${String(goal.maxGoalRounds)}`
-  if (goal.phase !== 'active') return { label: `goal ${goal.phase}`, running: false }
-  const running = goal.activation === 'armed'
-  return { label: running ? `goal ${rounds}` : `goal ${rounds} idle`, running }
+  const state = goal.phase !== 'active'
+    ? goal.phase
+    : goal.activation !== 'armed'
+      ? 'idle'
+      : goal.roundsStarted > 0 ? `${String(goal.roundsStarted)}/${String(goal.maxGoalRounds)}` : 'armed'
+  const short = `goal ${state}`
+  // An objective is untrusted text: the model writes it, and it reaches the
+  // terminal. Escaped before it is measured, so the cut and the width agree.
+  const objective = elide(escapeControls(goal.objective), OBJECTIVE_COLUMNS)
+  return {
+    label: objective === '' ? short : `${short} \u00b7 ${objective}`,
+    short,
+    running: goal.phase === 'active' && goal.activation === 'armed',
+  }
+}
+
+/**
+ * Fit text to a column budget, marking a cut with an ellipsis.
+ *
+ * `truncateToWidth` alone cuts silently, and a silently cut objective reads as a
+ * complete one — "migrate every call site off" is a plausible whole sentence and
+ * a wrong summary of what the goal actually says.
+ * @param text - the already-escaped text.
+ * @param columns - the budget, ellipsis included.
+ * @returns the text, or a cut form ending in an ellipsis.
+ */
+function elide(text: string, columns: number): string {
+  if (displayWidth(text) <= columns) return text.trimEnd()
+  return `${truncateToWidth(text, columns - 1).trimEnd()}\u2026`
 }

--- a/packages/tui/src/views.ts
+++ b/packages/tui/src/views.ts
@@ -34,8 +34,11 @@ export interface StatusState {
   tick: number
   /** Milliseconds since the current turn started, or undefined when idle. */
   elapsedMs: number | undefined
-  /** The tool call still awaiting a result, when one is outstanding. */
-  activity: string | undefined
+  /**
+   * The tool calls still awaiting results, when any are outstanding: the newest
+   * one's name, and how many others are running beside it.
+   */
+  activity: { name: string; others: number } | undefined
   /** Model id alone; the provider route is in the banner. */
   model: string | undefined
   /** Reasoning level, only when it differs from the route's default. */
@@ -315,8 +318,17 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
       // is running or the session has hung. First of the droppable facts, because
       // it is a convenience reading like `todo` and `work` — it says nothing the
       // transcript above will not eventually say.
+      //
+      // Its own segment rather than part of the timer, because the elapsed time is
+      // the TURN's and not this call's: the harness publishes no per-call duration,
+      // and `working 14m 26s run_shell_command` would claim one. `+2` counts the
+      // other calls running in parallel — naming one of six would be a smaller
+      // number of tools, not a shorter way of saying six.
       const activity = current.busy && current.activity !== undefined
-        ? style(escapeControls(current.activity), 'dim')
+        ? style(
+          `${escapeControls(current.activity.name)}${current.activity.others > 0 ? ` +${String(current.activity.others)}` : ''}`,
+          'dim',
+        )
         : undefined
       const model = current.model === undefined
         ? undefined

--- a/packages/tui/src/views.ts
+++ b/packages/tui/src/views.ts
@@ -14,6 +14,7 @@ import {
   box,
   chunkToWidth,
   displayWidth,
+  escapeControls,
   formatElapsed,
   formatTokens,
   layoutComposer,
@@ -33,6 +34,8 @@ export interface StatusState {
   tick: number
   /** Milliseconds since the current turn started, or undefined when idle. */
   elapsedMs: number | undefined
+  /** The tool call still awaiting a result, when one is outstanding. */
+  activity: string | undefined
   /** Model id alone; the provider route is in the banner. */
   model: string | undefined
   /** Reasoning level, only when it differs from the route's default. */
@@ -56,8 +59,11 @@ export interface StatusState {
   todo: string | undefined
   /** Whether plan mode is in force, so the agent will propose rather than act. */
   plan: boolean
-  /** A goal to report, already worded; `running` decides how loudly. */
-  goal: { label: string; running: boolean } | undefined
+  /**
+   * A goal to report, already worded. `running` decides how loudly, and `short`
+   * is the same fact without the objective, for a terminal that cannot hold it.
+   */
+  goal: { label: string; short: string; running: boolean } | undefined
 }
 
 /** The composer's prompt, inside the frame. */
@@ -304,6 +310,14 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
       // dropped. The effort rides WITH the model rather than beside it: it
       // qualifies that name, and a level left on screen after the model it
       // applied to was dropped would read as belonging to whatever came next.
+      // What a turn is DOING, beside how long it has been doing it. A fourteen
+      // minute `working` with nothing beside it reads the same whether a command
+      // is running or the session has hung. First of the droppable facts, because
+      // it is a convenience reading like `todo` and `work` — it says nothing the
+      // transcript above will not eventually say.
+      const activity = current.busy && current.activity !== undefined
+        ? style(escapeControls(current.activity), 'dim')
+        : undefined
       const model = current.model === undefined
         ? undefined
         : style(current.effort === undefined ? current.model : `${current.model} (${current.effort})`, 'dim')
@@ -333,9 +347,14 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
       // exists to prevent. A goal that will continue by itself is coloured like
       // the working spinner, because that is what it is.
       const plan = current.plan ? style('plan', 'cyan') : undefined
-      const goal = current.goal === undefined
-        ? undefined
-        : style(current.goal.label, current.goal.running ? 'yellow' : 'dim')
+      const goalStyle = (text: string): string =>
+        style(text, current.goal?.running === true ? 'yellow' : 'dim')
+      const goal = current.goal === undefined ? undefined : goalStyle(current.goal.label)
+      // The objective is the only part of a mode that MAY be given up separately,
+      // because it is the only part that is prose rather than a fact with a
+      // smaller false form. Dropping it leaves `goal 3/256`, which is true;
+      // shortening `3/256` would not be.
+      const goalShort = current.goal === undefined ? undefined : goalStyle(current.goal.short)
 
       // Hints are dropped WHOLE when the width runs out. Truncating the joined line
       // instead cut one in half — `ctrl-d qui` — which reads as a rendering fault
@@ -369,12 +388,14 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
       // same rule the hints follow — a reading cut to `14k/1.0` reads as a rendering
       // fault, not as a number.
       const status = facts[0] ?? ''
+      const doing = activity === undefined ? [] : [activity]
       const named = model === undefined ? [] : [model]
       const spent = usage === undefined ? [] : [usage]
       const bar = readingWithBar === undefined ? [] : [readingWithBar]
       const plain = reading === undefined ? [] : [reading]
       const planned = plan === undefined ? [] : [plan]
       const goalled = goal === undefined ? [] : [goal]
+      const goalBare = goalShort === undefined ? [] : [goalShort]
       const tooled = detail === undefined ? [] : [detail]
       const todoed = todo === undefined ? [] : [todo]
       const worked = work === undefined ? [] : [work]
@@ -392,10 +413,12 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
         [...planned, ...goalled, ...worked, ...todoed],
         [...planned, ...goalled, ...worked],
         [...planned, ...goalled],
-        [...goalled],
+        [...planned, ...goalBare],
+        [...goalBare],
         [],
       ]
       const bodies = [
+        [status, ...doing, ...named, ...spent, ...bar],
         [status, ...named, ...spent, ...bar],
         [status, ...named, ...spent, ...plain],
         [status, ...spent, ...plain],

--- a/packages/tui/tests/cards.spec.ts
+++ b/packages/tui/tests/cards.spec.ts
@@ -531,19 +531,49 @@ describe('review findings', () => {
   })
 })
 
-describe('the call a turn is waiting on', () => {
-  it('names the newest call with no result yet, and nothing once it lands', () => {
+describe('the calls a turn is waiting on', () => {
+  it('names the newest call, and nothing once every one has landed', () => {
     const cards = new ToolCards(bare, '/w')
     expect(cards.inFlight()).toBeUndefined()
     cards.call({ callId: 'c1', name: 'read_file', arguments: '{}' }, COLUMNS)
-    expect(cards.inFlight()).toBe('read_file')
-    // The newest outstanding call, not the oldest: a result is drawn as it
-    // arrives, so the last one still pending is the one nothing has shown yet.
-    cards.call({ callId: 'c2', name: 'run_shell_command', arguments: '{}' }, COLUMNS)
-    expect(cards.inFlight()).toBe('run_shell_command')
-    cards.result(result('', { callId: 'c2' }), COLUMNS)
-    expect(cards.inFlight()).toBe('read_file')
+    expect(cards.inFlight()).toEqual({ name: 'read_file', others: 0 })
     cards.result(result('', { callId: 'c1' }), COLUMNS)
+    expect(cards.inFlight()).toBeUndefined()
+  })
+
+  it('counts the calls running beside it, because the harness runs them in parallel', () => {
+    // Concurrency-safe calls are dispatched together, so several are legitimately
+    // outstanding. Naming one of six would report a different number of tools.
+    const cards = new ToolCards(bare, '/w')
+    for (const [id, name] of [['c1', 'read_file'], ['c2', 'grep'], ['c3', 'run_shell_command']] as const) {
+      cards.call({ callId: id, name, arguments: '{}' }, COLUMNS)
+    }
+    expect(cards.inFlight()).toEqual({ name: 'run_shell_command', others: 2 })
+  })
+
+  it('follows the count down whichever order the results arrive in', () => {
+    // Parallel calls finish out of order by definition, and the newest pending is
+    // whatever is left — not whatever was dispatched last.
+    const cards = new ToolCards(bare, '/w')
+    for (const [id, name] of [['c1', 'read_file'], ['c2', 'grep'], ['c3', 'run_shell_command']] as const) {
+      cards.call({ callId: id, name, arguments: '{}' }, COLUMNS)
+    }
+    // Newest first: the name changes, the count drops.
+    cards.result(result('', { callId: 'c3' }), COLUMNS)
+    expect(cards.inFlight()).toEqual({ name: 'grep', others: 1 })
+    // Oldest next: the name stays, the count drops.
+    cards.result(result('', { callId: 'c1' }), COLUMNS)
+    expect(cards.inFlight()).toEqual({ name: 'grep', others: 0 })
+    cards.result(result('', { callId: 'c2' }), COLUMNS)
+    expect(cards.inFlight()).toBeUndefined()
+  })
+
+  it('forgets calls a cancelled turn never resolved', () => {
+    // ctrl-c leaves a dispatched call with no result. Left pending, it would be
+    // reported as running through every turn that followed.
+    const cards = new ToolCards(bare, '/w')
+    cards.call({ callId: 'c1', name: 'run_shell_command', arguments: '{}' }, COLUMNS)
+    cards.reset()
     expect(cards.inFlight()).toBeUndefined()
   })
 })

--- a/packages/tui/tests/cards.spec.ts
+++ b/packages/tui/tests/cards.spec.ts
@@ -531,6 +531,23 @@ describe('review findings', () => {
   })
 })
 
+describe('the call a turn is waiting on', () => {
+  it('names the newest call with no result yet, and nothing once it lands', () => {
+    const cards = new ToolCards(bare, '/w')
+    expect(cards.inFlight()).toBeUndefined()
+    cards.call({ callId: 'c1', name: 'read_file', arguments: '{}' }, COLUMNS)
+    expect(cards.inFlight()).toBe('read_file')
+    // The newest outstanding call, not the oldest: a result is drawn as it
+    // arrives, so the last one still pending is the one nothing has shown yet.
+    cards.call({ callId: 'c2', name: 'run_shell_command', arguments: '{}' }, COLUMNS)
+    expect(cards.inFlight()).toBe('run_shell_command')
+    cards.result(result('', { callId: 'c2' }), COLUMNS)
+    expect(cards.inFlight()).toBe('read_file')
+    cards.result(result('', { callId: 'c1' }), COLUMNS)
+    expect(cards.inFlight()).toBeUndefined()
+  })
+})
+
 describe('the tool inspector', () => {
   /** A ToolCards that has drawn one completed result, returning both. */
   function completed(

--- a/packages/tui/tests/modes.spec.ts
+++ b/packages/tui/tests/modes.spec.ts
@@ -74,9 +74,19 @@ describe('goalReading()', () => {
     expect(goalReading(undefined)).toBeUndefined()
   })
 
-  it('counts the rounds while the goal is running', () => {
-    // "How far through" is the question about a run nobody watched start.
-    expect(goalReading(view({}))).toEqual({ label: 'goal 3/256', running: true })
+  it('counts the rounds while the goal is running, and says what it is', () => {
+    // "How far through" is the question about a run nobody watched start, and
+    // "what is it" is the question about a goal nobody set — which happens, since
+    // the harness's create_goal tool is model-callable.
+    expect(goalReading(view({}))).toEqual({ label: 'goal 3/256 · ship it', short: 'goal 3/256', running: true })
+  })
+
+  it('says armed rather than nought of a cap no round has approached', () => {
+    // `goal 0/256` reads as a progress meter stuck at zero. It is not progress at
+    // all: 256 is the deployment's round cap, and nothing has been spent against
+    // it. The count earns its place once there is a count to report.
+    expect(goalReading(view({ roundsStarted: 0 })))
+      .toEqual({ label: 'goal armed · ship it', short: 'goal armed', running: true })
   })
 
   it('marks a goal that is set but will not continue on its own', () => {
@@ -84,14 +94,26 @@ describe('goalReading()', () => {
     // persisted, so a resumed log holding an active goal is not a session about
     // to run one. The round count alone would say otherwise.
     expect(goalReading(view({ activation: 'disarmed' })))
-      .toEqual({ label: 'goal 3/256 idle', running: false })
+      .toEqual({ label: 'goal idle · ship it', short: 'goal idle', running: false })
   })
 
   it('replaces the count with the phase once the goal is not active', () => {
     // The round number of a paused goal is history, not progress.
     for (const phase of ['paused', 'blocked', 'complete'] as const) {
-      expect(goalReading(view({ phase })), phase).toEqual({ label: `goal ${phase}`, running: false })
+      expect(goalReading(view({ phase })), phase)
+        .toEqual({ label: `goal ${phase} · ship it`, short: `goal ${phase}`, running: false })
     }
+  })
+
+  it('bounds a long objective itself, so the status line never has to cut one', () => {
+    const long = goalReading(view({ objective: 'migrate every call site off the deprecated adapter' }))
+    expect(long?.label).toBe('goal 3/256 · migrate every call site off…')
+    expect(long?.short).toBe('goal 3/256')
+  })
+
+  it('shows an escape sequence in an objective instead of obeying it', () => {
+    // A model writes the objective and it reaches the terminal on every frame.
+    expect(goalReading(view({ objective: 'ship\u001b[2Jit' }))?.label).toContain('^[[2J')
   })
 
   it('never calls a goal running unless it is both active and armed', () => {

--- a/packages/tui/tests/status-frames.spec.ts
+++ b/packages/tui/tests/status-frames.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * What the status line actually says as a terminal narrows.
+ *
+ * The composition rules are three nested preferences deep, and a string
+ * assertion at one width proves nothing about the width either side of it. The
+ * failure worth catching is a segment that survives in HALF — a cut round count
+ * or a cut objective reads as a different fact, not as a smaller one — so this
+ * resizes across the range a real window is dragged through and reads the cells.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Screen } from '@riesbri/dsh-tui-renderer'
+import { createEmulator } from '../../../tests/emulator.ts'
+import type { StatusState } from '../src/views.ts'
+import { createStatusView } from '../src/views.ts'
+
+/** A session with every mode reporting at once, which is the crowded case. */
+const CROWDED: StatusState = {
+  busy: true,
+  tick: 0,
+  elapsedMs: 866_000,
+  activity: 'run_shell_command',
+  model: 'x-preview-f-free',
+  effort: undefined,
+  usage: '↑2.3M ↓21k',
+  tokens: 68_000,
+  contextWindow: 1_000_000,
+  detail: 'compact',
+  work: undefined,
+  todo: 'todo 5/11',
+  plan: false,
+  goal: { label: 'goal armed · ship the release', short: 'goal armed', running: true },
+}
+
+/**
+ * Draw the status line on a real terminal and read the row back.
+ * @param columns - the terminal width.
+ * @returns the visible status row.
+ */
+async function row(columns: number): Promise<string> {
+  const emulator = createEmulator(columns, 24)
+  new Screen(emulator.target).setLive(createStatusView(() => CROWDED).render(columns))
+  return (await emulator.screen()).map(line => line.trimEnd()).find(line => line !== '') ?? ''
+}
+
+describe('the status line on a real terminal', () => {
+  it('never wraps onto a second row, at any width', async () => {
+    for (const columns of [20, 30, 40, 50, 60, 72, 80, 100, 120, 160]) {
+      const emulator = createEmulator(columns, 24)
+      new Screen(emulator.target).setLive(createStatusView(() => CROWDED).render(columns))
+      const drawn = (await emulator.screen()).map(line => line.trimEnd()).filter(line => line !== '')
+      expect(drawn.length, `${String(columns)} columns: ${JSON.stringify(drawn)}`).toBe(1)
+    }
+  })
+
+  it('never leaves half a mode on the line', async () => {
+    for (const columns of [20, 26, 30, 34, 40, 46, 52, 58, 64, 72, 80, 100, 120]) {
+      const line = await row(columns)
+      // Either the whole objective or none of it; either `goal armed` or no goal.
+      const halfObjective = line.includes('ship') && !line.includes('ship the release')
+      const halfGoal = /goal(?! armed)\S*\s*$/u.test(line)
+      const halfTodo = line.includes('todo') && !line.includes('todo 5/11')
+      expect(halfObjective || halfGoal || halfTodo, `${String(columns)} columns: ${JSON.stringify(line)}`)
+        .toBe(false)
+    }
+  })
+
+  it('gives things up in the documented order as the window shrinks', async () => {
+    // Widest: everything, objective included.
+    expect(await row(120)).toContain('ship the release')
+    // The objective goes before the goal does.
+    const middle = await row(60)
+    expect(middle).toContain('goal armed')
+    expect(middle).not.toContain('ship the release')
+    // The goal outlives the model name and the session totals both.
+    const narrow = await row(44)
+    expect(narrow).toContain('goal armed')
+    expect(narrow).not.toContain('x-preview-f-free')
+    expect(narrow).not.toContain('2.3M')
+  })
+})

--- a/packages/tui/tests/status-frames.spec.ts
+++ b/packages/tui/tests/status-frames.spec.ts
@@ -19,7 +19,7 @@ const CROWDED: StatusState = {
   busy: true,
   tick: 0,
   elapsedMs: 866_000,
-  activity: 'run_shell_command',
+  activity: { name: 'run_shell_command', others: 2 },
   model: 'x-preview-f-free',
   effort: undefined,
   usage: '↑2.3M ↓21k',

--- a/packages/tui/tests/views.spec.ts
+++ b/packages/tui/tests/views.spec.ts
@@ -197,6 +197,7 @@ describe('the status line', () => {
       busy: false,
       tick: 0,
       elapsedMs: undefined,
+      activity: undefined,
       model: 'deepseek-v4-flash',
       effort: undefined,
       usage: undefined,
@@ -388,7 +389,7 @@ describe('the status line', () => {
   })
 
   it('says when a goal is taking rounds on its own', () => {
-    expect(status({ goal: { label: 'goal 3/256', running: true } })).toContain('goal 3/256')
+    expect(status({ goal: { label: 'goal 3/256', short: 'goal 3/256', running: true } })).toContain('goal 3/256')
     expect(status()).not.toContain('goal')
   })
 
@@ -397,7 +398,7 @@ describe('the status line', () => {
     // and which model it is on, and both are absent in the ordinary case anyway.
     const line = status({
       plan: true,
-      goal: { label: 'goal 3/256', running: true },
+      goal: { label: 'goal 3/256', short: 'goal 3/256', running: true },
       usage: '\u2191130k \u219312.4k $1.24',
       tokens: 130_000,
       contextWindow: 1_000_000,
@@ -411,7 +412,7 @@ describe('the status line', () => {
   it('keeps a running goal in preference to a hint', () => {
     // The hint reservation exists so a richer READING cannot crowd out help. It
     // must not outrank what the session is about to do on its own.
-    const line = status({ goal: { label: 'goal 12/256', running: true }, tokens: 14_000 }, 40)
+    const line = status({ goal: { label: 'goal 12/256', short: 'goal 12/256', running: true }, tokens: 14_000 }, 40)
     expect(line).toContain('goal 12/256')
     expect(line).not.toContain('alt-enter')
   })
@@ -422,7 +423,7 @@ describe('the status line', () => {
     for (const columns of [20, 24, 30, 36, 40, 44, 50, 60, 70, 80, 100]) {
       const line = status({
         plan: true,
-        goal: { label: 'goal 12/256', running: true },
+        goal: { label: 'goal 12/256', short: 'goal 12/256', running: true },
         usage: '\u2191130k \u219312.4k $1.24',
         tokens: 130_000,
         contextWindow: 1_000_000,
@@ -432,12 +433,74 @@ describe('the status line', () => {
     }
   })
 
+  it('gives up a goal\'s objective before the goal itself', () => {
+    // The objective is the one part of a mode that may be surrendered separately,
+    // because it is prose: a shortened objective is still an objective, where a
+    // shortened round count is a different number. So it goes before `plan` does,
+    // and long before the goal it describes.
+    const state = {
+      plan: true,
+      goal: { label: 'goal 3/256 · ship the release', short: 'goal 3/256', running: true },
+      tokens: 130_000,
+      contextWindow: 1_000_000,
+    }
+    expect(status(state, 100)).toContain('goal 3/256 · ship the release')
+    const narrow = status(state, 52)
+    expect(narrow).toContain('goal 3/256')
+    expect(narrow).not.toContain('ship the release')
+    expect(narrow).toContain('plan')
+    // And the bare goal still outlives plan mode, as it always did.
+    const narrower = status(state, 34)
+    expect(narrower).toContain('goal 3/256')
+    expect(narrower).not.toContain('plan')
+  })
+
+  it('never leaves half an objective on the line', () => {
+    // The whole reason the objective is bounded inside `goalReading` rather than
+    // here: this function drops segments, it does not shorten them.
+    const state = {
+      goal: { label: 'goal 3/256 · ship the release', short: 'goal 3/256', running: true },
+      tokens: 130_000,
+      contextWindow: 1_000_000,
+    }
+    for (const columns of [20, 24, 30, 36, 40, 46, 52, 60, 70, 80, 100, 120]) {
+      const line = status(state, columns)
+      const half = line.includes('ship') && !line.includes('ship the release')
+      expect(half, `${String(columns)} columns ended on ${JSON.stringify(line)}`).toBe(false)
+    }
+  })
+
+  it('names the tool a long turn is waiting on', () => {
+    // `working 14m 26s` alone reads the same whether a command is running or the
+    // session has hung.
+    const busy = status({ busy: true, elapsedMs: 866_000, activity: 'run_shell_command' })
+    expect(busy).toContain('working')
+    expect(busy).toContain('run_shell_command')
+    // Idle has nothing outstanding to name, whatever the last call was.
+    expect(status({ activity: 'run_shell_command' })).not.toContain('run_shell_command')
+    // And it is the first fact given up: a convenience reading, like todo and work.
+    const narrow = status({
+      busy: true,
+      elapsedMs: 866_000,
+      activity: 'run_shell_command',
+      tokens: 130_000,
+      contextWindow: 1_000_000,
+    }, 50)
+    expect(narrow).not.toContain('run_shell_command')
+    expect(narrow).toContain('130k/1.0M')
+  })
+
+  it('shows an escape sequence in a tool name instead of obeying it', () => {
+    // A tool name comes from the harness registry, which a plugin writes.
+    expect(status({ busy: true, elapsedMs: 4_000, activity: 'evil\u001b[2Jtool' })).toContain('^[[2J')
+  })
+
   it('drops a display preference before a mode that changes behaviour', () => {
     // At 56 columns all three fit; at 50 the display preference is the one that
     // goes, and both behaviour modes stay.
     const state = {
       plan: true,
-      goal: { label: 'goal 12/256', running: true },
+      goal: { label: 'goal 12/256', short: 'goal 12/256', running: true },
       detail: 'full' as const,
       tokens: 130_000,
       contextWindow: 1_000_000,
@@ -453,7 +516,7 @@ describe('the status line', () => {
     for (const columns of [20, 30, 40, 60, 80, 96, 120, 200]) {
       const line = status({
         plan: true,
-        goal: { label: 'goal 128/256 idle', running: false },
+        goal: { label: 'goal 128/256 idle', short: 'goal 128/256 idle', running: false },
         detail: 'full',
         effort: 'max',
         usage: '\u2191130k \u219312.4k $1.24',
@@ -494,7 +557,7 @@ describe('the status line', () => {
       todo: 'todo 2/5',
       work: '2 agents · 1 job',
       plan: true,
-      goal: { label: 'goal 12/256', running: true },
+      goal: { label: 'goal 12/256', short: 'goal 12/256', running: true },
       tokens: 130_000,
       contextWindow: 1_000_000,
     }
@@ -515,7 +578,7 @@ describe('the status line', () => {
     const state = {
       work: '2 agents · 1 job',
       plan: true,
-      goal: { label: 'goal 12/256', running: true },
+      goal: { label: 'goal 12/256', short: 'goal 12/256', running: true },
       tokens: 130_000,
       contextWindow: 1_000_000,
     }
@@ -530,7 +593,7 @@ describe('the status line', () => {
       const line = status({
         work: '2 agents · 1 job',
         plan: true,
-        goal: { label: 'goal 12/256', running: true },
+        goal: { label: 'goal 12/256', short: 'goal 12/256', running: true },
         tokens: 130_000,
         contextWindow: 1_000_000,
       }, columns)

--- a/packages/tui/tests/views.spec.ts
+++ b/packages/tui/tests/views.spec.ts
@@ -473,16 +473,19 @@ describe('the status line', () => {
   it('names the tool a long turn is waiting on', () => {
     // `working 14m 26s` alone reads the same whether a command is running or the
     // session has hung.
-    const busy = status({ busy: true, elapsedMs: 866_000, activity: 'run_shell_command' })
+    const busy = status({ busy: true, elapsedMs: 866_000, activity: { name: 'run_shell_command', others: 0 } })
     expect(busy).toContain('working')
     expect(busy).toContain('run_shell_command')
+    // Its own segment, not glued to the timer: the elapsed time is the TURN's,
+    // and the harness publishes no duration for one call.
+    expect(busy).toContain('14m 26s \u00b7 run_shell_command')
     // Idle has nothing outstanding to name, whatever the last call was.
-    expect(status({ activity: 'run_shell_command' })).not.toContain('run_shell_command')
+    expect(status({ activity: { name: 'run_shell_command', others: 0 } })).not.toContain('run_shell_command')
     // And it is the first fact given up: a convenience reading, like todo and work.
     const narrow = status({
       busy: true,
       elapsedMs: 866_000,
-      activity: 'run_shell_command',
+      activity: { name: 'run_shell_command', others: 0 },
       tokens: 130_000,
       contextWindow: 1_000_000,
     }, 50)
@@ -490,9 +493,20 @@ describe('the status line', () => {
     expect(narrow).toContain('130k/1.0M')
   })
 
+  it('counts the tools running in parallel beside the one it names', () => {
+    // The harness dispatches concurrency-safe calls together. `grep` alone would
+    // report one tool running where three are.
+    expect(status({ busy: true, elapsedMs: 4_000, activity: { name: 'grep', others: 2 } }))
+      .toContain('grep +2')
+    // One call is the common case and carries no count at all.
+    expect(status({ busy: true, elapsedMs: 4_000, activity: { name: 'grep', others: 0 } }))
+      .not.toContain('grep +')
+  })
+
   it('shows an escape sequence in a tool name instead of obeying it', () => {
     // A tool name comes from the harness registry, which a plugin writes.
-    expect(status({ busy: true, elapsedMs: 4_000, activity: 'evil\u001b[2Jtool' })).toContain('^[[2J')
+    expect(status({ busy: true, elapsedMs: 4_000, activity: { name: 'evil\u001b[2Jtool', others: 0 } }))
+      .toContain('^[[2J')
   })
 
   it('drops a display preference before a mode that changes behaviour', () => {


### PR DESCRIPTION
> **Stacked on #63.** Base is `feat/tool-output-reachability`; both touch `views.ts`. Retarget to `main` once #63 lands.

## What a person saw

```
  ⠙ working 14m 26s · x-preview-f-free · ↑2.3M ↓21k · ▌░░░░░░░ 68k/1.0M · goal 0/256 · todo 5/11 · ctrl-c interrupt
```

Two questions: *why is there a goal — I never ran `/goal`?* and *why has it been 0/256 for fourteen minutes?*

## The investigation

Not a rendering bug. `ctx.goals.get(agent)` returns `undefined` when no goal exists (`dsh-goal/lib/index.js:796-810`), so the segment was telling the truth. The goal was created by the **model**: the harness publishes `create_goal` as a model-callable tool (`@deepseek-ai/dsh-tool-goal`, mounted by `@deepseek-ai/dsh-base`) whose own description reads

> "Create one persisted same-session completion goal when the current direct human request is a long-running objective… **You may infer that intent without requiring the user to say 'create a goal'.**"

So a session can acquire automatic continuation authority nobody typed, and this segment is the only standing signal that it did. That makes it the wrong thing to have been showing: `256` is the deployment's round cap (`defaultMaxGoalRounds`), `0` is `roundsStarted`, and the objective — the first question about a goal you did not set — was nowhere.

## The change

| Before | After |
| --- | --- |
| `goal 0/256` | `goal armed · ship the release` |
| `goal 3/256` | `goal 3/256 · ship the release` |
| `goal 3/256 idle` | `goal idle · ship the release` |
| `goal paused` | `goal paused · ship the release` |

The count appears only once a round has been taken; before that `armed` says the same thing in words that are true, where `0/256` reads as a meter stuck at zero.

## Keeping AGENTS.md §9 intact

An objective is prose, and prose does not fit *"a mode is dropped whole rather than shortened"*. Hence two labels rather than one: dropping the objective leaves `goal 3/256`, which is still true, where shortening `3/256` would be a different number. That is one extra rung in the `tails` ladder, placed so the objective goes before `plan` and long before the goal itself. Bounding the objective's own width happens in `modes.ts`, not `views.ts`, so the composition function still has no way to cut anything.

## Also: what the fourteen minutes were spent on

```
  ⠙ working 14m 26s · run_shell_command · x-preview-f-free · …
```

`ToolCards` already knows — `pending` holds every call awaiting a result — so `inFlight()` returns the newest and it sits beside the timer. Elapsed time alone reads identically whether a command is running or the session has hung. It is the first fact surrendered when the line runs out, being a convenience reading like `todo` and `work`.

## Tests

Both the objective and the tool name are untrusted text reaching the terminal on every frame; both are escaped and both have a test. `status-frames.spec.ts` is new — it resizes across thirteen widths on a real emulator and asserts nothing ever survives in half.

Broken on purpose, each separately:

| Reverted | Caught by |
| --- | --- |
| `armed` → `0/256`, objective dropped | `says armed rather than nought of a cap no round has approached` |
| the objective ladder rung | `gives up a goal's objective before the goal itself` |
| `activity` from the body ladder | `names the tool a long turn is waiting on` |

`pnpm build && pnpm typecheck && pnpm test` — 972 passed, 1 skipped. Changeset: `minor`.

Docs: `docs/usage.md` gains the new goal wording, a **While a turn is running** section, and an explicit note that a goal can start without you; the `/goal` warning callout and the `ROADMAP.md` limitation both say so too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)