### PR TITLE
chore: add community scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Something this interface does wrong — wrong output, a key that does nothing, a crash.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Do not report security vulnerabilities here.** Use
+        [private vulnerability reporting](https://github.com/riesbri/dshline/security/advisories/new)
+        instead — see [SECURITY.md](https://github.com/riesbri/dshline/blob/main/SECURITY.md).
+
+        Everything below the first field is asked because a terminal bug is
+        unreproducible without it. dshline draws into your real terminal, so the
+        emulator, its width, and its keyboard protocol are part of the bug.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What you did, what you expected, and what happened instead
+      placeholder: |
+        I ran `/plugins` and pressed space on a built-in preset's row.
+        I expected a prompt offering to copy it. The overlay closed instead.
+    validations:
+      required: true
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal program and version
+      description: The emulator itself, not the shell. Ghostty, iTerm2, Terminal.app, Windows Terminal, tmux inside one of those…
+      placeholder: Ghostty 1.2.3
+    validations:
+      required: true
+
+  - type: input
+    id: term-env
+    attributes:
+      label: TERM, and COLUMNS × LINES
+      description: "Run: `echo $TERM $COLUMNS $LINES`"
+      placeholder: xterm-ghostty 120 40
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: macOS 15.2 · Ubuntu 24.04 · Windows 11
+    validations:
+      required: true
+
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: "`node --version`, `dshline --version`, and the Harness version if you know it."
+      placeholder: node v24.3.0 · dshline 0.9.0 · dsh 0.1.1-rc.2
+    validations:
+      required: true
+
+  - type: input
+    id: profile
+    attributes:
+      label: Harness profile
+      description: Which profile you launched, and its agent preset if the problem involves tools.
+      placeholder: dshline · standard
+    validations:
+      required: false
+
+  - type: textarea
+    id: keyprobe
+    attributes:
+      label: For a key that does nothing — what your terminal actually sends
+      description: |
+        Run `pnpm build && node tools/keyprobe.mjs` in a checkout and press the
+        key that misbehaves. Each line shows the raw bytes and the key this
+        project decodes them into; an empty `[]` means it was not recognised.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: dump-config
+    attributes:
+      label: For an install or plugin-loading problem — `dsh --profile dshline --dump-config`
+      render: text
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: width
+    attributes:
+      label: Does it change with the window
+      options:
+        - label: It still happens after resizing the terminal wider
+        - label: It only happens at some widths
+        - label: The output involves CJK, emoji, or other wide characters

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -83,6 +83,14 @@ body:
     id: dump-config
     attributes:
       label: For an install or plugin-loading problem — `dsh --profile dshline --dump-config`
+      description: |
+        **Read this before pasting.** The dump is not redacted: it prints every
+        plugin's own `config` block verbatim. That can include a gateway or
+        self-hosted `baseURL` with a token in it, request `headers`, the `env`
+        map of an MCP server, and absolute paths that name you or your work.
+        Review the output and replace anything sensitive with `REDACTED` — this
+        issue is public. If you would rather not post it at all, say so and the
+        specific line needed can be asked for instead.
       render: text
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/capability_adapter.yml
+++ b/.github/ISSUE_TEMPLATE/capability_adapter.yml
@@ -1,0 +1,80 @@
+name: Capability adapter proposal
+description: Present a Harness capability that dshline does not show yet.
+labels: [capability]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is the contribution the project most wants. Read
+        [ROADMAP.md](https://github.com/riesbri/dshline/blob/main/ROADMAP.md) and
+        [docs/architecture.md](https://github.com/riesbri/dshline/blob/main/docs/architecture.md)
+        first — the answers below are what decides whether an adapter fits, and
+        they are the same questions the merged ones had to answer.
+
+  - type: input
+    id: surface
+    attributes:
+      label: Which Harness surface publishes it
+      description: The `ctx.*` service, or the seam. If the answer is a provider's API or a package's internals, this is not an adapter yet.
+      placeholder: ctx.attachments
+    validations:
+      required: true
+
+  - type: textarea
+    id: publishes
+    attributes:
+      label: What that surface publishes
+      description: The structured facts it exposes — the methods you would read, and what they return. Not what you would draw yet.
+    validations:
+      required: true
+
+  - type: textarea
+    id: generic
+    attributes:
+      label: Why this needs no provider-specific code
+      description: |
+        An adapter presents whatever a surface publishes, so a new provider flows
+        through it with no dshline change. If presenting this needs a branch on a
+        provider name, say so — that is the thing to solve before building it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: authority
+    attributes:
+      label: If it offers an action, what defines the authority for it
+      description: |
+        "Observation and control are separate contracts." A callable mutation is
+        not automatically a human-safe action: it needs the owning seam's
+        lifecycle, authorization, scheduling, and model-notification semantics.
+        `ctx.jobs.kill()` fails this test; `ctx.subagents.interrupt` passes it.
+        Leave blank if the adapter only observes.
+    validations:
+      required: false
+
+  - type: textarea
+    id: presentation
+    attributes:
+      label: What it would look like in the terminal
+      description: |
+        A rough sketch is fine. Remember that finished rows are committed to real
+        scrollback and never rewritten, so anything interactive is a bounded
+        overlay in the live region.
+      render: text
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Boundaries
+      description: These are the non-goals an adapter must not cross.
+      options:
+        - label: It parses no rendered tool output for structured state
+          required: true
+        - label: It adds no second database, state machine, or persistence format
+          required: true
+        - label: It adds no provider connection or runtime of its own
+          required: true
+        - label: A profile without this capability still starts; the view is unavailable rather than fatal
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/riesbri/dshline/security/advisories/new
+    about: Report privately. Never open a public issue for something exploitable.
+  - name: A problem in DeepSeek Harness itself
+    url: https://github.com/deepseek-ai/deepseek-harness/issues
+    about: Harness owns capabilities, state, runtime, persistence, and policy. If you are unsure which side a problem is on, open it here and it will be routed.
+  - name: Terminal evidence for macOS or Windows
+    url: https://github.com/riesbri/dshline/blob/main/CONTRIBUTING.md
+    about: Windows has no real-terminal evidence at all, and macOS is verified only on Ghostty. A report from a terminal nobody has run this in is a contribution.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,9 @@ contact_links:
   - name: Security vulnerability
     url: https://github.com/riesbri/dshline/security/advisories/new
     about: Report privately. Never open a public issue for something exploitable.
-  - name: A problem in DeepSeek Harness itself
+  - name: A problem confirmed to be in DeepSeek Harness itself
     url: https://github.com/deepseek-ai/deepseek-harness/issues
-    about: Harness owns capabilities, state, runtime, persistence, and policy. If you are unsure which side a problem is on, open it here and it will be routed.
+    about: Harness owns capabilities, state, runtime, persistence, and policy, so a bug in any of those belongs upstream. Only use this when you have confirmed the problem is Harness's — if you are unsure which side it is on, use the dshline bug report form above instead and it will be routed from there.
   - name: Terminal evidence for macOS or Windows
     url: https://github.com/riesbri/dshline/blob/main/CONTRIBUTING.md
     about: Windows has no real-terminal evidence at all, and macOS is verified only on Ghostty. A report from a terminal nobody has run this in is a contribution.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@ by accident, and most review comments here are one of them.
 ## Checks
 
 - [ ] `pnpm build && pnpm typecheck && pnpm test` pass
+- [ ] `pnpm security` passes — the dependency and workflow checks CI runs
 - [ ] `pnpm run verify-docs` passes — if this edits either side of a bilingual pair, the counterpart is updated and re-recorded in this PR
 - [ ] A changeset is included, or nothing under `packages/` changed
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+Read AGENTS.md before opening this — it lists the rules that are easy to break
+by accident, and most review comments here are one of them.
+-->
+
+## What this changes, and why
+
+<!-- The why matters more than the what; the diff already says the what. -->
+
+## Checks
+
+- [ ] `pnpm build && pnpm typecheck && pnpm test` pass
+- [ ] `pnpm run verify-docs` passes — if this edits either side of a bilingual pair, the counterpart is updated and re-recorded in this PR
+- [ ] A changeset is included, or nothing under `packages/` changed
+
+## If this touches the terminal
+
+- [ ] Text is made safe **before** color is applied, never after
+- [ ] Every write goes through `Screen`; committed scrollback is not rewritten
+- [ ] Widths are measured in display columns, and every cut agrees with `displayWidth`
+- [ ] A new `ctrl` shortcut works in both the legacy and kitty keyboard formats
+- [ ] Checked at a narrow width, and after a resize
+
+Terminal and OS this was run in:
+
+## If this presents a Harness capability
+
+- [ ] It reads a standard `ctx.*` surface, not a provider API or rendered output
+- [ ] It keeps no second database, state machine, or persistence format
+- [ ] A profile without the capability still starts; the view is unavailable rather than fatal
+- [ ] Any action it offers has the owning seam's lifecycle and authorization behind it

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,12 +59,30 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement through
-[GitHub's private reporting](https://github.com/riesbri/dshline/security/advisories/new)
-or by opening a conversation with the maintainer. All complaints will be
-reviewed and investigated promptly and fairly.
+reported to the maintainer. All complaints will be reviewed and investigated
+promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the
+This project does not yet have a dedicated private address for conduct reports,
+and it is stated here rather than papered over. Until it does, the routes that
+exist are:
+
+- **[GitHub's report abuse form](https://github.com/contact/report-abuse)**, for
+  behavior that also violates GitHub's own terms. It reaches GitHub Support
+  directly and does not depend on this project's maintainer being available.
+- **Contacting the maintainer**, through any channel where they are already
+  reachable to you.
+
+Do **not** use [private vulnerability reporting](https://github.com/riesbri/dshline/security/advisories/new)
+for a conduct report. That channel exists for security vulnerabilities, it is
+described that way in [`SECURITY.md`](SECURITY.md), and a conduct report sent
+there would land in a queue meant for something else.
+
+This is a personal project rather than a funded one, and [`SECURITY.md`](SECURITY.md)
+is candid about what that means for response times. The same applies here:
+reports are handled by one person, which is a realistic commitment rather than a
+target with a team behind it.
+
+Whoever handles a report is obligated to respect the privacy and security of the
 reporter of any incident.
 
 ## Enforcement Guidelines

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement through
+[GitHub's private reporting](https://github.com/riesbri/dshline/security/advisories/new)
+or by opening a conversation with the maintainer. All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/inclusion


### PR DESCRIPTION
The repo has a security policy, a contributing guide, a 363-line roadmap, and a Scorecard badge — but nothing that shapes what arrives. `.github/` holds only `dependabot.yml`, the workflows, and `assets/`.

It has also never received an issue, so these are written from **what the maintainer already has to ask for**, not from what a first reporter would think to send.

## Bug report form

Required: emulator + version, `TERM` and `COLUMNS × LINES`, OS, and versions. A width or escape bug is unreproducible without them, and "my terminal" is not an answer a fix can be built on.

Optional but pre-asked, so the two commonest follow-ups happen once:

- the `node tools/keyprobe.mjs` procedure, for a key that does nothing
- `dsh --profile dshline --dump-config`, for an install or plugin-loading problem
- a checkbox for "only at some widths" and "involves CJK / emoji / wide characters"

## Capability adapter form

Asks the four questions every merged adapter had to answer — which `ctx.*` surface, what it publishes, why it needs no provider-specific code, and what defines the authority for any action it offers (the `ctx.jobs.kill()` vs `ctx.subagents.interrupt` distinction from `docs/architecture.md`).

The architecture's non-goals are **required checkboxes**: no parsing rendered output, no second database, no parallel runtime, and the view degrades rather than being fatal. An adapter that cannot answer these is better redirected before it is written than after.

## Contact links

Security → private disclosure. Harness problems → upstream. And one pointing at the platforms with no evidence: Windows has none at all, macOS is verified only on Ghostty.

## Also

- `PULL_REQUEST_TEMPLATE.md` with three conditional blocks — always-on checks, terminal-specific ones (safe-before-color, `Screen`, display widths, both keyboard formats, narrow width and resize, plus the terminal it was run in), and capability-specific ones
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1, reporting via private disclosure. Also a Scorecard signal.

## One deliberate omission

`CONTRIBUTING.md` does **not** link the code of conduct yet. It is half of a bilingual pair on #84, and editing one side here would land it out of sync. GitHub surfaces a root `CODE_OF_CONDUCT.md` in the community profile on its own; the link goes in once these branches merge.

## Verification

All three YAML forms parse, with the expected field and required-field counts. Repo topics (`terminal`, `tui`, `cli`, `deepseek`, `ai-agent`, `typescript`, `nodejs`, `developer-tools`) are set separately — currently the repo has none, which is a free discoverability lever going unused.

Independent of #83–#85; branches off `main` and can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)