### PR TITLE
feat(dshline): add /new to start a fresh session

### DIFF
--- a/.changeset/new-command.md
+++ b/.changeset/new-command.md
@@ -1,0 +1,5 @@
+---
+"@dshline/dshline": minor
+---
+
+Add `/new` to start a fresh session in the current window while keeping the previous conversation saved for reopening.

--- a/.changeset/new-command.md
+++ b/.changeset/new-command.md
@@ -2,4 +2,4 @@
 "@dshline/dshline": minor
 ---
 
-Add `/new` to start a fresh session in the current window while keeping the previous conversation saved for reopening.
+Add `/new` to start a fresh session in the current workspace, with the previous conversation available for reopening when Harness session persistence is enabled.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ See [Design](docs/design.md) for the terminal invariants and [Comparison](docs/c
 
 Type `/` to discover the commands and capabilities available in the active Harness profile.
 
+- `/new` — start a fresh session (the current one stays saved)
 - `/sessions` — browse and resume Harness sessions
 - `/work` — inspect jobs and subagents
 - `/connect` — configure providers through Harness

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See [Design](docs/design.md) for the terminal invariants and [Comparison](docs/c
 
 Type `/` to discover the commands and capabilities available in the active Harness profile.
 
-- `/new` — start a fresh session (the current one stays saved)
+- `/new` — start a fresh session in the current workspace; the previous one is reopenable when the active Harness profile provides session persistence
 - `/sessions` — browse and resume Harness sessions
 - `/work` — inspect jobs and subagents
 - `/connect` — configure providers through Harness

--- a/docs/design.md
+++ b/docs/design.md
@@ -235,7 +235,7 @@ A command may also succeed with no text at all. That is a valid result, and the 
 
 A line that is rejected as an unknown command is different: nothing ran, so the harness records nothing, and the message comes from this interface alone. It is not part of the saved conversation and does not reappear when the session is reopened.
 
-`/exit`, `/quit`, `/model`, `/reasoning`, `/usage`, and `/timing` are answered by this interface rather than registered with the harness. The harness's command registry is shared by every interface in the process, and a web page or an automation server has no terminal to leave, no picker to open, and no status line to switch a reading on and off in. They still appear in the `/` list next to the others, because someone typing `/` wants to see what they can type, not which registry it came from.
+`/exit`, `/quit`, `/model`, `/reasoning`, `/usage`, `/timing`, and `/new` are answered by this interface rather than registered with the harness. The harness's command registry is shared by every interface in the process, and a web page or an automation server has no terminal to leave, no picker to open, and no status line to switch a reading on and off in. They still appear in the `/` list next to the others, because someone typing `/` wants to see what they can type, not which registry it came from.
 
 A line that looks like a command but names nothing is reported as unknown, using the harness's own rule for what a command line is, so the two cannot disagree.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -277,7 +277,12 @@ because quitting means the same thing everywhere.
 
 ## Sessions and resuming
 
-Sessions are saved by the harness, so a conversation survives quitting. `--resume` rebuilds the transcript from the saved log and redraws it through the *same* code that drew it live, so a reopened session looks exactly like the one you watched happen. Two separate drawing paths would have drifted apart the first time either changed.
+When the active profile provides Harness session persistence, `--resume` rebuilds
+the transcript from the persisted log and redraws it through the *same* code that
+drew it live, so a reopened session looks exactly like the one you watched
+happen. Two separate drawing paths would have drifted apart the first time either
+changed. Profiles without persistence can still run fresh sessions; dshline does
+not add another store.
 
 What gets replayed is the record of what was actually said, not the version the model currently sees. Those differ: when history is summarized to save context, the model's view hides the messages that were replaced. Replaying that view would erase parts of the conversation you had already read. They are gone from the model's memory, but they still happened.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,7 +82,7 @@ Type `/` to see the commands your agent actually has. They come from two places.
 | `/usage` | Choose what the status line reports: `cost`, `tokens`, or `off`. Opens a picker with no argument |
 | `/timing` | `on` or `off` for the persistent live turn-timing panel; bare flips it |
 | `/work` | Open a bounded live view of active Harness jobs and subagents |
-| `/new` | Start a fresh session in this window; this conversation stays saved and reopenable from `/sessions` |
+| `/new` | Start a fresh session in the current workspace; the previous one remains reopenable when the active Harness profile provides session persistence |
 | `/sessions` | Browse, search, and reopen past sessions without leaving the window |
 | `/todos` | Open a bounded read-only view of the current Harness Todo list |
 | `/exit`, `/quit` | Leave, the same as `ctrl-d` |
@@ -753,14 +753,18 @@ If you want ordinary tool calls to ask first, add a plugin that makes that decis
 
 ## Sessions
 
-Sessions are saved by the harness itself, so a conversation survives quitting:
+When the active profile provides Harness session persistence, conversations can
+survive quitting and be reopened:
 
 ```sh
 dsh --profile dshline --resume          # browse, search, and choose one
 dsh --profile dshline --resume <id>     # reopen a session directly
 ```
 
-A reopened session looks exactly like the one you watched happen — reasoning, diffs, tool output and all — because the saved log is redrawn through the same code that drew it live.
+A reopened session looks exactly like the one you watched happen — reasoning,
+diffs, tool output and all — because its persisted log is redrawn through the
+same code that drew it live. Profiles without session persistence still support
+fresh conversations, but cannot offer those conversations again after they end.
 
 You do not have to decide at launch. `/sessions` opens the same browser from
 inside a running window and reopens a session in place; see

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,7 +54,7 @@ When no suggestion list is open, `↑` steps back through the lines you sent thi
 
 Consecutive identical submissions are remembered once, so running `run tests` three times in a row does not fill the history with three copies of it.
 
-Reopening a session restores the history the saved log recorded: every prompt and every resolved slash command whose input was recorded. The commands this interface handles itself (`/model`, `/reasoning`, `/usage`, `/timing`, `/sessions`, `/work`, `/todos`, `/exit`, `/quit`) and mistyped commands are remembered while the session is open but are not written to the session log, so they are not restored after a resume.
+Reopening a session restores the history the saved log recorded: every prompt and every resolved slash command whose input was recorded. The commands this interface handles itself (`/model`, `/reasoning`, `/usage`, `/timing`, `/new`, `/sessions`, `/work`, `/todos`, `/exit`, `/quit`) and mistyped commands are remembered while the session is open but are not written to the session log, so they are not restored after a resume.
 
 ### About shift-enter
 
@@ -82,6 +82,7 @@ Type `/` to see the commands your agent actually has. They come from two places.
 | `/usage` | Choose what the status line reports: `cost`, `tokens`, or `off`. Opens a picker with no argument |
 | `/timing` | `on` or `off` for the persistent live turn-timing panel; bare flips it |
 | `/work` | Open a bounded live view of active Harness jobs and subagents |
+| `/new` | Start a fresh session in this window; this conversation stays saved and reopenable from `/sessions` |
 | `/sessions` | Browse, search, and reopen past sessions without leaving the window |
 | `/todos` | Open a bounded read-only view of the current Harness Todo list |
 | `/exit`, `/quit` | Leave, the same as `ctrl-d` |

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -371,7 +371,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     },
     {
       name: 'new',
-      description: 'Start a fresh session in this window, leaving this one saved',
+      description: 'Start a fresh session in the current workspace',
       execute: rawInput => {
         if (rawInput.trim() !== '') {
           commit([style('\u2717 /new takes no argument', 'red')])
@@ -391,7 +391,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
           return
         }
         commit([style('· starting a new session…', 'gray')])
-        requestNext({ kind: 'new' })
+        requestNext({ kind: 'new', cwd: workspace })
         draw()
       },
     },

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -13,7 +13,6 @@
  */
 
 import { createUserMessage } from '@deepseek-ai/dsh-llm'
-import { SessionId } from '@deepseek-ai/dsh-session'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 // Empty type imports carry the Context merges this module reads but does not
 // otherwise import from: the questions seam and the launcher's exit request. The
@@ -54,7 +53,8 @@ import { listConnectTargets, openConnect } from './connect/index.ts'
 import { openPlugins } from './plugins/index.ts'
 import { openProfiles } from './profiles/index.ts'
 import { browseSessions } from './sessions/index.ts'
-import type { AttachOutcome } from './sessions/reopen.ts'
+import { planNew } from './sessions/plan.ts'
+import type { AttachOutcome, AttachTarget } from './sessions/reopen.ts'
 import { StreamBuffer } from './stream.ts'
 import { effortLabel, pickReasoning, reasoningValues } from './reasoning.ts'
 import { createTimingView, TurnTimer } from './timing.ts'
@@ -95,7 +95,7 @@ const COMMAND_TIMEOUT_MS = 120_000
 const CLEAR_DISPLAY = '\u001b[2J\u001b[H'
 
 /**
- * Drive one session until the reader reopens another.
+ * Drive one session until the reader chooses the next attachment target.
  *
  * Everything registered here is owned by a {@link SessionScope} rather than by
  * the plugin fiber, because all of it — the slot views, the log projection, the
@@ -105,17 +105,17 @@ const CLEAR_DISPLAY = '\u001b[2J\u001b[H'
  * the reader is leaving.
  * @param w - the window this session is attached to.
  * @param outcome - the agent the loop opened, and the target it came from.
- * @returns the session to attach next, once the reader has asked for it.
+ * @returns the target to attach next, once the reader has asked for it.
  */
-export async function attachSession(w: Window, outcome: AttachOutcome): Promise<SessionId> {
+export async function attachSession(w: Window, outcome: AttachOutcome): Promise<AttachTarget> {
   const { ctx, terminal, exit, startup, pricing, peakHours, selection, prefs, draw, commit } = w
   const { target, attached } = outcome
   const scope = new SessionScope()
-  // Created before anything can ask for it: a `/sessions` choice made while the
+  // Created before anything can ask for it: a transition requested while the
   // transcript is still replaying must not resolve into a promise that does not
   // exist yet.
-  let requestSwitch: (sessionId: SessionId) => void = () => {}
-  const switched = new Promise<SessionId>(resolve => { requestSwitch = resolve })
+  let requestNext: (target: AttachTarget) => void = () => {}
+  const switched = new Promise<AttachTarget>(resolve => { requestNext = resolve })
   const { agent, dispose: disposeAgent } = attached.handle
 
   // Held until after the banner, so the transcript reads in the order it
@@ -365,7 +365,33 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
           busy: () => agent.status === 'running',
           activeWork: () => activeWorkCount(work.snapshot()),
         })
-        if (chosen !== undefined) requestSwitch(chosen)
+        if (chosen !== undefined) requestNext({ kind: 'resume', id: chosen })
+        draw()
+      },
+    },
+    {
+      name: 'new',
+      description: 'Start a fresh session in this window, leaving this one saved',
+      execute: rawInput => {
+        if (rawInput.trim() !== '') {
+          commit([style('\u2717 /new takes no argument', 'red')])
+          draw()
+          return
+        }
+        // `/new` retires a live agent exactly like `/sessions` does, so it must
+        // pass the same capability checks rather than tearing one down while
+        // Harness has not defined the fate of its active work.
+        const plan = planNew({
+          busy: agent.status === 'running',
+          activeWork: activeWorkCount(work.snapshot()),
+        })
+        if (plan.kind === 'refused') {
+          commit([style(plan.message, 'red')])
+          draw()
+          return
+        }
+        commit([style('· starting a new session…', 'gray')])
+        requestNext({ kind: 'new' })
         draw()
       },
     },
@@ -828,15 +854,15 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   //
   // Both halves are reported rather than thrown. A rejected teardown would
   // otherwise reach the runner's boot-failure path and end the window over a
-  // session the reader has already left; the next attachment resumes a different
-  // id, so it does not collide with whatever failed to come down.
+  // session the reader has already left; the next attachment drives another
+  // target, so it does not collide with whatever failed to come down.
   try {
     scope.dispose()
   } catch (error: unknown) {
     report(error)
   }
   const closing = ctx.tuiSlots.register('status', {
-    render: (): string[] => [style('· reopening a session…', 'gray')],
+    render: (): string[] => [style('· switching sessions…', 'gray')],
   })
   draw()
   try {

--- a/packages/dshline/src/index.ts
+++ b/packages/dshline/src/index.ts
@@ -114,7 +114,7 @@ export function apply(ctx: Context, config?: Config): void {
  * Own the terminal for the life of this plugin and drive its sessions.
  *
  * Never resolves in normal use: each attachment settles only when the reader
- * reopens another session, and leaving is `ctx.appExit`. Nothing awaits this
+ * chooses the next session, and leaving is `ctx.appExit`. Nothing awaits this
  * promise, which is why an endless loop is the right shape rather than a leak —
  * the alternative, returning after the first session, is what made reopening one
  * impossible.
@@ -130,7 +130,7 @@ export function apply(ctx: Context, config?: Config): void {
 async function run(ctx: Context, pricing: PricingTable, peakHours: readonly PeakWindow[]): Promise<void> {
   const w = await createWindow(ctx, { pricing, peakHours, version: VERSION })
   // The launch flag decides the FIRST target only. Everything after it is the
-  // reader's own choice, made in the same browser.
+  // reader's own choice, made through the session browser or `/new`.
   let target: AttachTarget = w.startup.resume === undefined
     ? { kind: 'new' }
     : w.startup.resume === true
@@ -151,6 +151,6 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
       report: reason => { w.commit(reopenFailureLines(reason)) },
       ask: () => chooseTarget(w),
     }, target)
-    target = { kind: 'resume', id: await attachSession(w, outcome) }
+    target = await attachSession(w, outcome)
   }
 }

--- a/packages/dshline/src/index.ts
+++ b/packages/dshline/src/index.ts
@@ -39,7 +39,7 @@ import type {} from '@deepseek-ai/dsh-cmdline'
 import { attachSession } from './attachment.ts'
 import { pluginsSeams } from './plugins/harness.ts'
 import type { AttachTarget } from './sessions/reopen.ts'
-import { attachTarget, reopenFailureLines } from './sessions/reopen.ts'
+import { attachTarget, newSessionFailureLines, reopenFailureLines } from './sessions/reopen.ts'
 import { TuiSlots } from './slots.ts'
 import type { ModelRates, PeakWindow, PricingTable } from './usage.ts'
 import { parsePeakWindows, pricingFrom } from './usage.ts'
@@ -148,7 +148,9 @@ async function run(ctx: Context, pricing: PricingTable, peakHours: readonly Peak
       // current default today.
       newSessionPreset: () => pluginsSeams(ctx).agentPresets?.defaultId,
       options: attachOptions(w),
-      report: reason => { w.commit(reopenFailureLines(reason)) },
+      report: (kind, reason) => {
+        w.commit(kind === 'new' ? newSessionFailureLines(reason) : reopenFailureLines(reason))
+      },
       ask: () => chooseTarget(w),
     }, target)
     target = await attachSession(w, outcome)

--- a/packages/dshline/src/sessions/index.ts
+++ b/packages/dshline/src/sessions/index.ts
@@ -38,7 +38,7 @@ export type { ResumeRequest, SessionsOverlaySpec } from './overlay.ts'
 export type { ResumeConditions, ResumePlan } from './plan.ts'
 export { planResume } from './plan.ts'
 export type { AgentOpener, Attached, AttachOutcome, AttachSpec, AttachTarget } from './reopen.ts'
-export { attachTarget, reopenFailureLines } from './reopen.ts'
+export { attachTarget, newSessionFailureLines, reopenFailureLines } from './reopen.ts'
 
 /** What opening the browser needs to know about the window it opens over. */
 export interface BrowseSpec {

--- a/packages/dshline/src/sessions/plan.ts
+++ b/packages/dshline/src/sessions/plan.ts
@@ -1,11 +1,11 @@
 /**
- * Whether reopening a session is a safe thing to do right now.
+ * Whether leaving for another session is a safe thing to do right now.
  *
- * Resuming from inside a running window is not the same act as resuming at
- * launch. At launch there is nothing to lose; from inside a session it retires a
- * live Agent, and `AgentHandle.dispose()` stops that agent's loop, removes its
- * session from the store, and unwinds its whole scoped world — including
- * anything a capability started under it.
+ * Switching from inside a running window is not the same act as choosing a
+ * target at launch. At launch there is nothing to lose; from inside a session
+ * it retires a live Agent, and `AgentHandle.dispose()` stops that agent's loop,
+ * removes its session from the store, and unwinds its whole scoped world —
+ * including anything a capability started under it.
  *
  * That is the "observation is not control" rule applied to a lifecycle call the
  * frontend genuinely owns. The handle disposer IS this frontend's capability: it
@@ -14,7 +14,7 @@
  * mid-flight, so the frontend refuses in exactly the states where it would be
  * guessing, and says which one it is refusing on.
  *
- * Pure and separate from the overlay because these are the rules worth pinning
+ * Pure and separate from presentation because these are the rules worth pinning
  * with tests; drawing them is the easy half.
  * @module dshline/sessions/plan
  */
@@ -34,12 +34,44 @@ export interface ResumeConditions {
   readonly activeWork: number
 }
 
+/** Everything the new-session decision depends on, gathered by the caller. */
+export interface NewConditions {
+  /** Whether the current agent is mid-turn. */
+  readonly busy: boolean
+  /** Jobs and subagents currently attached to the session being left. */
+  readonly activeWork: number
+}
+
 /** The decision, and the sentence to show when it is no. */
 export type ResumePlan =
   /** Retire the current agent, if any, and resume the target. */
   | { readonly kind: 'resume' }
   /** Do nothing; `message` says why, in words a reader can act on. */
   | { readonly kind: 'refused'; readonly message: string }
+
+/** The decision to start fresh, and the sentence to show when it is no. */
+export type NewPlan =
+  /** Retire the current agent and start a fresh session. */
+  | { readonly kind: 'new' }
+  /** Do nothing; `message` says why, in words a reader can act on. */
+  | { readonly kind: 'refused'; readonly message: string }
+
+/**
+ * Explain why work still owned by this agent prevents retiring it.
+ * @param activeWork - jobs and subagents attached to the current session.
+ * @returns the refusal, or undefined when no work blocks the transition.
+ */
+function activeWorkRefusal(
+  activeWork: number,
+): { readonly kind: 'refused'; readonly message: string } | undefined {
+  if (activeWork <= 0) return undefined
+  const singular = activeWork === 1
+  const subject = `${String(activeWork)} job${singular ? '' : 's'} or subagent${singular ? '' : 's'}`
+  return {
+    kind: 'refused',
+    message: `${subject} ${singular ? 'is' : 'are'} still attached to this session.`,
+  }
+}
 
 /**
  * Decide whether to reopen one session.
@@ -75,12 +107,18 @@ export function planResume(conditions: ResumeConditions): ResumePlan {
   // The refused case Harness does not answer: a job or a delegated child is
   // owned by the agent about to be retired, and no generic seam says whether a
   // human-initiated owner teardown should stop it, orphan it, or wait for it.
-  if (activeWork > 0) {
-    const plural = activeWork === 1 ? 'is' : 'are'
-    return {
-      kind: 'refused',
-      message: `${String(activeWork)} job${activeWork === 1 ? '' : 's'} or subagent${activeWork === 1 ? '' : 's'} ${plural} still attached to this session.`,
-    }
+  return activeWorkRefusal(activeWork) ?? { kind: 'resume' }
+}
+
+/**
+ * Decide whether to retire this attachment and start a fresh session.
+ * @param conditions - the gathered capability facts.
+ * @returns the plan, carrying a refusal message when the answer is no.
+ */
+export function planNew(conditions: NewConditions): NewPlan {
+  const { busy, activeWork } = conditions
+  if (busy) {
+    return { kind: 'refused', message: 'Finish or interrupt the current turn before starting a new session.' }
   }
-  return { kind: 'resume' }
+  return activeWorkRefusal(activeWork) ?? { kind: 'new' }
 }

--- a/packages/dshline/src/sessions/reopen.ts
+++ b/packages/dshline/src/sessions/reopen.ts
@@ -11,8 +11,10 @@
  * question the launch path asks and leaves the reader in control. Dismissing it
  * is how they choose a new session, deliberately.
  *
- * A failed `create` is deliberately NOT caught. There is nothing to fall back to
- * and nothing to ask; it belongs on the runner's boot-failure path.
+ * A failed launch-time `create` is deliberately NOT caught. There is nothing to
+ * fall back to and nothing to ask; it belongs on the runner's boot-failure path.
+ * An in-window `/new` is different: its target carries the attachment's current
+ * workspace, so failure is reported and the same browser asks what to do next.
  *
  * Narrowed to two calls and two callbacks so the policy is testable without a
  * plugin tree or a terminal.
@@ -28,9 +30,11 @@ export type AttachTarget =
   /**
    * Open a fresh session. `afterDismissal` marks the one case worth a note: the
    * window asked which session to open and the reader chose none, where silence
-   * would read as the request having been ignored.
+   * would read as the request having been ignored. `cwd` is present on a live
+   * attachment's `/new` transition and any fresh retry after it: it preserves
+   * that attachment's workspace and distinguishes recoverable creation from boot.
    */
-  | { readonly kind: 'new'; readonly afterDismissal?: boolean }
+  | { readonly kind: 'new'; readonly afterDismissal?: boolean; readonly cwd?: string }
   /** Reopen this persisted session. */
   | { readonly kind: 'resume'; readonly id: SessionId }
 
@@ -61,7 +65,7 @@ export interface AttachSpec {
   readonly agents: AgentOpener
   /** Mint the id for a new session; called only when one is created. */
   readonly newSessionId: () => SessionId
-  /** Workspace for a new session; a reopened one keeps its own header's. */
+  /** Startup workspace for a new target that does not carry one of its own. */
   readonly cwd: string
   /**
    * The preset a new session's header records at creation, when a preset
@@ -73,8 +77,8 @@ export interface AttachSpec {
   readonly newSessionPreset: () => string | undefined
   /** Route and setup shared by both paths, read at attach time. */
   readonly options: Omit<ResumeAgentOptions, 'resumeSessionId'>
-  /** Say why reopening failed, in the transcript, before asking again. */
-  readonly report: (reason: string) => void
+  /** Say which attachment operation failed, in the transcript, before asking again. */
+  readonly report: (kind: 'new' | 'resume', reason: string) => void
   /** Ask which session to open; dismissal answers `{ kind: 'new' }`. */
   readonly ask: () => Promise<AttachTarget>
 }
@@ -104,6 +108,18 @@ export function reopenFailureLines(reason: string): string[] {
 }
 
 /**
+ * The lines a failed in-window `/new` commits before the browser is asked again.
+ * @param reason - Harness's own message; untrusted, so it is escaped here.
+ * @returns lines to write into scrollback.
+ */
+export function newSessionFailureLines(reason: string): string[] {
+  return [
+    style(`✗ could not start a new session: ${escapeControls(reason)}`, 'red'),
+    style('· choose a session, or press esc to try fresh again', 'gray'),
+  ]
+}
+
+/**
  * Resolve a target into an attached agent, asking again while reopening fails.
  *
  * Loops on the reader's answer, not on its own: every failure is reported and
@@ -116,15 +132,33 @@ export function reopenFailureLines(reason: string): string[] {
  */
 export async function attachTarget(spec: AttachSpec, first: AttachTarget): Promise<AttachOutcome> {
   let target = first
+  // Kept across reader choices after a failed `/new`: choosing a broken resume
+  // and then trying fresh must not quietly fall back to the launch directory.
+  const recoveryCwd = first.kind === 'new' ? first.cwd : undefined
   for (;;) {
     if (target.kind === 'new') {
       const preset = spec.newSessionPreset()
-      const handle = await spec.agents.create({
-        sessionId: spec.newSessionId(),
-        meta: { cwd: spec.cwd, ...preset === undefined ? {} : { agentPreset: preset } },
-        ...spec.options,
-      })
-      return { target, attached: { handle, reopened: false } }
+      const cwd = target.cwd ?? recoveryCwd ?? spec.cwd
+      try {
+        const handle = await spec.agents.create({
+          sessionId: spec.newSessionId(),
+          meta: { cwd, ...preset === undefined ? {} : { agentPreset: preset } },
+          ...spec.options,
+        })
+        const attachedTarget = target.cwd === undefined && recoveryCwd !== undefined
+          ? { ...target, cwd: recoveryCwd }
+          : target
+        return { target: attachedTarget, attached: { handle, reopened: false } }
+      } catch (error: unknown) {
+        // No cwd means application boot or a normal browser dismissal. Those
+        // failures still belong to the runner's boot-failure path; only `/new`
+        // has already retired a healthy attachment and has somewhere to return.
+        if (recoveryCwd === undefined) throw error
+        spec.report('new', error instanceof Error ? error.message : String(error))
+        const chosen = await spec.ask()
+        target = chosen.kind === 'new' ? { ...chosen, cwd: recoveryCwd } : chosen
+        continue
+      }
     }
     try {
       const handle = await spec.agents.resume({ resumeSessionId: target.id, ...spec.options })
@@ -134,8 +168,11 @@ export async function attachTarget(spec: AttachSpec, first: AttachTarget): Promi
       // persistence is unmounted, because the log fails replay validation, or
       // because a header is from an incompatible format version, and the reader's
       // next move is the same for all of them.
-      spec.report(error instanceof Error ? error.message : String(error))
-      target = await spec.ask()
+      spec.report('resume', error instanceof Error ? error.message : String(error))
+      const chosen = await spec.ask()
+      target = chosen.kind === 'new' && recoveryCwd !== undefined
+        ? { ...chosen, cwd: recoveryCwd }
+        : chosen
     }
   }
 }

--- a/packages/dshline/tests/sessions-plan.spec.ts
+++ b/packages/dshline/tests/sessions-plan.spec.ts
@@ -5,7 +5,7 @@ import type { AgentHandle, CreateAgentOptions, ResumeAgentOptions } from '@deeps
 import type { SessionId } from '@deepseek-ai/dsh-session'
 import { stripAnsi } from '@dshline/renderer'
 import type { SessionEntry } from '../src/sessions/model.ts'
-import { planResume } from '../src/sessions/plan.ts'
+import { planNew, planResume } from '../src/sessions/plan.ts'
 import type { AgentOpener, AttachTarget } from '../src/sessions/reopen.ts'
 import { attachTarget, reopenFailureLines } from '../src/sessions/reopen.ts'
 
@@ -85,6 +85,36 @@ describe('whether a session may be reopened', () => {
       activeWork: 2,
     })
     expect(plan.kind === 'refused' && plan.message).toContain('already open')
+  })
+})
+
+describe('whether a fresh session may be started', () => {
+  it('accepts while the current session is idle', () => {
+    expect(planNew({ busy: false, activeWork: 0 })).toEqual({ kind: 'new' })
+  })
+
+  it('refuses mid-turn with the new-session instruction', () => {
+    const plan = planNew({ busy: true, activeWork: 0 })
+    expect(plan.kind === 'refused' && plan.message)
+      .toBe('Finish or interrupt the current turn before starting a new session.')
+  })
+
+  it('refuses while one job or subagent is still attached', () => {
+    const plan = planNew({ busy: false, activeWork: 1 })
+    expect(plan.kind === 'refused' && plan.message)
+      .toBe('1 job or subagent is still attached to this session.')
+  })
+
+  it('refuses while several jobs or subagents are still attached', () => {
+    const plan = planNew({ busy: false, activeWork: 3 })
+    expect(plan.kind === 'refused' && plan.message)
+      .toBe('3 jobs or subagents are still attached to this session.')
+  })
+
+  it('names the current turn before attached work', () => {
+    const plan = planNew({ busy: true, activeWork: 2 })
+    expect(plan.kind === 'refused' && plan.message)
+      .toBe('Finish or interrupt the current turn before starting a new session.')
   })
 })
 

--- a/packages/dshline/tests/sessions-plan.spec.ts
+++ b/packages/dshline/tests/sessions-plan.spec.ts
@@ -7,7 +7,7 @@ import { stripAnsi } from '@dshline/renderer'
 import type { SessionEntry } from '../src/sessions/model.ts'
 import { planNew, planResume } from '../src/sessions/plan.ts'
 import type { AgentOpener, AttachTarget } from '../src/sessions/reopen.ts'
-import { attachTarget, reopenFailureLines } from '../src/sessions/reopen.ts'
+import { attachTarget, newSessionFailureLines, reopenFailureLines } from '../src/sessions/reopen.ts'
 
 /**
  * A persisted, reopenable session with only the facts the policy reads.
@@ -161,17 +161,23 @@ function handle(label: string): AgentHandle {
  * @returns the spec fields and the recorded reports.
  */
 function windowSide(answers: readonly AttachTarget[]): {
-  report: (reason: string) => void
+  report: (kind: 'new' | 'resume', reason: string) => void
   ask: () => Promise<AttachTarget>
+  reportedKinds: Array<'new' | 'resume'>
   reported: string[]
   asked: () => number
 } {
   const reported: string[] = []
+  const reportedKinds: Array<'new' | 'resume'> = []
   let index = 0
   return {
     reported,
+    reportedKinds,
     asked: () => index,
-    report: reason => { reported.push(reason) },
+    report: (kind, reason) => {
+      reportedKinds.push(kind)
+      reported.push(reason)
+    },
     ask: async () => answers[index++] ?? { kind: 'new', afterDismissal: true },
   }
 }
@@ -193,6 +199,21 @@ describe('attaching the agent a window drives', () => {
     expect(resumed).toHaveLength(0)
     expect(created[0]).toMatchObject({ sessionId: 'dshline-new', meta: { cwd: '/w' } })
     expect(side.reported).toEqual([])
+  })
+
+  it('creates an in-window /new in the current resumed workspace, not the startup workspace', async () => {
+    const { agents, created } = opener(async () => { throw new Error('unused') })
+    const side = windowSide([])
+    const outcome = await attachTarget({
+      agents,
+      newSessionId: () => 'dshline-new' as SessionId,
+      newSessionPreset: () => undefined,
+      cwd: '/foo',
+      options: {},
+      ...side,
+    }, { kind: 'new', cwd: '/bar' })
+    expect(created[0]).toMatchObject({ meta: { cwd: '/bar' } })
+    expect(outcome.target).toEqual({ kind: 'new', cwd: '/bar' })
   })
 
   it('stamps a new session\'s header with the resolved preset, when one is mounted', async () => {
@@ -282,7 +303,7 @@ describe('attaching the agent a window drives', () => {
     }, { kind: 'resume', id: 'past' as SessionId })
     expect(side.reported).toEqual(['session persistence is not configured'])
     expect(outcome.target).toEqual({ kind: 'new', afterDismissal: true })
-    expect(created[0]).toMatchObject({ sessionId: 'dshline-new' })
+    expect(created[0]).toMatchObject({ sessionId: 'dshline-new', meta: { cwd: '/w' } })
   })
 
   it('keeps asking while reopening keeps failing, and never loops on its own', async () => {
@@ -338,6 +359,63 @@ describe('attaching the agent a window drives', () => {
       options: {},
       ...side,
     }, { kind: 'new' })).rejects.toThrow('no factory registered')
+    expect(side.reported).toEqual([])
+    expect(side.asked()).toBe(0)
+  })
+
+  it('reports an in-window /new failure and opens the chooser instead of substituting fresh', async () => {
+    const created: CreateAgentOptions[] = []
+    const resumed: ResumeAgentOptions[] = []
+    const agents: AgentOpener = {
+      create: async options => {
+        created.push(options)
+        throw new Error('factory setup failed')
+      },
+      resume: async options => {
+        resumed.push(options)
+        return handle('resumed')
+      },
+    }
+    const side = windowSide([{ kind: 'resume', id: 'left-session' as SessionId }])
+    const outcome = await attachTarget({
+      agents,
+      newSessionId: () => 'dshline-new' as SessionId,
+      newSessionPreset: () => undefined,
+      cwd: '/foo',
+      options: {},
+      ...side,
+    }, { kind: 'new', cwd: '/bar' })
+    expect(side.reportedKinds).toEqual(['new'])
+    expect(side.reported).toEqual(['factory setup failed'])
+    expect(side.asked()).toBe(1)
+    expect(created).toHaveLength(1)
+    expect(resumed.map(options => options.resumeSessionId)).toEqual(['left-session'])
+    expect(outcome.target).toEqual({ kind: 'resume', id: 'left-session' })
+    expect(outcome.attached.reopened).toBe(true)
+  })
+
+  it('retries fresh only after the reader asks, and keeps the attachment workspace', async () => {
+    const created: CreateAgentOptions[] = []
+    const agents: AgentOpener = {
+      create: async options => {
+        created.push(options)
+        if (created.length === 1) throw new Error('first setup failed')
+        return handle('created')
+      },
+      resume: async () => { throw new Error('unused') },
+    }
+    const side = windowSide([{ kind: 'new', afterDismissal: true }])
+    const outcome = await attachTarget({
+      agents,
+      newSessionId: () => `dshline-new-${created.length}` as SessionId,
+      newSessionPreset: () => undefined,
+      cwd: '/foo',
+      options: {},
+      ...side,
+    }, { kind: 'new', cwd: '/bar' })
+    expect(side.asked()).toBe(1)
+    expect(created.map(options => options.meta?.cwd)).toEqual(['/bar', '/bar'])
+    expect(outcome.target).toEqual({ kind: 'new', afterDismissal: true, cwd: '/bar' })
   })
 })
 
@@ -352,6 +430,21 @@ describe('what a failed reopen says', () => {
     // Harness messages can carry a filesystem path, and a persisted log can put
     // anything in one.
     const lines = reopenFailureLines(`before${String.fromCharCode(27)}[2Jafter`)
+    expect(lines.join('\n')).not.toContain(String.fromCharCode(27) + '[2J')
+    expect(stripAnsi(lines[0] ?? '')).toContain('after')
+  })
+})
+
+describe('what a failed in-window /new says', () => {
+  it('names the actual create reason and returns control to Sessions', () => {
+    const lines = newSessionFailureLines('factory setup failed').map(stripAnsi)
+    expect(lines[0]).toContain('could not start a new session: factory setup failed')
+    expect(lines[1]).toContain('choose a session')
+    expect(lines[1]).toContain('try fresh again')
+  })
+
+  it('escapes a create reason it did not compose', () => {
+    const lines = newSessionFailureLines(`before${String.fromCharCode(27)}[2Jafter`)
     expect(lines.join('\n')).not.toContain(String.fromCharCode(27) + '[2J')
     expect(stripAnsi(lines[0] ?? '')).toContain('after')
   })


### PR DESCRIPTION
## What

Adds a `/new` local slash command that starts a fresh Harness session in the current window, the way Claude Code and OpenCode answer the same intent. The previous conversation stays persisted on disk and remains reopenable through `/sessions`.

```
› /new
· starting a new session…
```

## How

- `attachSession` returned a bare `SessionId`, which forced the plugin loop to wrap every answer as a resume. It now returns an `AttachTarget` — the same union `attachTarget` already consumes — so an attachment can hand back either `{ kind: 'resume', id }` (what `/sessions` does) or `{ kind: 'new' }`.
- New pure planner `planNew` beside `planResume` in `sessions/plan.ts`. `/new` retires a live agent exactly like reopening another session does, so it passes the same capability checks instead of tearing down unconditionally: it refuses mid-turn ("Finish or interrupt the current turn before starting a new session.") and while jobs/subagents are still attached to the session being left. The shared active-work refusal sentence is extracted so both planners cannot drift.
- Refusals print in red; a non-empty argument gets a usage line (`✗ /new takes no argument`) rather than being silently ignored, matching how `/timing` validates its input.
- The between-attachments status row now says "switching sessions…" rather than "reopening", since a fresh start goes through it too.
- Completion picks the command up automatically from the local registry, so `/new` appears in the `/` list with its description.

## Docs & release

- `docs/usage.md` command table and self-handled-command list, `README.md` command bullets, and the `docs/design.md` local-command sentence all mention `/new`.
- Changeset included: `@dshline/dshline` **minor**.

## Verification

- `pnpm build`, `pnpm typecheck`: clean.
- `pnpm test`: 1,462 passed, 1 skipped (pre-existing e2e skip).
- Broke `planNew`'s busy guard on purpose per the contribution guide: "refuses mid-turn with the new-session instruction" and "names the current turn before attached work" failed by name, then passed again once restored.
- Five new tests in `sessions-plan.spec.ts` pin acceptance while idle, both refusal messages, singular/plural work counts, and busy-before-work ordering.

Implementation was delegated to a Codex subagent and reviewed and verified in-session.

Co-Authored-By: ox-alpha <ox-alpha@users.noreply.github.com>
