### PR TITLE
docs: correct the pending release notes

### DIFF
--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -9,4 +9,4 @@ Every call site said `style(text, 'red')`, which names an appearance instead of 
 
 `NO_COLOR`, `FORCE_COLOR`, `COLORTERM`, and `TERM=dumb` are now respected; none of them was read before. A palette may be authored in 256-colour or 24-bit form, and declares its own sixteen-colour fallback per role rather than being approximated.
 
-New in `@dshline/renderer`: `paint`, `setPalette`, `activePalette`, `resolveColorDepth`, `DEFAULT_PALETTE`, `sgr`, and the `Role`, `Palette`, `RoleColor`, `Sgr`, `ColorDepth`, and `ColorEnvironment` types. `style`, `Style`, and `StyleName` remain exported and unchanged.
+New in `@dshline/renderer`: `paint`, `setPalette`, `activePalette`, `MARKDOWN_ROLES`, `sgr`, and the `Role`, `Palette`, `PaletteRoles`, `RoleColor`, `Sgr`, and `ColorDepth` types. `style`, `Style`, and `StyleName` remain exported and unchanged.

--- a/.changeset/olive-pianos-invent.md
+++ b/.changeset/olive-pianos-invent.md
@@ -11,4 +11,4 @@ The last three are authored in 24-bit colour and each declares its own sixteen-c
 
 A theme reaches new rows only: committed scrollback is never rewritten, so rows above the live region keep the colours they were printed with. Applying one is confirmed by a single line drawn in the new palette, and the live region redraws with it.
 
-The palette is a window preference, like the usage meter and the tool detail level — it survives reopening a session, and resets when the process exits. User-authored palettes are not supported yet.
+The palette is a window preference, like the usage meter and the tool detail level — it survives reopening a session. User-authored palettes are not supported yet.

--- a/packages/dshline/src/themes/builtin.ts
+++ b/packages/dshline/src/themes/builtin.ts
@@ -245,7 +245,7 @@ const PAPER = fromSwatch(
 )
 
 /**
- * Every shipped palette, in the order `/themes` offers them.
+ * Every shipped palette, in the order `/theme` offers them.
  *
  * `default` leads because it is what a reader already has, and the rest are
  * ordered shallowest first so the two that work on any terminal are seen before

--- a/packages/dshline/src/themes/index.ts
+++ b/packages/dshline/src/themes/index.ts
@@ -1,5 +1,5 @@
 /**
- * `/themes`: choose the palette, and show what it did.
+ * `/theme`: choose the palette, and show what it did.
  *
  * Two things about this frontend make a theme picker unusual, and both are
  * terminal-model consequences rather than gaps to fill in later.
@@ -47,7 +47,7 @@ const DEPTH_NAMES: Readonly<Record<ColorDepth, string>> = {
 }
 
 /**
- * The values `/themes` accepts, for completing its argument.
+ * The values `/theme` accepts, for completing its argument.
  * @returns each shipped theme's id, with its description beside it.
  */
 export function themeValues(): readonly { value: string; note?: string }[] {
@@ -88,7 +88,7 @@ export function themeReport(
   return `${mark} ${name}${paint(`${degraded} · rows above keep the colours they were printed with${stored}`, 'muted')}`
 }
 
-/** What the caller has to supply for `/themes` to do its work. */
+/** What the caller has to supply for `/theme` to do its work. */
 export interface ThemeCommand {
   /** Plugin context, for the picker overlay. */
   readonly ctx: Context
@@ -111,7 +111,7 @@ export interface ThemeCommand {
 }
 
 /**
- * Run `/themes`, named or asked for.
+ * Run `/theme`, named or asked for.
  *
  * Named and asked-for meet at one resolve, so a typed word and a chosen row
  * cannot drift — the same rule `/usage` and `/reasoning` follow. A name that


### PR DESCRIPTION
Cleanup found in pre-release review of the three pending changesets (#91, #96, #93). Prose only — no executable change.

## What was stale

**`.changeset/olive-donkeys-shake.md`** advertised a renderer export surface from an intermediate architecture: `resolveColorDepth`, `DEFAULT_PALETTE`, and `ColorEnvironment` do not exist in `@dshline/renderer`. In the final design, depth is answered where it is needed (`window.ts`, via Node's own `getColorDepth`), `DEFAULT_PALETTE` lives in `@dshline/dshline`, and the environment type dissolved into that call. The "New in" sentence now names the real surface: `paint`, `setPalette`, `activePalette`, `MARKDOWN_ROLES`, `sgr`, plus the `Role`, `Palette`, `PaletteRoles`, `RoleColor`, `Sgr`, and `ColorDepth` types.

**`.changeset/olive-pianos-invent.md`** said the palette "resets when the process exits" — true when written, false within this same release, since *eighty-pears-repeat* persists the choice through Harness settings. Both entries ship in one changelog, so leaving both would contradict itself. The clause is dropped rather than restated here, because whether a profile can save depends on its settings provider and the entry that adds saving owns that nuance.

## Comment nit (included)

Four TSDoc comments in `packages/dshline/src/themes/index.ts` called the command `/themes`; the command, docs, and tests all say `/theme`. One more instance of the same slip sat in `themes/builtin.ts` ("the order `/themes` offers them") and is corrected too. `@module dshline/themes` keeps its name — that is the module path, not the command.

## Verification

- The export list was checked by diffing `packages/renderer/src/index.ts` against the `v0.10.0` tag, not by memory: everything it exports from `theme.ts` is new since that tag, as is `sgr`.
- Greps confirm no `resolveColorDepth`/`ColorEnvironment` reference remains anywhere and no `/themes` command reference remains in tracked sources.
- `pnpm typecheck` and `pnpm test` pass (81 files, 1582 tests).

No new changeset: changeset-text corrections and internal comments are not user-visible package changes.
