### PR TITLE
feat(dshline): keep turn timing live

### DIFF
--- a/.changeset/red-cups-move.md
+++ b/.changeset/red-cups-move.md
@@ -1,0 +1,5 @@
+---
+"@dshline/dshline": minor
+---
+
+Replace post-turn timing dumps with a bounded live panel that tracks active turns and tools in real time.

--- a/docs/design.md
+++ b/docs/design.md
@@ -16,7 +16,7 @@ How this interface is built, and the reason behind each decision. Every heading 
 - [The status line drops details instead of cutting them](#the-status-line-drops-details-instead-of-cutting-them)
 - [Prices are shipped, and every one of them is wrong eventually](#prices-are-shipped-and-every-one-of-them-is-wrong-eventually)
 - [A command that takes a value offers its values](#a-command-that-takes-a-value-offers-its-values)
-- [The profiler does not claim the parts add up](#the-profiler-does-not-claim-the-parts-add-up)
+- [The profiler stays live without inventing history](#the-profiler-stays-live-without-inventing-history)
 - [Character widths follow the Unicode standard](#character-widths-follow-the-unicode-standard)
 - [Measuring and cutting agree about escape sequences](#measuring-and-cutting-agree-about-escape-sequences)
 - [Untrusted text is made safe before it is drawn](#untrusted-text-is-made-safe-before-it-is-drawn)
@@ -132,15 +132,41 @@ Where the values come from is the part worth being careful about. They are asked
 
 An argument completes only while it is a single word. `/tmp is full` is a sentence about a folder, and a list that opened inside it would be claiming a line the user is writing as prose.
 
-## The profiler does not claim the parts add up
+## The profiler stays live without inventing history
 
-`/timing` draws where a turn's time went, and the interesting decision is what its bars are measured against.
+`/timing` draws where a turn's time is going, not only where it went. While it is
+enabled, a small indented panel remains in the live region through the turn and
+the idle time after it. It is plain rather than boxed because it is persistent
+chrome beside the composer and status line, not a modal card asking for focus.
+It is capped at six rows, with omitted spans counted in one final row, so a turn
+that invokes dozens of tools cannot grow the redraw area past the terminal.
+
+The panel is the only presentation. Committing a second finished chart below the
+reply would duplicate the same fact and turn optional instrumentation into
+permanent transcript noise, so a completed measurement stays in place until the
+next turn replaces it. When timing is off, the slot contributes no rows at all.
+
+The interesting decision is what its bars are measured against.
 
 The obvious choice is the turn: every row a fraction of the whole, adding to one. It is also false. Tool calls within a step run at the same time as each other, and thinking interleaves with them across steps, so these are overlapping spans — two ten-second tools inside a ten-second turn are both correct. Drawn against the total they would be half-full bars implying twenty seconds of something else happened; drawn against each other they say what actually happened, which is that both took ten seconds.
 
 So the bars are scaled against the longest row, and the turn's wall clock is printed in the heading where it makes no claim about the rows beneath it. What the chart supports is "which of these took the time", which is the question anyone types the command to ask. What it deliberately does not support is "what fraction of the turn was thinking", because the log cannot answer that.
 
-It is fed from the live event feed rather than from the shared projection, and that is not symmetry with the usage counter but the opposite of it on purpose. A reopened session replays its log with the streamed chunks filtered out — they are the token-by-token form of a reply the log also stores whole, and replaying both would print every message twice. A profiler behind that filter would chart every past turn as though the model had thought for no time at all.
+It is fed from the live event feed rather than from the shared projection, and
+that is not symmetry with the usage counter but the opposite of it on purpose. A
+reopened session replays its log with the streamed chunks filtered out — they are
+the token-by-token form of a reply the log also stores whole, and replaying both
+would print every message twice. A profiler behind that filter would chart every
+past turn as though the model had thought for no time at all, so a reopened
+attachment shows an honest `no turn measured yet` placeholder instead.
+
+Finished spans use those events' timestamps and never change afterwards. An open
+turn and an open tool have no ending event yet, so their provisional durations
+tick against the wall clock already driving the working spinner; reasoning and
+output advance as their streamed timestamps arrive. Once a result or turn end
+lands, its log timestamp replaces the provisional clock reading. Keeping that
+exception explicit is more truthful than either freezing active work between
+events or pretending a renderer clock was part of the saved log.
 
 ## Character widths follow the Unicode standard
 
@@ -226,7 +252,7 @@ The selection is stored whole, route and reasoning level together, even when onl
 
 ## The interface is made of plugins too
 
-The banner, input line, status line, and every box are separate registrations in `ctx.tuiSlots` — the terminal's equivalent of the web interface's view registry. Positions are named (`stream`, `composer`, `completion`, `status`), so an internal view chooses where it appears by naming one, and whichever view owns text entry reports where the cursor belongs.
+The banner, input line, status line, and every box are separate registrations in `ctx.tuiSlots` — the terminal's equivalent of the web interface's view registry. Positions are named (`stream`, `composer`, `completion`, `timing`, `status`), so an internal view chooses where it appears by naming one, and whichever view owns text entry reports where the cursor belongs.
 
 ```ts
 ctx.tuiSlots.register('status', { render: () => ['my widget'] })

--- a/docs/design.md
+++ b/docs/design.md
@@ -139,7 +139,10 @@ enabled, a small indented panel remains in the live region through the turn and
 the idle time after it. It is plain rather than boxed because it is persistent
 chrome beside the composer and status line, not a modal card asking for focus.
 It is capped at six rows, with omitted spans counted in one final row, so a turn
-that invokes dozens of tools cannot grow the redraw area past the terminal.
+that invokes dozens of tools cannot grow the redraw area past the terminal. The
+cap is also what makes its persistence honest: the composer budgets against a
+header row for it, and on a terminal too short for both, instrumentation yields
+to interaction — body rows first, then the header, never the input line.
 
 The panel is the only presentation. Committing a second finished chart below the
 reply would duplicate the same fact and turn optional instrumentation into

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -702,6 +702,12 @@ nothing is added to scrollback — until the next turn replaces it. Tool-heavy
 turns are capped to a small fixed height and end with a `+N more` row rather than
 crowding the composer off screen.
 
+On a terminal too short to hold everything, the panel degrades before the input
+line does: its span rows go first, then its header, and only on a terminal of a
+handful of rows does it disappear entirely — an input line is never pushed off
+screen to keep a chart visible. The composer behaves by the same rule, shedding
+the blank line above its frame before it takes rows the panel was promised.
+
 The bars are scaled against the **longest** row, not against the turn. These are
 spans, not shares: tool calls in a step run at the same time as each other, so
 their lengths can add up to more than the turn took, and the difference is not

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,7 +80,7 @@ Type `/` to see the commands your agent actually has. They come from two places.
 | `/plugins` | Browse, search, and customize the running agent's Harness preset composition |
 | `/profiles` | Browse Harness profiles and the bundles each one composes; install, update, or remove one |
 | `/usage` | Choose what the status line reports: `cost`, `tokens`, or `off`. Opens a picker with no argument |
-| `/timing` | `on` or `off` for the per-turn time breakdown; bare flips it |
+| `/timing` | `on` or `off` for the persistent live turn-timing panel; bare flips it |
 | `/work` | Open a bounded live view of active Harness jobs and subagents |
 | `/sessions` | Browse, search, and reopen past sessions without leaving the window |
 | `/todos` | Open a bounded read-only view of the current Harness Todo list |
@@ -685,19 +685,36 @@ Any *other* gateway is unpriced until you say otherwise: only routes this interf
 
 ### Where a turn's time went
 
-`/timing` prints a breakdown under each reply, from the next turn on:
+`/timing` opens a persistent live breakdown above the status line:
 
 ```
-turn 14 · 42.8s
+  timing · turn 14 · 42.8s · live
   reasoning  ███████████  18.2s
   bash       ██████████   16.4s
   edit       ██            3.1s
   output     █             2.1s
 ```
 
-The bars are scaled against the **longest** row, not against the turn. These are spans, not shares: tool calls in a step run at the same time as each other, so their lengths can add up to more than the turn took, and the difference is not idle time. The wall clock in the heading is the turn; the bars only compare the rows with each other.
+It stays there while the agent works and while it is idle. The turn clock and
+open tool calls advance in real time; reasoning and output grow as their streamed
+events arrive. When the turn ends, the same panel holds its final measurement —
+nothing is added to scrollback — until the next turn replaces it. Tool-heavy
+turns are capped to a small fixed height and end with a `+N more` row rather than
+crowding the composer off screen.
 
-It is off by default, because a chart between every reply and the next prompt is noise when you are not asking the question it answers. `/timing` on its own flips it — there are only two states, so a list of two would be a ceremony — and `/timing on` or `/timing off` sets it outright.
+The bars are scaled against the **longest** row, not against the turn. These are
+spans, not shares: tool calls in a step run at the same time as each other, so
+their lengths can add up to more than the turn took, and the difference is not
+idle time. The wall clock in the heading is the turn; the bars only compare the
+rows with each other.
+
+It is off by default, and while it is off it contributes no live rows at all.
+`/timing` on its own flips it — there are only two states, so a list of two would
+be a ceremony — and `/timing on` or `/timing off` sets it outright. Enabling it
+during a live turn shows the measurement already in progress. Reopening a saved
+session starts with `no turn measured yet`: historical replay deliberately omits
+the streamed chunks needed for an honest breakdown, so the panel does not invent
+one from incomplete data.
 
 It was called `/profile` before, which was a name collision waiting to happen: a Harness **profile** is the composition a launcher boots, and `/profiles` browses those. This command is a stopwatch and now says so.
 

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -57,7 +57,7 @@ import { browseSessions } from './sessions/index.ts'
 import type { AttachOutcome } from './sessions/reopen.ts'
 import { StreamBuffer } from './stream.ts'
 import { effortLabel, pickReasoning, reasoningValues } from './reasoning.ts'
-import { timingLines, TurnTimer } from './timing.ts'
+import { createTimingView, TurnTimer } from './timing.ts'
 import { goalReading, planModeAfter } from './modes.ts'
 import { commandEcho, commandLines, projectEvent } from './transcript.ts'
 import { promptSelect } from './select.ts'
@@ -75,9 +75,15 @@ import { createTodoOverlay } from './todos/overlay.ts'
 
 /** What `/timing` accepts, for completing its argument. */
 const TIMING_VALUES: readonly LocalCommandChoice[] = [
-  { value: 'on', note: 'Chart each turn under its reply' },
-  { value: 'off', note: 'Stop charting turns' },
+  { value: 'on', note: 'Show the live turn timing panel' },
+  { value: 'off', note: 'Hide the live turn timing panel' },
 ]
+
+/** Fixed status row every ordinary live-region composition ends with. */
+const STATUS_LIVE_ROWS = 1
+
+/** Minimum row that keeps an enabled timing panel persistently identifiable. */
+const TIMING_LIVE_ROWS = 1
 
 /**
  * Budget for a slash command, so a command that never settles cannot wedge the
@@ -141,7 +147,12 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     invalidate: () => { ctx.tuiSlots.invalidate() },
   })
   scope.own(() => { projections.dispose() })
-  const composerView = createComposerView(composer, workspace)
+  // Completion and the composer budget against the fixed views below them. The
+  // timing row is conditional, but while enabled it must survive a tall paste or
+  // suggestion list instead of being pushed beyond the physical screen.
+  const persistentRowsBelow = (): number =>
+    STATUS_LIVE_ROWS + (prefs.timing ? TIMING_LIVE_ROWS : 0)
+  const composerView = createComposerView(composer, workspace, persistentRowsBelow)
   const stream = new StreamBuffer()
   // Scoped to the agent: a scoped tool shadows a global one, and a restricted-away
   // tool reads as absent, so the card must come from the definition that ran.
@@ -200,7 +211,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
       // one word cannot mean both a per-turn stopwatch and that. This command
       // never had anything to do with profiles.
       name: 'timing',
-      description: 'Show where the time went in each turn, under the reply',
+      description: 'Show a live breakdown of the current or latest turn',
       complete: () => TIMING_VALUES,
       execute: rawInput => {
         const named = rawInput.trim().toLowerCase()
@@ -212,7 +223,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
         // Binary, so a bare gesture flips it rather than opening a list of two.
         prefs.timing = named === '' ? !prefs.timing : named === 'on'
         commit([style(
-          prefs.timing ? '· turn timer: on, from the next turn' : '· turn timer: off',
+          prefs.timing ? '· turn timer: on, in the live area' : '· turn timer: off',
           'gray',
         )])
         draw()
@@ -398,7 +409,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
         return []
       }
     },
-  }, () => { ctx.tuiSlots.invalidate() })
+  }, () => { ctx.tuiSlots.invalidate() }, persistentRowsBelow)
 
   /**
    * The current goal, or nothing when there is none to report.
@@ -437,11 +448,13 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     goal: goalReading(currentGoal()),
   }))
   const streamView = { render: (columns: number): string[] => stream.live(columns) }
+  const timingView = createTimingView(timer, () => prefs.timing)
 
   scope.own(ctx.tuiSlots.register('stream', streamView))
   scope.own(ctx.tuiSlots.register('status', status))
   scope.own(ctx.tuiSlots.register('composer', composerView))
   scope.own(ctx.tuiSlots.register('completion', completion.view))
+  scope.own(ctx.tuiSlots.register('timing', timingView))
   scope.own(installApprovalAnswerer(ctx, () => agent))
   scope.own(installQuestionProvider(ctx))
 
@@ -555,16 +568,15 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   scope.own(ctx.on('session/event', (session, event: SessionEvent) => {
     if (session !== agent.session) return
     const columns = terminal.columns()
+    // Always fold the live feed. Gating observation on the preference made an
+    // enable during a turn either blank or partial; the preference owns only
+    // presentation, and a fresh attachment still starts without invented data.
+    timer.observe(event)
     commit(project(event, columns))
     // Fed from the LIVE feed and not from `project`, which the replay also runs:
     // the replay carries no `assistant/chunk` events — they are the streamed form
     // of a message the log also stores assembled — so a timer behind it would
-    // chart every reopened turn as though the model had thought for no time.
-    // Committed after the projection so the chart lands under the finished reply.
-    if (prefs.timing) {
-      const profile = timer.observe(event)
-      if (profile !== undefined) commit(timingLines(profile, columns))
-    }
+    // measure every reopened turn as though the model had thought for no time.
     draw()
   }))
 

--- a/packages/dshline/src/completion.ts
+++ b/packages/dshline/src/completion.ts
@@ -22,24 +22,6 @@ import { chromeWidth } from './views.ts'
 const VISIBLE_ROWS = 6
 
 /**
- * Rows this view must leave for the live region BELOW it: the status line.
- *
- * Known here rather than negotiated because `SLOT_ORDER` is a fixed list of four
- * names in `slots.ts`, not an open registry — `completion` is followed by
- * `status`, and a status line is exactly one row at every width by construction.
- * What is above this view is not counted here at all: `TuiSlots.compose()` has
- * already subtracted it from the rows it passes in.
- *
- * So this constant is deliberately coupled to two facts that hold today: that
- * slot order is closed, and that exactly one row follows this view. Neither is
- * promised beyond pre-1.0. The moment third-party persistent rows exist — the
- * global live-region layout budget the roadmap makes a precondition for them —
- * knowing what comes below stops being a view's business, and this reservation
- * belongs in that budget rather than here.
- */
-const ROWS_BELOW = 1
-
-/**
  * Rows this view spends on its own chrome: the elision marker and the help line.
  *
  * Both are reserved even when the marker will not be drawn. Whether it is drawn
@@ -186,12 +168,14 @@ export interface Completion {
  * @param composer - the buffer being edited; accepting a candidate rewrites it.
  * @param sources - where candidates come from.
  * @param redraw - asks the runner to redraw.
+ * @param rowsBelow - fixed live rows the list must leave beneath itself.
  * @returns the live completion state.
  */
 export function createCompletion(
   composer: Composer,
   sources: CompletionSources,
   redraw: () => void,
+  rowsBelow: () => number = () => 1,
 ): Completion {
   let candidates: readonly Candidate[] = []
   let token: Token | undefined
@@ -267,7 +251,7 @@ export function createCompletion(
         // what it gets. `terminalRows` is already net of the stream and the
         // composer above, so a ten-row prompt shrinks this list rather than
         // pushing the prompt off the top.
-        const capacity = Math.min(VISIBLE_ROWS, terminalRows - ROWS_BELOW - CHROME_ROWS)
+        const capacity = Math.min(VISIBLE_ROWS, terminalRows - Math.max(0, rowsBelow()) - CHROME_ROWS)
         // Nothing at all rather than a row or two of chrome. When the composer has
         // taken the screen, the prompt is what the keystrokes are going to and a
         // list that cannot show a single candidate is not worth a row of it — and

--- a/packages/dshline/src/slots.ts
+++ b/packages/dshline/src/slots.ts
@@ -30,10 +30,10 @@ declare module '@deepseek-ai/cordis' {
  * slot, so reordering the chrome never means editing the runner. This is
  * experimental pre-1.0 extension vocabulary, not a stable plugin API.
  */
-export type TuiSlotName = 'stream' | 'composer' | 'completion' | 'status'
+export type TuiSlotName = 'stream' | 'composer' | 'completion' | 'timing' | 'status'
 
 /** Composition order, which is the reading order on screen. */
-const SLOT_ORDER: readonly TuiSlotName[] = ['stream', 'composer', 'completion', 'status']
+const SLOT_ORDER: readonly TuiSlotName[] = ['stream', 'composer', 'completion', 'timing', 'status']
 
 /**
  * A registered contributor of live-region lines.

--- a/packages/dshline/src/slots.ts
+++ b/packages/dshline/src/slots.ts
@@ -64,9 +64,14 @@ export interface TuiSlotView {
    *
    * At most one registered view should answer; the first that does wins.
    * @param columns - the terminal's current width.
+   * @param rows - the same unspent-row figure {@link TuiSlotView.render} received.
+   *   A self-bounding view has to slice what it draws and place its cursor inside
+   *   that ONE window; two calculations of it agree everywhere except the short
+   *   terminal where they must, and there the disagreement puts the cursor on
+   *   chrome below this view instead of on its text.
    * @returns the placement, or undefined when this view wants no cursor.
    */
-  cursor?(columns: number): LiveCursor | undefined
+  cursor?(columns: number, rows?: number): LiveCursor | undefined
 }
 
 /**
@@ -183,8 +188,12 @@ export class TuiSlots extends Service {
     let cursor: LiveCursor | undefined
     for (const name of SLOT_ORDER) {
       for (const entry of this.slots.get(name) ?? []) {
-        const own = entry.view.render(columns, Math.max(0, rows - lines.length))
-        const placement = cursor === undefined ? entry.view.cursor?.(columns) : undefined
+        // One figure for both halves of a view's contract: rendering against one
+        // window and placing the cursor against another leaves the cursor on rows
+        // the frame no longer shows — inside whatever chrome follows this view.
+        const available = Math.max(0, rows - lines.length)
+        const own = entry.view.render(columns, available)
+        const placement = cursor === undefined ? entry.view.cursor?.(columns, available) : undefined
         // Translate the view-relative row into the composed region's row space.
         if (placement !== undefined) cursor = { row: lines.length + placement.row, column: placement.column }
         lines.push(...own)

--- a/packages/dshline/src/timing.ts
+++ b/packages/dshline/src/timing.ts
@@ -1,46 +1,50 @@
 /**
- * Where a turn's time went.
+ * Where the current or most recently measured turn's time went.
  *
- * Every duration comes from the timestamps the session log already carries, not
- * from clock reads taken while drawing, so the chart reports the run rather than
- * the renderer's view of it.
+ * Finished durations come from timestamps carried by the live session events,
+ * not from clock reads taken while drawing. An open turn has no closing event,
+ * so its wall clock and any running tools advance against the current clock;
+ * once they finish, their event timestamps replace that provisional reading.
  *
  * The one thing this deliberately does NOT claim is that the parts add up to the
  * whole. Tool calls in a step run concurrently and reasoning interleaves with
  * them across steps, so these are overlapping spans: their sum can exceed the
  * turn, and the difference is not idle time. That is why the bars are scaled
- * against the LARGEST span rather than against the turn's wall clock — a bar
- * measured against the total would be a picture asserting a partition that does
- * not exist. The wall clock sits in the header, where it makes no such claim.
+ * against the LARGEST span rather than against the turn's wall clock.
  * @module dshline/timing
  */
 
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { displayWidth, escapeControls, formatElapsed, style, truncateToWidth } from '@dshline/renderer'
+import type { TuiSlotView } from './slots.ts'
 import { chromeWidth } from './views.ts'
 
 /** One measured span within a turn. */
 export interface TurnSpan {
   /** What was running: `reasoning`, `output`, or a tool's name. */
-  label: string
+  readonly label: string
   /** Milliseconds the span covered. */
-  ms: number
+  readonly ms: number
+  /** Whether at least one call represented by this row is still open. */
+  readonly running: boolean
 }
 
-/** One finished turn, as the chart draws it. */
+/** A live or finished turn, as the panel draws it. */
 export interface TurnTiming {
-  /** The turn's number, as the session log counts them. */
-  turn: number
-  /** Wall clock from `turn/start` to `turn/end`. */
-  totalMs: number
+  /** The turn's number, as the session log counts it. */
+  readonly turn: number
+  /** Wall clock from `turn/start` to the current or closing timestamp. */
+  readonly totalMs: number
+  /** Whether the closing `turn/end` has not arrived yet. */
+  readonly running: boolean
   /** Spans worth drawing, longest first. */
-  spans: readonly TurnSpan[]
+  readonly spans: readonly TurnSpan[]
 }
 
 /** Widest a label column grows before names are cut; beyond this the bars starve. */
 const LABEL_COLUMNS = 14
 
-/** Columns between the three fields, so nothing reads as one word. */
+/** Columns between fields, so a label, bar, and duration never read as one word. */
 const FIELD_GAP = 2
 
 /** Left indent, matching the status line's. */
@@ -56,11 +60,22 @@ const BAR_FULL = '█'
 const TENTHS_BELOW_MS = 60_000
 
 /**
+ * Maximum logical rows the persistent panel may claim.
+ *
+ * Six keeps four named spans plus an honest elision row visible without letting
+ * a tool-heavy turn crowd the composer out of an ordinary 24-row terminal.
+ */
+const PANEL_ROWS = 6
+
+/** The status line is the one fixed row below the timing slot. */
+const STATUS_ROWS = 1
+
+/**
  * A span's duration, at a precision that keeps distinct spans distinct.
  *
  * `formatElapsed` floors to whole seconds, which is right for a status line
  * counting a turn up but wrong here: most tool calls finish in single-digit
- * seconds, and rounding them all to `3s` collapses the differences the chart
+ * seconds, and rounding them all to `3s` collapses the differences the panel
  * exists to show.
  * @param milliseconds - the span.
  * @returns e.g. `18.2s`, `1m 04s`.
@@ -71,8 +86,21 @@ function formatSpan(milliseconds: number): string {
   return `${(value / 1000).toFixed(1)}s`
 }
 
+/** One streamed kind within one model step. */
+interface StreamSpan {
+  readonly kind: 'reasoning' | 'output'
+  first: number
+  last: number
+}
+
+/** One tool call awaiting its result. */
+interface PendingTool {
+  readonly name: string
+  readonly at: number
+}
+
 /**
- * Collects timings for the turn in progress.
+ * Collects timings for the live turn and retains the most recent finished one.
  *
  * Fed from the runner's LIVE event listener rather than from its shared
  * projection, and that is not an oversight. A resumed session's replay has no
@@ -86,14 +114,16 @@ export class TurnTimer {
   private startedAt: number | undefined
   private turn = 0
   /** First and last delta of one kind within one step, keyed `kind:step`. */
-  private readonly streams = new Map<string, { first: number; last: number }>()
+  private readonly streams = new Map<string, StreamSpan>()
   /** Calls awaiting their result, keyed by call id. */
-  private readonly pending = new Map<string, { name: string; at: number }>()
-  /** Milliseconds spent in each tool, keyed by the tool's name. */
+  private readonly pending = new Map<string, PendingTool>()
+  /** Finished milliseconds for each tool name in the open turn. */
   private readonly tools = new Map<string, number>()
+  /** The last complete measurement, retained while the attachment is idle. */
+  private finished: TurnTiming | undefined
 
-  /** Forget the open turn, so a partial measurement is never charted. */
-  private reset(): void {
+  /** Forget only the open turn; a completed panel remains useful while idle. */
+  private resetOpen(): void {
     this.startedAt = undefined
     this.streams.clear()
     this.pending.clear()
@@ -101,126 +131,173 @@ export class TurnTimer {
   }
 
   /**
-   * Fold one live event in, and report a finished turn.
+   * Fold one live event into the current measurement.
    *
-   * A turn already running when measurement began is skipped rather than charted
-   * from the middle: its `turn/start` was never seen, so its total would be the
-   * time since the toggle rather than the time the turn took.
-   * @param event - one committed session event.
-   * @returns the finished profile on `turn/end`, otherwise undefined.
+   * Observation is intentionally not gated by the display preference. Toggling
+   * a presentation should not fabricate a partial turn beginning at the toggle,
+   * and the event fold is cheap enough to keep the view immediately truthful.
+   * @param event - one committed live session event.
+   * @returns nothing; read the current result through {@link snapshot}.
    */
-  observe(event: SessionEvent): TurnTiming | undefined {
+  observe(event: SessionEvent): void {
     if (event.type === 'turn/start') {
-      this.reset()
+      this.resetOpen()
       this.startedAt = event.time
       this.turn = event.data.turn
-      return undefined
+      return
     }
-    if (this.startedAt === undefined) return undefined
+    if (this.startedAt === undefined) return
     if (event.type === 'assistant/chunk') {
       const { chunk, step } = event.data
       const kind = chunk.type === 'reasoning-delta' ? 'reasoning' : chunk.type === 'text-delta' ? 'output' : undefined
-      if (kind === undefined) return undefined
+      if (kind === undefined) return
       const key = `${kind}:${String(step)}`
       const span = this.streams.get(key)
-      if (span === undefined) this.streams.set(key, { first: event.time, last: event.time })
+      if (span === undefined) this.streams.set(key, { kind, first: event.time, last: event.time })
       else span.last = event.time
-      return undefined
+      return
     }
     if (event.type === 'tool/call') {
       this.pending.set(event.data.callId, { name: event.data.name, at: event.time })
-      return undefined
+      return
     }
     if (event.type === 'tool/result') {
       // Paired by call id, exactly as the tool cards pair them: several calls can
       // be open at once, so the newest result does not belong to the newest call.
       const block = event.data.message.content[0]
       const call = this.pending.get(block.toolCallId)
-      if (call === undefined) return undefined
+      if (call === undefined) return
       this.pending.delete(block.toolCallId)
       this.tools.set(call.name, (this.tools.get(call.name) ?? 0) + Math.max(0, event.time - call.at))
-      return undefined
+      return
     }
-    if (event.type !== 'turn/end') return undefined
+    if (event.type !== 'turn/end') return
+    this.finished = this.reading(event.time, false)
+    this.resetOpen()
+  }
 
-    const spans = new Map<string, number>()
-    for (const [key, span] of this.streams) {
-      const label = key.slice(0, key.indexOf(':'))
-      spans.set(label, (spans.get(label) ?? 0) + (span.last - span.first))
+  /**
+   * Current live measurement, or the most recent completed turn while idle.
+   * @param now - current wall clock, used only for values whose closing event has
+   *   not arrived; defaults to the clock at render time.
+   * @returns the current or retained measurement, or undefined in a fresh attachment.
+   */
+  snapshot(now = Date.now()): TurnTiming | undefined {
+    return this.startedAt === undefined ? this.finished : this.reading(now, true)
+  }
+
+  /** Build one immutable reading without mutating the fold. */
+  private reading(at: number, running: boolean): TurnTiming {
+    const startedAt = this.startedAt ?? at
+    const spans = new Map<string, { ms: number; running: boolean }>()
+    for (const span of this.streams.values()) {
+      const current = spans.get(span.kind)
+      const ms = Math.max(0, span.last - span.first)
+      spans.set(span.kind, { ms: (current?.ms ?? 0) + ms, running: false })
     }
-    for (const [name, ms] of this.tools) spans.set(name, ms)
-    const profile: TurnTiming = {
+    for (const [name, ms] of this.tools) spans.set(name, {
+      ms: (spans.get(name)?.ms ?? 0) + ms,
+      running: spans.get(name)?.running ?? false,
+    })
+    for (const call of this.pending.values()) spans.set(call.name, {
+      ms: (spans.get(call.name)?.ms ?? 0) + Math.max(0, at - call.at),
+      running,
+    })
+    return {
       turn: this.turn,
-      totalMs: Math.max(0, event.time - this.startedAt),
+      totalMs: Math.max(0, at - startedAt),
+      running,
       spans: [...spans]
-        .map(([label, ms]) => ({ label, ms }))
-        // A span of zero measured something real that finished inside one
-        // timestamp; drawing it would put a bar against a duration of `0.0s`.
-        .filter(span => span.ms > 0)
+        .map(([label, span]) => ({ label, ...span }))
+        // A live zero says the span has begun. Once finished, a row beside 0.0s
+        // measures nothing a reader can act on and is dropped as before.
+        .filter(span => running || span.ms > 0)
         .sort((left, right) => right.ms - left.ms),
     }
-    this.reset()
-    return profile
   }
 }
 
 /**
- * The chart, as lines to commit below the reply.
- * @param profile - a finished turn.
+ * The bounded timing panel as live-region lines.
+ * @param profile - current or retained timing, or undefined before a live turn.
  * @param columns - the terminal's current width.
- * @returns lines to write into scrollback, or none when there was nothing to measure.
+ * @param rows - maximum rows this panel may spend.
+ * @returns lines for the live region, including a placeholder when no turn exists.
  */
-export function timingLines(profile: TurnTiming, columns: number): string[] {
-  if (profile.spans.length === 0) return []
-  const width = chromeWidth(columns)
-  // Tool names come from the model, so they are made safe BEFORE any width is
-  // measured from them and long before any color is applied.
-  const safe = profile.spans.map(span => escapeControls(span.label))
-  const durations = profile.spans.map(span => formatSpan(span.ms))
+export function timingLines(profile: TurnTiming | undefined, columns: number, rows = PANEL_ROWS): string[] {
+  const height = Math.max(0, Math.min(PANEL_ROWS, rows))
+  if (height === 0) return []
+  const width = Math.max(1, Math.min(columns, chromeWidth(columns)))
+  const headings = profile === undefined
+    ? ['timing · no turn measured yet', 'timing · no turn yet', 'timing']
+    : [
+      `timing · turn ${String(profile.turn)} · ${formatSpan(profile.totalMs)}${profile.running ? ' · live' : ''}`,
+      `timing · turn ${String(profile.turn)} · ${formatSpan(profile.totalMs)}`,
+      `timing · turn ${String(profile.turn)}`,
+      'timing',
+    ]
+  // Whole facts are dropped before the final fallback is cut. A heading ending
+  // in `· 4` reads as a broken duration, not as a narrower version of one.
+  const heading = headings.find(candidate => displayWidth(INDENT + candidate) <= width) ?? 'timing'
+  const lines = [style(truncateToWidth(`${INDENT}${heading}`, width), 'cyan', 'bold')]
+  if (profile === undefined || profile.spans.length === 0 || height === 1) return lines
+
+  const bodyRows = height - 1
+  const needsElision = profile.spans.length > bodyRows
+  const shownCount = needsElision ? Math.max(0, bodyRows - 1) : bodyRows
+  const shown = profile.spans.slice(0, shownCount)
+  if (shown.length > 0) lines.push(...spanLines(shown, width))
+  if (needsElision) {
+    const hidden = profile.spans.length - shown.length
+    lines.push(style(truncateToWidth(`${INDENT}… +${String(hidden)} more`, width), 'dim'))
+  }
+  return lines
+}
+
+/** Render measured rows after every untrusted label has been made safe. */
+function spanLines(spans: readonly TurnSpan[], width: number): string[] {
+  const safe = spans.map(span => escapeControls(span.label))
+  const durations = spans.map(span => formatSpan(span.ms))
   const durationWidth = Math.max(...durations.map(displayWidth))
-  // The label column is cut to what is left after the duration, not only to
-  // LABEL_COLUMNS. A cap alone is a cap on a terminal wide enough to honour it,
-  // and on a narrow one the rows would run past the chrome every other element
-  // lines up with.
+  const indentWidth = displayWidth(INDENT)
+  const gap = Math.max(1, Math.min(FIELD_GAP, width - indentWidth - durationWidth - 1))
   const labelWidth = Math.max(1, Math.min(
     LABEL_COLUMNS,
     Math.max(...safe.map(displayWidth)),
-    width - displayWidth(INDENT) - FIELD_GAP - durationWidth,
+    width - indentWidth - gap - durationWidth,
   ))
-  const rows = profile.spans.map((span, index) => ({
-    label: truncateToWidth(safe[index] ?? '', labelWidth),
-    duration: durations[index] ?? '',
-    ms: span.ms,
-  }))
-  const barCells = width - displayWidth(INDENT) - labelWidth - durationWidth - FIELD_GAP * 2
-  const longest = Math.max(...rows.map(row => row.ms))
+  const barCells = width - indentWidth - labelWidth - durationWidth - gap * 2
+  const longest = Math.max(...spans.map(span => span.ms), 1)
 
-  // The wall clock is dropped WHOLE when it will not fit, rather than cut: the
-  // same rule the status line's hints follow, because `turn 14 · 4` reads as a
-  // rendering fault and not as a duration.
-  const heading = `${INDENT}turn ${String(profile.turn)}`
-  const total = ` · ${formatSpan(profile.totalMs)}`
-  const lines = [displayWidth(heading + total) <= width
-    ? `${INDENT}${style(`turn ${String(profile.turn)}`, 'bold')}${style(total, 'gray')}`
-    : `${INDENT}${style(truncateToWidth(`turn ${String(profile.turn)}`, width - displayWidth(INDENT)), 'bold')}`]
-  for (const row of rows) {
+  return spans.map((span, index) => {
+    const cut = truncateToWidth(safe[index] ?? '', labelWidth)
     // Padded by DISPLAY width, not by string length: a label with a wide
     // character measures two columns per unit, and `padEnd` counts units.
-    const label = `${row.label}${' '.repeat(labelWidth - displayWidth(row.label))}`
-    const duration = `${' '.repeat(durationWidth - displayWidth(row.duration))}${row.duration}`
+    const label = `${cut}${' '.repeat(labelWidth - displayWidth(cut))}`
+    const durationText = durations[index] ?? ''
+    const duration = `${' '.repeat(durationWidth - displayWidth(durationText))}${durationText}`
     if (barCells < MIN_BAR_CELLS) {
-      // Too narrow for a picture, so the numbers alone: a one-cell bar beside
-      // every row would say every span was the same length.
-      lines.push(`${INDENT}${style(label, 'dim')}${' '.repeat(FIELD_GAP)}${style(duration, 'dim')}`)
-      continue
+      return `${INDENT}${style(label, 'dim')}${' '.repeat(gap)}${style(duration, span.running ? 'cyan' : 'dim')}`
     }
     // Any measured span rounds up to one cell, for the reason the context bar
     // does: a blank row beside a real duration reads as a drawing fault.
-    const cells = Math.max(1, Math.round((row.ms / longest) * barCells))
+    const cells = Math.max(1, Math.round((span.ms / longest) * barCells))
     const bar = `${BAR_FULL.repeat(cells)}${' '.repeat(barCells - cells)}`
-    lines.push(
-      `${INDENT}${style(label, 'dim')}${' '.repeat(FIELD_GAP)}${style(bar, 'cyan')}${' '.repeat(FIELD_GAP)}${style(duration, 'dim')}`,
-    )
+    return `${INDENT}${style(label, 'dim')}${' '.repeat(gap)}${style(bar, 'cyan')}${' '.repeat(gap)}${style(duration, span.running ? 'cyan' : 'dim')}`
+  })
+}
+
+/**
+ * Create the persistent timing slot.
+ * @param timer - live event fold owned by this attachment.
+ * @param enabled - window preference deciding whether the view contributes rows.
+ * @returns a view that leaves the fixed status row beneath it.
+ */
+export function createTimingView(timer: TurnTimer, enabled: () => boolean): TuiSlotView {
+  return {
+    render(columns, rows = 24) {
+      if (!enabled()) return []
+      return timingLines(timer.snapshot(), columns, Math.max(0, rows - STATUS_ROWS))
+    },
   }
-  return lines
 }

--- a/packages/dshline/src/views.ts
+++ b/packages/dshline/src/views.ts
@@ -90,6 +90,8 @@ const MAX_COLUMNS = 100
  */
 const COMPOSER_ROWS = 10
 
+/** Blank separator and two borders outside the composer's content rows. */
+const COMPOSER_FIXED_ROWS = 3
 
 /** Cells in the context-pressure bar. */
 const BAR_CELLS = 8
@@ -136,9 +138,14 @@ export function chromeWidth(columns: number): number {
  * know how tall a border is.
  * @param composer - the buffer being edited.
  * @param workspace - session workspace, whose basename titles the frame.
+ * @param rowsBelow - fixed live rows the composer must leave beneath itself.
  * @returns the slot view.
  */
-export function createComposerView(composer: Composer, workspace: string): TuiSlotView {
+export function createComposerView(
+  composer: Composer,
+  workspace: string,
+  rowsBelow: () => number = () => 1,
+): TuiSlotView {
   const label = basename(workspace) === '' ? workspace : basename(workspace)
 
   /**
@@ -171,20 +178,26 @@ export function createComposerView(composer: Composer, workspace: string): TuiSl
    * The rows to draw, scrolled so the cursor's row is visible.
    * @param all - every wrapped row of the buffer.
    * @param row - the cursor's row within them.
+   * @param maximum - most content rows the current live-region budget permits.
    * @returns the visible rows and how many were scrolled past above them.
    */
-  const window = (all: readonly string[], row: number): { rows: readonly string[]; offset: number } => {
-    if (all.length <= COMPOSER_ROWS) return { rows: all, offset: 0 }
+  const window = (
+    all: readonly string[],
+    row: number,
+    maximum = COMPOSER_ROWS,
+  ): { rows: readonly string[]; offset: number } => {
+    const visible = Math.max(1, Math.min(COMPOSER_ROWS, maximum))
+    if (all.length <= visible) return { rows: all, offset: 0 }
     // Keep the cursor's row in view, preferring to show what follows it: a person
     // pasting or typing is working at the end.
-    const offset = Math.min(all.length - COMPOSER_ROWS, Math.max(0, row - COMPOSER_ROWS + 1))
-    return { rows: all.slice(offset, offset + COMPOSER_ROWS), offset }
+    const offset = Math.min(all.length - visible, Math.max(0, row - visible + 1))
+    return { rows: all.slice(offset, offset + visible), offset }
   }
 
   return {
     // A blank line above separates the frame from whatever the transcript just
     // committed, so a reply and the input box do not read as one block.
-    render: columns => {
+    render: (columns, terminalRows = 24) => {
       if (composer.isEmpty) {
         return ['', ...box(chunkToWidth(`${PROMPT}${style('ask anything', 'gray')}`, composerInner(columns)), {
           width: chromeWidth(columns),
@@ -193,7 +206,10 @@ export function createComposerView(composer: Composer, workspace: string): TuiSl
         })]
       }
       const { rows, row } = layout(columns)
-      const shown = window(rows, row)
+      // The timer and status are persistent when enabled, so a tall paste gives
+      // up composer history rather than pushing either below the physical screen.
+      const contentRows = terminalRows - Math.max(0, rowsBelow()) - COMPOSER_FIXED_ROWS
+      const shown = window(rows, row, contentRows)
       const hidden = rows.length - shown.rows.length
       return ['', ...box([...shown.rows], {
         width: chromeWidth(columns),

--- a/packages/dshline/src/views.ts
+++ b/packages/dshline/src/views.ts
@@ -194,38 +194,73 @@ export function createComposerView(
     return { rows: all.slice(offset, offset + visible), offset }
   }
 
+  /**
+   * Content rows the frame may spend inside the live-region budget, shared by
+   * render and cursor.
+   *
+   * The slice a frame draws and the window its cursor assumes are two projections
+   * of one calculation, and keeping them apart put the cursor on chrome below the
+   * frame exactly when a short terminal scrolled a tall buffer — the only case
+   * where the two windows differ, and therefore the one that has to be tested.
+   * @param rows - the budget compose() handed this view, or undefined from a
+   *   caller that does not know one; the composer's own cap alone bounds it there.
+   * @returns most content rows the frame may draw around its cursor.
+   */
+  const contentBudget = (rows: number | undefined): number =>
+    rows === undefined ? COMPOSER_ROWS : rows - Math.max(0, rowsBelow()) - COMPOSER_FIXED_ROWS
+
+  /**
+   * Whether the frame keeps the blank separating it from committed output.
+   *
+   * An empty buffer cannot scroll like a filled one, so under budget pressure the
+   * frame sheds decoration before structure: the separator goes first, the borders
+   * never — an input line is how every interaction starts, and on an impossibly
+   * small terminal usability outranks the reservation, the same priority the
+   * timing panel honours by giving up body rows ahead of its header.
+   * @param rows - the budget compose() handed this view, or undefined when unbounded.
+   * @returns true when the full frame fits alongside everything reserved below.
+   */
+  const keepsSeparator = (rows: number | undefined): boolean =>
+    rows === undefined || COMPOSER_FIXED_ROWS + 1 <= rows - Math.max(0, rowsBelow())
+
+  /** Row of the frame's first content line, which the separator's presence moves. */
+  const contentRowOffset = (rows: number | undefined): number => keepsSeparator(rows) ? 2 : 1
+
   return {
     // A blank line above separates the frame from whatever the transcript just
     // committed, so a reply and the input box do not read as one block.
     render: (columns, terminalRows = 24) => {
       if (composer.isEmpty) {
-        return ['', ...box(chunkToWidth(`${PROMPT}${style('ask anything', 'gray')}`, composerInner(columns)), {
+        const prompt = box(chunkToWidth(`${PROMPT}${style('ask anything', 'gray')}`, composerInner(columns)), {
           width: chromeWidth(columns),
           title: style(label, 'cyan'),
           border: text => style(text, 'gray'),
-        })]
+        })
+        return keepsSeparator(terminalRows) ? ['', ...prompt] : [...prompt]
       }
       const { rows, row } = layout(columns)
       // The timer and status are persistent when enabled, so a tall paste gives
       // up composer history rather than pushing either below the physical screen.
-      const contentRows = terminalRows - Math.max(0, rowsBelow()) - COMPOSER_FIXED_ROWS
-      const shown = window(rows, row, contentRows)
+      const shown = window(rows, row, contentBudget(terminalRows))
       const hidden = rows.length - shown.rows.length
-      return ['', ...box([...shown.rows], {
+      const framed = box([...shown.rows], {
         width: chromeWidth(columns),
         title: hidden > 0
           ? `${style(label, 'cyan')} ${style(`+${String(hidden)} rows`, 'gray')}`
           : style(label, 'cyan'),
         border: text => style(text, 'gray'),
-      })]
+      })
+      // The same shed rule as the empty frame, so the cursor's own arithmetic in
+      // cursor() can share it without either half learning the other's ladder.
+      return keepsSeparator(terminalRows) ? ['', ...framed] : [...framed]
     },
-    cursor: (columns): LiveCursor => {
-      if (composer.isEmpty) return { row: 2, column: 2 + displayWidth(PROMPT) }
-      const { rows, row, column } = layout(columns)
-      const shown = window(rows, row)
-      // Row 0 is the separating blank and row 1 the top border, so content starts
-      // at row 2, and the placement is relative to the visible window.
-      return { row: 2 + row - shown.offset, column: 2 + column }
+    cursor: (columns, rows): LiveCursor => {
+      if (composer.isEmpty) return { row: contentRowOffset(rows), column: 2 + displayWidth(PROMPT) }
+      const { rows: every, row, column } = layout(columns)
+      const shown = window(every, row, contentBudget(rows))
+      // Content starts below the separator and the top border, and the placement
+      // is relative to the visible window — the SAME window render chose.
+      return { row: contentRowOffset(rows) + row - shown.offset, column: 2 + column }
     },
   }
 }

--- a/packages/dshline/src/window.ts
+++ b/packages/dshline/src/window.ts
@@ -53,7 +53,7 @@ import type { PeakWindow, PricingTable, UsageMode } from './usage.ts'
 export interface WindowPrefs {
   /** What the status line reports. */
   usageMode: UsageMode
-  /** Whether each turn is charted under its reply. */
+  /** Whether the persistent live timing panel is shown. */
   timing: boolean
   /** How much of a tool card is drawn. */
   cardDetail: CardDetail

--- a/packages/dshline/tests/timing-frames.spec.ts
+++ b/packages/dshline/tests/timing-frames.spec.ts
@@ -1,0 +1,206 @@
+/** Real-terminal frames for the persistent timing panel. */
+
+import { Context } from '@deepseek-ai/cordis'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { Composer, displayWidth, Screen } from '@dshline/renderer'
+import { describe, expect, it, vi } from 'vitest'
+import { createEmulator } from '../../../tests/emulator.ts'
+import { TuiSlots } from '../src/slots.ts'
+import { createTimingView, TurnTimer } from '../src/timing.ts'
+import { createComposerView, createStatusView } from '../src/views.ts'
+
+/** Standard frame width, narrow enough that bars have to make real trade-offs. */
+const COLUMNS = 40
+
+/** Standard frame height, small enough to exercise the panel's row budget. */
+const ROWS = 12
+
+/** One log event, with only the fields the timer reads. */
+function event(time: number, type: string, data: unknown): SessionEvent {
+  return { time, type, data } as unknown as SessionEvent
+}
+
+/** A streamed delta of one kind, at one moment. */
+function delta(time: number, type: 'reasoning-delta' | 'text-delta'): SessionEvent {
+  return event(time, 'assistant/chunk', { turn: 1, step: 0, chunk: { type, text: 'x' } })
+}
+
+/** Start one tool call. */
+function call(time: number, callId: string, name: string): SessionEvent {
+  return event(time, 'tool/call', { turn: 1, step: 0, callId, name, arguments: '{}' })
+}
+
+/** Finish one tool call. */
+function result(time: number, callId: string): SessionEvent {
+  return event(time, 'tool/result', {
+    turn: 1,
+    step: 0,
+    message: { content: [{ toolCallId: callId }] },
+  })
+}
+
+/** The plain non-empty rows a person currently sees. */
+async function visible(emulator: ReturnType<typeof createEmulator>): Promise<string[]> {
+  return (await emulator.screen()).map(row => row.trimEnd()).filter(row => row !== '')
+}
+
+/**
+ * Mount the real slot composition and Screen redraw path.
+ * @param columns - terminal width.
+ * @param rows - terminal height.
+ * @param typed - optional multi-line composer content.
+ * @returns state controls and a draw function.
+ */
+function terminal(columns = COLUMNS, rows = ROWS, typed = ''): {
+  readonly emulator: ReturnType<typeof createEmulator>
+  readonly screen: Screen
+  readonly timer: TurnTimer
+  readonly enabled: { value: boolean }
+  readonly draw: () => void
+} {
+  const emulator = createEmulator(columns, rows)
+  const screen = new Screen(emulator.target)
+  const timer = new TurnTimer()
+  const enabled = { value: true }
+  const slots = new TuiSlots(new Context())
+  const below = (): number => enabled.value ? 2 : 1
+  const composer = new Composer()
+  if (typed !== '') composer.handle({ kind: 'text', text: typed })
+  slots.register('composer', createComposerView(composer, '/work', below))
+  slots.register('timing', createTimingView(timer, () => enabled.value))
+  slots.register('status', createStatusView(() => ({
+    busy: false,
+    tick: 0,
+    elapsedMs: undefined,
+    activity: undefined,
+    model: undefined,
+    effort: undefined,
+    usage: undefined,
+    tokens: undefined,
+    contextWindow: undefined,
+    detail: 'compact',
+    work: undefined,
+    todo: undefined,
+    plan: false,
+    goal: undefined,
+  })))
+  return {
+    emulator,
+    screen,
+    timer,
+    enabled,
+    draw: () => { screen.setLive(slots.compose(columns, rows).lines) },
+  }
+}
+
+describe('the timing live panel on a real terminal', () => {
+  it('is present while on and leaves no row at all while off', async () => {
+    const frame = terminal()
+    frame.draw()
+    expect((await visible(frame.emulator)).join('\n')).toContain('timing · no turn measured yet')
+
+    frame.enabled.value = false
+    frame.draw()
+    const off = (await visible(frame.emulator)).join('\n')
+    expect(off).not.toContain('timing')
+    expect(off).toContain('ask anything')
+    expect(off).toContain('ready')
+  })
+
+  it('grows open measurements between event batches and stops finished tools', async () => {
+    let now = 5_000
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const frame = terminal()
+    frame.timer.observe(event(1_000, 'turn/start', { turn: 1 }))
+    frame.timer.observe(delta(2_000, 'reasoning-delta'))
+    frame.timer.observe(delta(4_000, 'reasoning-delta'))
+    frame.timer.observe(call(4_500, 'a', 'bash'))
+    frame.draw()
+    const first = (await visible(frame.emulator)).join('\n')
+    expect(first).toContain('turn 1 · 4.0s · live')
+    expect(first).toContain('0.5s')
+
+    now = 8_000
+    frame.timer.observe(result(7_000, 'a'))
+    frame.draw()
+    const second = (await visible(frame.emulator)).join('\n')
+    expect(second).toContain('turn 1 · 7.0s · live')
+    expect(second).toContain('2.5s')
+
+    now = 20_000
+    frame.draw()
+    const third = (await visible(frame.emulator)).join('\n')
+    expect(third).toContain('turn 1 · 19.0s · live')
+    expect(third).toContain('2.5s')
+    clock.mockRestore()
+  })
+
+  it('caps tool-heavy turns and keeps the whole live region on screen', async () => {
+    const frame = terminal()
+    frame.timer.observe(event(0, 'turn/start', { turn: 1 }))
+    for (let index = 0; index < 12; index += 1) {
+      const id = String(index)
+      frame.timer.observe(call(index * 10, id, `tool-${id}`))
+      frame.timer.observe(result(2_000 + index, id))
+    }
+    frame.timer.observe(event(3_000, 'turn/end', { turn: 1, reason: 'complete' }))
+    frame.draw()
+    const shown = await visible(frame.emulator)
+    expect(shown.join('\n')).toContain('+8 more')
+    expect(frame.screen.height).toBe(11)
+    expect(frame.screen.height).toBeLessThanOrEqual(ROWS)
+    expect((await frame.emulator.scrollback()).filter(row => row.includes('timing'))).toHaveLength(1)
+  })
+
+  it('keeps its header present when a tall composer spends the rest of the screen', async () => {
+    const rows = 16
+    const typed = Array.from({ length: 20 }, (_unused, index) => `line ${String(index)}`).join('\n')
+    const frame = terminal(COLUMNS, rows, typed)
+    frame.timer.observe(event(0, 'turn/start', { turn: 1 }))
+    frame.draw()
+    const shown = (await visible(frame.emulator)).join('\n')
+    expect(frame.screen.height).toBeLessThanOrEqual(rows)
+    expect(shown).toContain('line 19')
+    expect(shown).toContain('timing · turn 1')
+    expect(shown).toContain('ready')
+  })
+
+  it('fits every logical panel row without wrapping on a narrow terminal', async () => {
+    const columns = 14
+    const frame = terminal(columns, ROWS)
+    frame.timer.observe(event(0, 'turn/start', { turn: 88 }))
+    frame.timer.observe(call(0, 'a', '工具\u001b[2J-name'))
+    frame.timer.observe(result(12_345, 'a'))
+    frame.timer.observe(event(12_345, 'turn/end', { turn: 88, reason: 'complete' }))
+    frame.draw()
+    const shown = await visible(frame.emulator)
+    expect(shown.every(row => displayWidth(row) <= columns)).toBe(true)
+    expect(shown.join('\n')).toContain('timing')
+    expect((await frame.emulator.scrollback()).filter(row => row.includes('╭─ work'))).toHaveLength(1)
+  })
+
+  it('shows a placeholder after resume instead of fabricating timing history', async () => {
+    // A resumed attachment deliberately has a fresh live-only fold. Its replay
+    // omits streamed chunks, so reconstructing a historical chart would be false.
+    const resumed = terminal()
+    resumed.screen.commit(['● reply restored from the session log'])
+    resumed.draw()
+    const shown = (await visible(resumed.emulator)).join('\n')
+    expect(shown).toContain('reply restored from the session log')
+    expect(shown).toContain('timing · no turn measured yet')
+    expect(shown).not.toContain('turn 1')
+  })
+
+  it('does not commit a finished timing panel beneath the reply', async () => {
+    const frame = terminal()
+    frame.timer.observe(event(0, 'turn/start', { turn: 1 }))
+    frame.timer.observe(delta(1_000, 'text-delta'))
+    frame.timer.observe(delta(2_000, 'text-delta'))
+    frame.timer.observe(event(3_000, 'turn/end', { turn: 1, reason: 'complete' }))
+    frame.screen.commit(['● finished reply'])
+    frame.draw()
+    const history = await frame.emulator.scrollback()
+    expect(history.filter(row => row.includes('finished reply'))).toHaveLength(1)
+    expect(history.filter(row => row.includes('timing'))).toHaveLength(1)
+  })
+})

--- a/packages/dshline/tests/timing-frames.spec.ts
+++ b/packages/dshline/tests/timing-frames.spec.ts
@@ -5,6 +5,7 @@ import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { Composer, displayWidth, Screen } from '@dshline/renderer'
 import { describe, expect, it, vi } from 'vitest'
 import { createEmulator } from '../../../tests/emulator.ts'
+import { createCompletion } from '../src/completion.ts'
 import { TuiSlots } from '../src/slots.ts'
 import { createTimingView, TurnTimer } from '../src/timing.ts'
 import { createComposerView, createStatusView } from '../src/views.ts'
@@ -49,13 +50,16 @@ async function visible(emulator: ReturnType<typeof createEmulator>): Promise<str
  * @param columns - terminal width.
  * @param rows - terminal height.
  * @param typed - optional multi-line composer content.
- * @returns state controls and a draw function.
+ * @returns state controls, the slot registry, and a draw function that places
+ *   the hardware cursor exactly as the window does.
  */
 function terminal(columns = COLUMNS, rows = ROWS, typed = ''): {
   readonly emulator: ReturnType<typeof createEmulator>
   readonly screen: Screen
   readonly timer: TurnTimer
   readonly enabled: { value: boolean }
+  readonly slots: TuiSlots
+  readonly composer: Composer
   readonly draw: () => void
 } {
   const emulator = createEmulator(columns, rows)
@@ -89,7 +93,15 @@ function terminal(columns = COLUMNS, rows = ROWS, typed = ''): {
     screen,
     timer,
     enabled,
-    draw: () => { screen.setLive(slots.compose(columns, rows).lines) },
+    slots,
+    composer,
+    draw: () => {
+      // The window's own two-step: compose returns the cursor, and Screen is
+      // what turns it into a hardware position. Drawing lines alone would make
+      // every cursor assertion below vacuously pass.
+      const { lines, cursor } = slots.compose(columns, rows)
+      screen.setLive(lines, cursor)
+    },
   }
 }
 
@@ -202,5 +214,110 @@ describe('the timing live panel on a real terminal', () => {
     const history = await frame.emulator.scrollback()
     expect(history.filter(row => row.includes('finished reply'))).toHaveLength(1)
     expect(history.filter(row => row.includes('timing'))).toHaveLength(1)
+  })
+
+  it('puts the cursor on the visible tail of a scrolled composer, never on the chrome below', async () => {
+    // Ten rows is short enough that the panel's reservation scrolls the buffer:
+    // the composer may draw five of fifteen wrapped rows, so its window is
+    // exactly where render and cursor must agree.
+    const typed = Array.from({ length: 15 }, (_unused, index) => `row ${String(index)}`).join('\n')
+    const frame = terminal(COLUMNS, 10, typed)
+    frame.draw()
+    const place = await frame.emulator.cursor()
+    // Asserted against what a person sees: the hardware cursor must sit ON the
+    // visible tail row. A frame that looks right while the cursor points into
+    // the timing or status row beneath it is precisely the old fault.
+    const shown = await frame.emulator.screen()
+    const tailRow = shown.findIndex(row => row.includes('row 14'))
+    expect(tailRow).toBeGreaterThan(-1)
+    expect(place.row).toBe(tailRow)
+    expect((await frame.emulator.cell(place.column, place.row))?.chars).not.toBe('')
+  })
+
+  it('sheds the empty frame\'s separator before the panel\'s header on a small terminal', () => {
+    // Five rows cannot hold the four-row frame beside the reservation, so the
+    // decorative blank goes while every promise stays: input, header, status.
+    const frame = terminal(COLUMNS, 5)
+    const { lines } = frame.slots.compose(COLUMNS, 5)
+    expect(lines).toHaveLength(5)
+    expect(lines[0]).toContain('╭')
+    const joined = lines.join('\n')
+    expect(joined).toContain('ask anything')
+    expect(joined).toContain('timing · no turn measured yet')
+    expect(joined).toContain('ready')
+    // One row more of room restores the decoration first, pinning the ladder.
+    const roomier = frame.slots.compose(COLUMNS, 6).lines
+    expect(roomier[0]).toBe('')
+    expect(roomier).toHaveLength(6)
+  })
+
+  it('moves the empty-frame cursor up with the shed separator', () => {
+    const frame = terminal()
+    expect(frame.slots.compose(COLUMNS, ROWS).cursor?.row).toBe(2)
+    expect(frame.slots.compose(COLUMNS, 5).cursor?.row).toBe(1)
+  })
+
+  it('keeps input usable when even the reservation cannot hold, and yields the panel', async () => {
+    // Four rows: below the ladder's floor. Usability outranks the reservation
+    // there — the same priority that lets the panel give up body rows ahead of
+    // its header — so the panel goes whole rather than the input box.
+    const frame = terminal(COLUMNS, 4)
+    frame.draw()
+    expect(frame.screen.height).toBeLessThanOrEqual(4)
+    const joined = (await visible(frame.emulator)).join('\n')
+    expect(joined).toContain('ask anything')
+    expect(joined).toContain('ready')
+    expect(joined).not.toContain('timing')
+  })
+
+  it('sheds the separator on a filled frame too, so a paste still fits a five-row terminal', async () => {
+    const typed = Array.from({ length: 30 }, (_unused, index) => `pasted ${String(index)}`).join('\n')
+    const frame = terminal(COLUMNS, 5, typed)
+    frame.draw()
+    expect(frame.screen.height).toBeLessThanOrEqual(5)
+    const joined = (await visible(frame.emulator)).join('\n')
+    // Scrolled, not lost: the elision count says what the window gave up.
+    expect(joined).toContain('+29 rows')
+    expect(joined).toContain('no turn measured yet')
+    expect(joined).toContain('ready')
+  })
+
+  it('holds composer, completion, timing, and status together on a short terminal', async () => {
+    // The whole ordinary composition at once: a slash command mid-word opens the
+    // suggestion list while the panel is live, and every reservation has to hold.
+    const frame = terminal(COLUMNS, 14, '/tim')
+    const completion = createCompletion(frame.composer, {
+      commands: () => [
+        { name: 'timing', description: 'live turn panel' },
+        { name: 'todos', description: 'todo list' },
+        { name: 'tool-output', description: 'inspector' },
+        { name: 'profiles', description: 'profile browser' },
+        { name: 'plugins', description: 'plugin list' },
+        { name: 'sessions', description: 'session browser' },
+        { name: 'usage', description: 'cost reading' },
+      ],
+      commandArguments: async () => [],
+      paths: async () => [],
+    }, () => {}, () => 2)
+    await completion.refresh()
+    expect(completion.active).toBe(true)
+    frame.slots.register('completion', completion.view)
+    // A start near the real clock, because an OPEN turn reads its total
+    // provisionally against Date.now(): starting at zero would chart the age of
+    // the epoch and push the `live` mark onto a narrower heading.
+    frame.timer.observe(event(Date.now() - 4_000, 'turn/start', { turn: 1 }))
+    frame.draw()
+    expect(frame.screen.height).toBeLessThanOrEqual(14)
+    const shown = await visible(frame.emulator)
+    const joined = shown.join('\n')
+    expect(joined).toContain('timing · turn 1')
+    expect(joined).toContain('· live')
+    expect(joined).toContain('ready')
+    // The cursor belongs to the text being completed, with the list open above
+    // the panel — not to whatever chrome the shrinking budgets left below.
+    // Indexed against the RAW screen: `visible()` drops blank rows, and the
+    // separator blank is exactly what shifts positional indices here.
+    const place = await frame.emulator.cursor()
+    expect((await frame.emulator.screen())[place.row] ?? '').toContain('/tim')
   })
 })

--- a/packages/dshline/tests/timing.spec.ts
+++ b/packages/dshline/tests/timing.spec.ts
@@ -37,9 +37,8 @@ const ends = (time: number, turn = 1): SessionEvent =>
  */
 function profile(events: readonly SessionEvent[]): TurnTiming | undefined {
   const timer = new TurnTimer()
-  let finished: TurnTiming | undefined
-  for (const one of events) finished = timer.observe(one) ?? finished
-  return finished
+  for (const one of events) timer.observe(one)
+  return timer.snapshot()
 }
 
 /** The spans of a profile as a plain label-to-milliseconds map. */
@@ -131,7 +130,8 @@ describe('TurnTimer', () => {
     timer.observe(event(6_000, 'turn/start', { turn: 2 }))
     timer.observe(delta(6_000, 0, 'text-delta'))
     timer.observe(delta(8_000, 0, 'text-delta'))
-    expect(spans(timer.observe(ends(9_000, 2)))).toEqual({ output: 2_000 })
+    timer.observe(ends(9_000, 2))
+    expect(spans(timer.snapshot())).toEqual({ output: 2_000 })
   })
 
   it('drops a span that finished inside one timestamp', () => {
@@ -146,6 +146,31 @@ describe('TurnTimer', () => {
     ])
     expect(spans(finished)).toEqual({ output: 3_000 })
   })
+
+  it('ticks open totals and tools, then keeps their event-derived finish', () => {
+    const timer = new TurnTimer()
+    timer.observe(event(1_000, 'turn/start', { turn: 3 }))
+    timer.observe(call(2_000, 'a', 'bash'))
+    expect(timer.snapshot(5_000)).toMatchObject({
+      turn: 3,
+      totalMs: 4_000,
+      running: true,
+      spans: [{ label: 'bash', ms: 3_000, running: true }],
+    })
+    timer.observe(result(6_000, 'a'))
+    expect(timer.snapshot(9_000)?.spans).toEqual([{ label: 'bash', ms: 4_000, running: false }])
+    timer.observe(ends(10_000, 3))
+    expect(timer.snapshot(99_000)).toMatchObject({ totalMs: 9_000, running: false })
+  })
+
+  it('observes a whole live turn even when presentation is enabled midway through it', () => {
+    const timer = new TurnTimer()
+    timer.observe(event(1_000, 'turn/start', { turn: 4 }))
+    timer.observe(delta(2_000, 0, 'reasoning-delta'))
+    timer.observe(delta(4_000, 0, 'reasoning-delta'))
+    expect(timer.snapshot(5_000)).toMatchObject({ turn: 4, totalMs: 4_000, running: true })
+    expect(spans(timer.snapshot(5_000))).toEqual({ reasoning: 2_000 })
+  })
 })
 
 describe('timingLines()', () => {
@@ -155,8 +180,13 @@ describe('timingLines()', () => {
    * @param columns - the terminal width.
    * @returns the lines a person would see.
    */
-  function chart(spans: readonly TurnSpan[], columns = 100): string[] {
-    return timingLines({ turn: 14, totalMs: 42_800, spans }, columns).map(stripAnsi)
+  function chart(spans: readonly Omit<TurnSpan, 'running'>[], columns = 100): string[] {
+    return timingLines({
+      turn: 14,
+      totalMs: 42_800,
+      running: false,
+      spans: spans.map(span => ({ ...span, running: false })),
+    }, columns).map(stripAnsi)
   }
 
   /** Cells in a row's bar. */
@@ -219,7 +249,16 @@ describe('timingLines()', () => {
     expect(lines).toContain('18.2s')
   })
 
-  it('draws nothing when there was nothing to measure', () => {
-    expect(timingLines({ turn: 1, totalMs: 900, spans: [] }, 100)).toEqual([])
+  it('keeps a placeholder present before this attachment measures a turn', () => {
+    expect(timingLines(undefined, 100).map(stripAnsi)).toEqual(['  timing · no turn measured yet'])
+  })
+
+  it('caps span rows and reports how many were elided', () => {
+    const lines = chart(Array.from({ length: 9 }, (_, index) => ({
+      label: `tool-${String(index)}`,
+      ms: 10_000 - index,
+    })))
+    expect(lines).toHaveLength(6)
+    expect(lines.at(-1)).toContain('+5 more')
   })
 })


### PR DESCRIPTION
## What changed

`/timing` no longer dumps a static bar chart under each finished reply. It now renders a **persistent, bounded live panel** in the live region:

- **On:** persistent whenever the live-region budget permits. During a turn it updates in real time — reasoning/output spans grow as chunks arrive, tools appear when called and freeze at their measured total on result, the header's wall clock ticks live (`timing · turn 3 · 41.2s · live`). While idle it retains the most recent finished turn; after a resume it shows `timing · no turn measured yet` rather than fabricating history from a replay that carries no `assistant/chunk` events.
- **Off:** every row disappears — nothing is shown at all.
- **Degradation:** timing is optional instrumentation and yields before critical interaction chrome. On an extremely short terminal its span rows go first, then its header; input and status stay usable to the end, and the composer sheds only its decorative separator before touching rows reserved for others.
- The finished chart is deliberately **no longer committed to scrollback**: with a persistent panel, keeping both read as two sources of truth for one measurement.

Visual style follows the Work overlay rows (dim label column, cyan bar, right-aligned duration), capped at six rows: header + four spans + `… +N more`, so the bounded live region cannot grow with tool count.

## Design decisions

Implemented by a Codex agent against five reviewer-proposed starting points; verdicts recorded here:

- **(a) Presentation — agreed, plain indented panel, no box**, as its own `timing` slot between `completion` and `status`.
- **(b) Data — agreed**: new `TurnTimer.snapshot()` yields incremental state; the existing attachment-scoped spinner heartbeat drives redraws (no second timer). Observation runs regardless of the preference, so enabling mid-turn is immediately truthful instead of inventing a partial turn from the toggle.
- **(c) End-of-turn — agreed to stop committing to scrollback**; panel retains the latest completed turn while idle.
- **(d) Bounds — agreed**: hard cap of six rows with elision; composer/completion reserve the panel's minimum row.
- **(e) Real-time vs log-timestamp principle — agreed with an explicit exception**, documented in the module header: completed measurements stay event-timestamp-derived; only open turns/tools tick provisionally against the wall clock because their closing event has not arrived.

One assumption needed refinement during implementation: `TuiSlots` subtracts rows spent *above* a view but reserved nothing *below* it, so merely adding and capping a slot would not guarantee persistent presence beside a tall composer or completion list. Those views now carry an explicit conditional downstream reservation. A review pass (`3e4fda8`) then closed the two gaps that reservation left: `cursor()` now receives the same unspent-row budget as `render()` (one shared calculation inside the composer), and the frame sheds decoration before structure on terminals too short for everything.

## Verification

- `pnpm build`, `pnpm typecheck`, full suite: **1443 passed / 1 skipped**; `pnpm audit` clean; zizmor (pedantic): no findings.
- xterm frame coverage (`packages/dshline/tests/timing-frames.spec.ts`): visible when on / absent when off, real-time growth between event batches, row capping, narrow terminals, resume placeholder, clean scrollback — plus, after the review commit: shared cursor/render budget with the hardware cursor asserted **on the visible tail cell** of a scrolled composer on a short terminal, empty/filled separator shedding with the cursor following, input surviving an impossibly small terminal while the panel yields whole, and composer + completion + timing + status held together on a fourteen-row terminal.
- Break-your-fix checks: inverted enable guard → named on/off frame test failed; cap raised 6→60 → capping test failed; snapshots frozen at turn start → growth test failed; restored fixed-10-row cursor → visible-tail regression failed by name; reverted separator shedding → named ladder tests failed by name.
- Minor changeset included (`red-cups-move.md`).

🤖 Co-authored implementation: Codex agent (design verdicts above); review fixes, verification, and PR upkeep by ox-alpha.
