### PR TITLE
fix(dshline): run /profiles children through Harness's subprocess capability

### DIFF
--- a/.changeset/quiet-process-trees.md
+++ b/.changeset/quiet-process-trees.md
@@ -1,0 +1,5 @@
+---
+"@dshline/dshline": patch
+---
+
+Run `/profiles` launcher processes through the Harness subprocess capability so environment scrubbing and cross-platform process-tree cleanup remain Harness-owned.

--- a/.changeset/quiet-process-trees.md
+++ b/.changeset/quiet-process-trees.md
@@ -2,4 +2,4 @@
 "@dshline/dshline": patch
 ---
 
-Run `/profiles` launcher processes through the Harness subprocess capability so environment scrubbing and cross-platform process-tree cleanup remain Harness-owned.
+Run `/profiles` launcher processes through the Harness subprocess capability while keeping their authentication semantics: the child environment restores every variable set in the package managers' own namespaces (`NPM_*`, `PNPM_*`, `COREPACK_*`, `NODE_AUTH_TOKEN`) plus the Host-resolved `DSH_HOME` after the seam's credential scrubbing, so private registries authenticating through `${NPM_TOKEN}`-style `.npmrc` references keep working. A relative `$DSH_BIN` is pinned to an absolute path before the seam verifies the launcher.

--- a/packages/dshline/package.json
+++ b/packages/dshline/package.json
@@ -79,6 +79,7 @@
     "@deepseek-ai/dsh-session-projection": "0.1.1-rc.2",
     "@deepseek-ai/dsh-session-query": "0.1.1-rc.2",
     "@deepseek-ai/dsh-subagent": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-subprocess": "0.1.1-rc.2",
     "@deepseek-ai/dsh-system-prompt": "0.1.1-rc.2",
     "@deepseek-ai/dsh-tool-ask-user": "0.1.1-rc.2",
     "@deepseek-ai/dsh-tool-todo": "0.1.1-rc.2",

--- a/packages/dshline/src/launcher.ts
+++ b/packages/dshline/src/launcher.ts
@@ -33,7 +33,7 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { homedir } from 'node:os'
-import { delimiter, dirname, join } from 'node:path'
+import { delimiter, dirname, join, resolve } from 'node:path'
 
 /** The harness's launcher package, resolved when no `dsh` is on PATH. */
 export const LAUNCHER_PACKAGE = '@deepseek-ai/dsh'
@@ -194,7 +194,19 @@ export function resolveLauncher(
     if (!existsSync(expanded)) {
       return { kind: 'misconfigured', message: `$DSH_BIN points at ${expanded}, which does not exist` }
     }
-    return { kind: 'found', launcher: { command: expanded, prefix: [], describe: `$DSH_BIN (${expanded})` } }
+    return {
+      kind: 'found',
+      launcher: {
+        // A relative DSH_BIN (`./bin/dsh`) is looked up against this process's
+        // working directory — that is how the wrapper's own spawn still runs
+        // it. The managed subprocess seam deliberately rejects relative paths
+        // because ITS resolution base is undefined, so the cwd answer found
+        // here is pinned in before the seam ever sees the command.
+        command: resolve(expanded),
+        prefix: [],
+        describe: `$DSH_BIN (${expanded})`,
+      },
+    }
   }
   const checkout = (env.DSH_HARNESS ?? '').trim()
   if (checkout !== '') return fromCheckout(checkout)

--- a/packages/dshline/src/profiles/actions.ts
+++ b/packages/dshline/src/profiles/actions.ts
@@ -10,12 +10,13 @@
  * update). Reproducing any part of that here would be a second installer whose
  * idea of the bundle list drifts from the real one the moment either changes.
  *
- * There is no Harness service for this: `runPlugin` lives in the CLI app, not
- * in a mounted plugin, and nothing publishes it into a context. So the
- * mechanism used is the one Harness itself owns — the `dsh` executable,
- * resolved by `../launcher.ts` the same four ways `bin/dshline.mjs` resolves
- * it, so a `/profiles` mutation reaches the launcher in every environment this
- * frontend itself starts in.
+ * There is no Harness service for profile mutation: `runPlugin` lives in the
+ * CLI app, not in a mounted plugin, and nothing publishes it into a context.
+ * So the operation still goes through Harness's own `dsh` executable, resolved
+ * by `../launcher.ts` the same four ways `bin/dshline.mjs` resolves it. Process
+ * ownership is a separate concern, though, and belongs to `ctx.subprocess`:
+ * that seam owns executable lookup, environment policy, process trees, and
+ * cross-platform termination for every Harness consumer.
  *
  * Four things this module does that the CLI does not, all because a TUI owns
  * the terminal and a person is waiting:
@@ -29,10 +30,9 @@
  *                                   lines are ever held, so a long install
  *                                   cannot grow this process's memory with
  *                                   text nobody will read
- * the timeout SETTLES               a bound that sends SIGTERM and then waits
- *                                   forever is not a bound: a child that
- *                                   ignores it would hold the profile lock for
- *                                   the rest of the session
+ * the timeout SETTLES               the subprocess seam escalates termination;
+ *                                   this caller still classifies its own
+ *                                   deadline and stops waiting at a hard bound
  * specs are REDACTED for display    a package spec can carry a token in a URL;
  *                                   it is passed to the launcher verbatim and
  *                                   never written to the transcript as-is
@@ -40,7 +40,7 @@
  * @module dshline/profiles/actions
  */
 
-import { spawn } from 'node:child_process'
+import type { SubprocessRuntime } from '@deepseek-ai/dsh-subprocess'
 import { resolveLauncher } from '../launcher.ts'
 import type { Launcher } from '../launcher.ts'
 import { displayArgument, shellQuote } from './model.ts'
@@ -58,8 +58,8 @@ const PLUGIN_TIMEOUT_MS = 600_000
  * How long a stopped child is given to exit before it is killed outright.
  *
  * pnpm spawns its own children, and a SIGTERM it declines to act on must not
- * become an indefinite wait. On Windows there is no graceful signal at all —
- * `kill()` terminates — so this grace period simply never elapses there.
+ * become an indefinite wait. The Harness provider applies this to the whole
+ * process tree, using the platform's own termination mechanism.
  */
 const KILL_GRACE_MS = 5_000
 
@@ -93,6 +93,10 @@ export interface ProfileOperationSpec {
   readonly profile: string
   /** The resolved operation, from `model.ts`. */
   readonly resolved: ResolvedOperation
+  /** Harness's process owner; absent only on an older or incomplete Host. */
+  readonly subprocess?: Pick<SubprocessRuntime, 'resolveExecutable' | 'spawn'>
+  /** Resolved Harness home, explicitly restored after subprocess env scrubbing. */
+  readonly dshHome?: string
   /**
    * Resolve the launcher; injected so a test drives the whole chain without a
    * launcher installed.
@@ -174,86 +178,72 @@ export interface ChildTimings {
 }
 
 /**
- * Stop a child, and everything it started.
+ * Spawn one managed child with piped stdio, returning its code and retained output.
  *
- * pnpm spawns its own children, so signalling only the launcher would leave a
- * download or a build running with nothing waiting for it. On POSIX the child
- * is its own process-group leader (`detached`), so the negative pid signals the
- * whole group; Windows has no group signal and no graceful one either, where
- * `kill()` terminates the child directly.
- * @param child - the spawned launcher.
- * @param signal - the signal to send.
- */
-function stopTree(child: { pid?: number | undefined; kill: (signal: NodeJS.Signals) => boolean }, signal: NodeJS.Signals): void {
-  if (process.platform !== 'win32' && child.pid !== undefined) {
-    try {
-      process.kill(-child.pid, signal)
-      return
-    } catch {
-      // The group is already gone, or this child never became a leader. Fall
-      // through to signalling the process itself, which is still worth trying.
-    }
-  }
-  try {
-    child.kill(signal)
-  } catch {
-    // Already exited between the timeout firing and this call.
-  }
-}
-
-/**
- * Spawn one child with piped stdio, returning its code and retained output.
- *
- * Settles exactly once, and always. The timeout stops the child and then
- * ESCALATES: `SIGTERM` to the process group, then `SIGKILL` after a grace
- * period, then — because even a kill can leave this promise waiting on a pipe
- * that never closes — the result is resolved on its own. A bound that sends a
- * signal and then waits indefinitely is not a bound, and the profile lock is
- * waiting on this one.
+ * Harness owns executable resolution, the isolated process tree, platform
+ * signalling, and TERM-to-KILL escalation. This caller owns its deadline and
+ * result vocabulary: after asking the handle to terminate it still resolves
+ * independently if the provider cannot prove closure, because the profile lock
+ * must not become an indefinite wait.
+ * @param subprocess - Harness's process capability.
  * @param launcher - how to run the launcher.
  * @param args - the arguments after the launcher's own prefix.
  * @param timings - overrides for the bound; defaults are the module constants.
+ * @param dshHome - resolved Harness home to restore after managed env scrubbing.
  * @returns the exit code and retained output; never rejects.
  */
-export function spawnCaptured(
+export async function spawnCaptured(
+  subprocess: Pick<SubprocessRuntime, 'resolveExecutable' | 'spawn'>,
   launcher: Launcher,
   args: readonly string[],
   timings: ChildTimings = {},
+  dshHome?: string,
 ): Promise<ChildResult> {
   const timeoutMs = timings.timeoutMs ?? PLUGIN_TIMEOUT_MS
   const killGraceMs = timings.killGraceMs ?? KILL_GRACE_MS
+  let command: string
+  try {
+    command = await subprocess.resolveExecutable(launcher.command)
+  } catch (error) {
+    return { code: 127, output: `${error instanceof Error ? error.message : String(error)}\n` }
+  }
   return new Promise(resolve => {
     const tail = new OutputTail()
     let settled = false
-    let killTimer: NodeJS.Timeout | undefined
+    let timer: NodeJS.Timeout | undefined
     let giveUpTimer: NodeJS.Timeout | undefined
     const settle = (code: number, note?: string): void => {
       if (settled) return
       settled = true
-      clearTimeout(timer)
-      if (killTimer !== undefined) clearTimeout(killTimer)
+      if (timer !== undefined) clearTimeout(timer)
       if (giveUpTimer !== undefined) clearTimeout(giveUpTimer)
       if (note !== undefined) tail.push(`\n${note}\n`)
       resolve({ code, output: tail.text() })
     }
-    // `shell: false`: the launcher is a resolved path (or a bare `dsh` Node
-    // itself finds), so there is nothing for a shell to look up, and passing a
-    // user-typed package spec through one would make it shell syntax.
-    const child = spawn(launcher.command, [...launcher.prefix, ...args], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      // Its own process group on POSIX, so `stopTree` can signal everything
-      // pnpm started rather than only the launcher.
-      detached: process.platform !== 'win32',
-      ...launcher.cwd === undefined ? {} : { cwd: launcher.cwd },
-    })
-    const collect = (chunk: Buffer): void => { tail.push(chunk.toString('utf8')) }
+    let child: ReturnType<SubprocessRuntime['spawn']>
+    try {
+      child = subprocess.spawn({
+        // Exact argv, never shell syntax: a user-typed package spec remains one
+        // argument all the way to `dsh plugin`.
+        argv: [command, ...launcher.prefix, ...args],
+        cwd: launcher.cwd ?? process.cwd(),
+        stdio: { stdin: 'ignore', stdout: 'pipe', stderr: 'pipe' },
+        graceMs: killGraceMs,
+        // The provider intentionally scrubs every ambient DSH_* value. This is
+        // the one nested-launch identity `dsh plugin` needs, sourced from the
+        // Host's resolved service rather than copied from ambient process env.
+        ...dshHome === undefined ? {} : { env: { DSH_HOME: dshHome } },
+      })
+    } catch (error) {
+      settle(127, error instanceof Error ? error.message : String(error))
+      return
+    }
+    const collect = (chunk: Buffer | string): void => { tail.push(chunk.toString()) }
     child.stdout?.on('data', collect)
     child.stderr?.on('data', collect)
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       tail.push(`\ndsh: no answer after ${String(Math.round(timeoutMs / 1_000))}s; stopping the child\n`)
-      stopTree(child, 'SIGTERM')
-      killTimer = setTimeout(() => { stopTree(child, 'SIGKILL') }, killGraceMs)
-      killTimer.unref()
+      child.terminate()
       giveUpTimer = setTimeout(
         () => { settle(124, 'dsh: the child did not exit after being killed') },
         killGraceMs * 2,
@@ -261,8 +251,10 @@ export function spawnCaptured(
       giveUpTimer.unref()
     }, timeoutMs)
     timer.unref()
-    child.on('error', (error: Error) => { settle(127, error.message) })
-    child.on('close', code => { settle(code ?? 1) })
+    void child.done.then(
+      outcome => { settle(outcome.exitCode ?? 1) },
+      (error: unknown) => { settle(127, error instanceof Error ? error.message : String(error)) },
+    )
   })
 }
 
@@ -379,7 +371,19 @@ export async function runProfileOperation(spec: ProfileOperationSpec): Promise<P
     }
   }
   const args = ['plugin', '--profile', profile, ...resolved.args]
-  const { code, output } = await (spec.run ?? spawnCaptured)(resolution.launcher, args)
+  const subprocess = spec.subprocess
+  const run = spec.run ?? (subprocess === undefined
+    ? undefined
+    : (launcher: Launcher, childArgs: readonly string[]) =>
+        spawnCaptured(subprocess, launcher, childArgs, {}, spec.dshHome))
+  if (run === undefined) {
+    return {
+      kind: 'failed',
+      message: `the Harness subprocess capability is unavailable — run this yourself: ${command}`,
+      output: [],
+    }
+  }
+  const { code, output } = await run(resolution.launcher, args)
   if (code !== 0) {
     const reason = failureReason(output)
     const headline = reason === undefined

--- a/packages/dshline/src/profiles/actions.ts
+++ b/packages/dshline/src/profiles/actions.ts
@@ -85,9 +85,23 @@ const OUTPUT_TAIL_BYTES = 16_384
  * namespaces is restored because whoever set it set it FOR them; nothing else
  * is, because the scrub exists precisely so harness secrets —
  * `DEEPSEEK_API_KEY` above all — never reach the lifecycle scripts of what
- * gets installed. A custom name referenced as `${MY_TOKEN}` in an `.npmrc`
- * sits in no manager's namespace and stays unreached: spell that token into
- * the user or profile `.npmrc` instead of an ambient variable.
+ * gets installed.
+ *
+ * Custom names (`${MY_COMPANY_TOKEN}`) stay excluded on purpose, and are not
+ * rescued by scanning config files for references: those files are writable
+ * by anything running as this user — including a lifecycle script from an
+ * earlier install — so honoring their references would let one poisoned
+ * config promote an ambient harness secret into the next install. That is
+ * the exfiltration shape pnpm itself closed when it stopped trusting
+ * project-level auth settings entirely (pnpm 11.5.3), which is also why the
+ * old advice "put it in the profile's .npmrc" is wrong twice over. Keep
+ * environment delivery under a name the managers own instead: reference
+ * `${NPM_TOKEN}` from USER-level config and provide it at launch
+ * (`NPM_TOKEN="$MY_COMPANY_TOKEN" dshline …`) — the secret stays out of
+ * files, under either spelling. Ecosystem variables such as
+ * CODEARTIFACT_AUTH_TOKEN are enumerated nowhere because their tooling
+ * writes literal rotating credentials into user config rather than feeding
+ * the variable through raw pnpm.
  */
 const PACKAGE_MANAGER_ENV = /^(?:NPM_|PNPM_|COREPACK_|NODE_AUTH_TOKEN)/iu
 

--- a/packages/dshline/src/profiles/actions.ts
+++ b/packages/dshline/src/profiles/actions.ts
@@ -16,7 +16,11 @@
  * by `../launcher.ts` the same four ways `bin/dshline.mjs` resolves it. Process
  * ownership is a separate concern, though, and belongs to `ctx.subprocess`:
  * that seam owns executable lookup, environment policy, process trees, and
- * cross-platform termination for every Harness consumer.
+ * cross-platform termination for every Harness consumer. Its credential scrub
+ * is narrowed here rather than undone — the child keeps what was set inside
+ * the package managers' own namespaces plus the Host-resolved home, because
+ * pnpm authenticates from the child's environment (`_authToken=${NPM_TOKEN}`),
+ * while harness secrets stay scrubbed away from install scripts.
  *
  * Four things this module does that the CLI does not, all because a TUI owns
  * the terminal and a person is waiting:
@@ -68,6 +72,24 @@ const KEPT_OUTPUT_LINES = 10
 
 /** Bytes of child output held at once, before older text is dropped. */
 const OUTPUT_TAIL_BYTES = 16_384
+
+/**
+ * Ambient names restored to the launcher's child, by owner rather than value.
+ *
+ * The subprocess seam scrubs every credential-SHAPED name (`*KEY*`, `*TOKEN*`,
+ * `*SECRET*`, `*PASSWORD*`), which is right for model-driven children and
+ * silently breaking here in one specific way: pnpm expands
+ * `_authToken=${NPM_TOKEN}` from an `.npmrc` against the CHILD's environment,
+ * so a private-registry install that authenticated under direct spawning
+ * would fail under the scrub. Everything in the package managers' own
+ * namespaces is restored because whoever set it set it FOR them; nothing else
+ * is, because the scrub exists precisely so harness secrets —
+ * `DEEPSEEK_API_KEY` above all — never reach the lifecycle scripts of what
+ * gets installed. A custom name referenced as `${MY_TOKEN}` in an `.npmrc`
+ * sits in no manager's namespace and stays unreached: spell that token into
+ * the user or profile `.npmrc` instead of an ambient variable.
+ */
+const PACKAGE_MANAGER_ENV = /^(?:NPM_|PNPM_|COREPACK_|NODE_AUTH_TOKEN)/iu
 
 /** How one invocation ended, in words the transcript can carry. */
 export interface ProfileActionOutcome {
@@ -178,6 +200,26 @@ export interface ChildTimings {
 }
 
 /**
+ * The environment one launcher child runs with.
+ *
+ * The seam's scrubbed base already keeps `PATH`, `HOME`, locale, and proxy
+ * settings, so ordinary installs need nothing from here; this restores only
+ * what the scrub would take away that the child has a legitimate claim on:
+ * {@link PACKAGE_MANAGER_ENV} namespaces and the resolved Harness home, which
+ * merges last so an explicit Host answer wins over any ambient spelling.
+ * @param dshHome - the Host-resolved home, when this deployment provides one.
+ * @returns the explicit entries layered onto the scrubbed base.
+ */
+function childEnvironment(dshHome: string | undefined): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [name, value] of Object.entries(process.env)) {
+    if (value !== undefined && PACKAGE_MANAGER_ENV.test(name)) env[name] = value
+  }
+  if (dshHome !== undefined) env.DSH_HOME = dshHome
+  return env
+}
+
+/**
  * Spawn one managed child with piped stdio, returning its code and retained output.
  *
  * Harness owns executable resolution, the isolated process tree, platform
@@ -229,10 +271,10 @@ export async function spawnCaptured(
         cwd: launcher.cwd ?? process.cwd(),
         stdio: { stdin: 'ignore', stdout: 'pipe', stderr: 'pipe' },
         graceMs: killGraceMs,
-        // The provider intentionally scrubs every ambient DSH_* value. This is
-        // the one nested-launch identity `dsh plugin` needs, sourced from the
-        // Host's resolved service rather than copied from ambient process env.
-        ...dshHome === undefined ? {} : { env: { DSH_HOME: dshHome } },
+        // Layered onto the seam's scrub by name: package-manager namespaces
+        // and the Host-resolved home. Never a wholesale passthrough — see
+        // `childEnvironment` for the line this walks.
+        env: childEnvironment(dshHome),
       })
     } catch (error) {
       settle(127, error instanceof Error ? error.message : String(error))

--- a/packages/dshline/src/profiles/index.ts
+++ b/packages/dshline/src/profiles/index.ts
@@ -29,6 +29,7 @@
 import type { Context } from '@deepseek-ai/cordis'
 import { escapeControls, paint } from '@dshline/renderer'
 import type { BundleRow, PlainDependencyRow, ProfileRow } from './harness.ts'
+import { dshHomePathOf } from './harness.ts'
 import { ProfilesCatalog } from './catalog.ts'
 import type { ProfilesCatalogSpec } from './catalog.ts'
 import {
@@ -43,7 +44,7 @@ import {
   validProfileName,
 } from './model.ts'
 import type { ResolvedOperation } from './model.ts'
-import type { ProfileActionOutcome } from './actions.ts'
+import type { ProfileActionOutcome, ProfileOperationSpec } from './actions.ts'
 import { runProfileOperation } from './actions.ts'
 import {
   operationInFlight,
@@ -317,8 +318,15 @@ async function performOn(
   overlay.report(`${profileName}: ${resolved.running}…`, false)
   // The runtime holds the lock AND the running row, so both edges reach every
   // open view rather than only this one.
+  const subprocess = subprocessOf(spec.ctx)
+  const dshHomePath = dshHomePathOf(spec.ctx)
   const outcome = await runExclusively(profileName, resolved.running, async () =>
-    (spec.run ?? runProfileOperation)({ profile: profileName, resolved }))
+    (spec.run ?? runProfileOperation)({
+      profile: profileName,
+      resolved,
+      ...subprocess === undefined ? {} : { subprocess },
+      ...dshHomePath === undefined ? {} : { dshHome: dshHomePath() },
+    }))
   if (outcome === undefined) {
     // Lost the race to another overlay between the check above and the lock.
     overlay.report(`${profileName} already has an operation running; wait for it to finish`, true)
@@ -337,6 +345,15 @@ async function performOn(
   land(spec, catalog, overlay, note === undefined
     ? outcome
     : { ...outcome, message: `${outcome.message} — ${note}` })
+}
+
+/**
+ * Read Harness's process capability without making an incomplete Host fail at boot.
+ * @param ctx - the plugin context.
+ * @returns the process seam, or undefined when this deployment has none.
+ */
+function subprocessOf(ctx: Context): ProfileOperationSpec['subprocess'] {
+  return ctx.get('subprocess') as ProfileOperationSpec['subprocess']
 }
 
 /**

--- a/packages/dshline/tests/launcher-policy.spec.ts
+++ b/packages/dshline/tests/launcher-policy.spec.ts
@@ -15,7 +15,7 @@
 import { mkdtemp, rm, writeFile, chmod, mkdir } from 'node:fs/promises'
 import { readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { isAbsolute, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
 import { LAUNCHER_PACKAGE, resolveLauncher } from '../src/launcher.ts'
@@ -49,6 +49,30 @@ describe('DSH_BIN, when the user has pointed at a launcher', () => {
     expect(found.launcher.command).toBe(bin)
     expect(found.launcher.prefix).toEqual([])
     expect(found.launcher.describe).toContain('$DSH_BIN')
+  })
+
+  it('pins a relative path against this folder, so the managed seam can verify it', async () => {
+    // The subprocess seam rejects relative commands (its resolution base is
+    // undefined), while a relative $DSH_BIN has always meant "against the
+    // working directory this process runs in". The lookup resolves that
+    // answer itself instead of handing the seam a path it must refuse.
+    const dir = await tempDir()
+    await writeFile(join(dir, 'dsh'), '', 'utf8')
+    const given = `${relative(process.cwd(), dir)}/dsh`
+    const found = resolveLauncher({ DSH_BIN: given }, NO_PACKAGES)
+    expect(found.kind).toBe('found')
+    if (found.kind !== 'found') throw new Error('expected found')
+    expect(found.launcher.command).toBe(resolve(given))
+    expect(isAbsolute(found.launcher.command)).toBe(true)
+    // The diagnostic still names what the user actually wrote.
+    expect(found.launcher.describe).toContain(given)
+  })
+
+  it('reports a wrong relative path as a misconfiguration, unchanged', () => {
+    const found = resolveLauncher({ DSH_BIN: './somewhere/missing' }, NO_PACKAGES)
+    expect(found.kind).toBe('misconfigured')
+    if (found.kind !== 'misconfigured') throw new Error('expected misconfigured')
+    expect(found.message).toContain('./somewhere/missing')
   })
 
   it('reports a wrong path as a misconfiguration, not as "no launcher"', () => {

--- a/packages/dshline/tests/profiles-actions.spec.ts
+++ b/packages/dshline/tests/profiles-actions.spec.ts
@@ -10,7 +10,7 @@
 
 import { Context } from '@deepseek-ai/cordis'
 import LocalSubprocessRuntime from '@deepseek-ai/dsh-subprocess-local'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import type { Launcher, LauncherResolution } from '../src/launcher.ts'
 import type { ChildResult } from '../src/profiles/actions.ts'
 import {
@@ -47,6 +47,11 @@ const FOUND: () => LauncherResolution = () => ({
 /** A never-called child runner, for paths that must not spawn. */
 const NEVER: (launcher: Launcher, args: readonly string[]) => Promise<ChildResult> = () => {
   throw new Error('must not spawn')
+}
+
+/** A launcher that runs one inline Node program. */
+function nodeProgram(source: string): Launcher {
+  return { command: process.execPath, prefix: ['-e', source], describe: 'test child' }
 }
 
 describe('the command line a reader could run themselves', () => {
@@ -275,11 +280,6 @@ describe('one operation per profile, for the whole process', () => {
 })
 
 describe('the timeout is a bound, not a request', () => {
-  /** A launcher that runs one inline Node program. */
-  function nodeProgram(source: string): Launcher {
-    return { command: process.execPath, prefix: ['-e', source], describe: 'test child' }
-  }
-
   it('settles even when the child ignores SIGTERM', async () => {
     // The bug this pins: SIGTERM followed by an indefinite wait is not a bound,
     // and the profile lock is held until this promise settles.
@@ -334,6 +334,41 @@ describe('the timeout is a bound, not a request', () => {
     expect(result.code).toBe(0)
     expect(result.output.length).toBeLessThanOrEqual(16_384)
   }, 25_000)
+})
+
+describe('the environment the launcher child runs with', () => {
+  afterEach(() => { vi.unstubAllEnvs() })
+
+  it('restores package-manager credentials that the scrub removes by shape', async () => {
+    // pnpm expands `_authToken=${NPM_TOKEN}` from an .npmrc against the CHILD's
+    // environment, so a private-registry install that authenticated under
+    // direct spawning would fail under the seam's scrub without this restore.
+    vi.stubEnv('NPM_TOKEN', 'env-test-token')
+    vi.stubEnv('NODE_AUTH_TOKEN', 'env-test-gh-token')
+    const result = await spawnCaptured(
+      processContext.subprocess,
+      nodeProgram("process.stdout.write([process.env.NPM_TOKEN, process.env.NODE_AUTH_TOKEN].join(' '))"),
+      [],
+      { timeoutMs: 5_000 },
+    )
+    expect(result.output).toBe('env-test-token env-test-gh-token')
+  }, 10_000)
+
+  it('still keeps everything outside those namespaces away from install scripts', async () => {
+    // The scrub's point stands: harness and model secrets must not reach the
+    // lifecycle scripts of whatever the operation installs.
+    vi.stubEnv('DEEPSEEK_API_KEY', 'must-not-travel')
+    vi.stubEnv('GITHUB_TOKEN', 'also-must-not-travel')
+    const result = await spawnCaptured(
+      processContext.subprocess,
+      nodeProgram(
+        "process.stdout.write((process.env.DEEPSEEK_API_KEY ?? 'absent') + ' ' + (process.env.GITHUB_TOKEN ?? 'absent'))",
+      ),
+      [],
+      { timeoutMs: 5_000 },
+    )
+    expect(result.output).toBe('absent absent')
+  }, 10_000)
 })
 
 describe('a failure says what went wrong, not just that it did', () => {

--- a/packages/dshline/tests/profiles-actions.spec.ts
+++ b/packages/dshline/tests/profiles-actions.spec.ts
@@ -8,7 +8,9 @@
  * rather than as an exception out of a keystroke.
  */
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import LocalSubprocessRuntime from '@deepseek-ai/dsh-subprocess-local'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import type { Launcher, LauncherResolution } from '../src/launcher.ts'
 import type { ChildResult } from '../src/profiles/actions.ts'
 import {
@@ -30,6 +32,12 @@ import { displayArgument, resolveOperation } from '../src/profiles/model.ts'
 // or a queued restart behind would poison the next one.
 afterEach(() => { resetProfilesRuntime() })
 
+/** Real published Harness process provider for lifecycle and platform tests. */
+const processContext = new Context()
+
+beforeAll(async () => { await processContext.plugin(LocalSubprocessRuntime) })
+afterAll(async () => { await processContext.fiber.dispose() })
+
 /** A launcher that is present, without touching the environment. */
 const FOUND: () => LauncherResolution = () => ({
   kind: 'found',
@@ -49,9 +57,9 @@ describe('the command line a reader could run themselves', () => {
 
   it('quotes an argument a shell would otherwise act on', () => {
     // An argv list pasted together with spaces is not the command that ran.
-    const shown = pluginCommand('dshline', ['add', 'name; rm -rf /'])
-    expect(shown).toContain(`'name; rm -rf /'`)
-    expect(shown).not.toContain('add name; rm')
+    const shown = pluginCommand('dshline', ['add', 'name; echo harmless-fixture'])
+    expect(shown).toContain(`'name; echo harmless-fixture'`)
+    expect(shown).not.toContain('add name; echo')
   })
 
   it('withholds a spec that could carry a credential', () => {
@@ -119,6 +127,17 @@ describe('running one operation', () => {
     })
     expect(outcome.kind).toBe('done')
     expect(outcome.message).toContain('installing @example/plugin')
+  })
+
+  it('reports an incomplete Host without taking process ownership back', async () => {
+    const outcome = await runProfileOperation({
+      profile: 'dshline',
+      resolved: resolveOperation('init'),
+      launcher: FOUND,
+    })
+    expect(outcome.kind).toBe('failed')
+    expect(outcome.message).toContain('subprocess capability is unavailable')
+    expect(outcome.message).toContain('run this yourself')
   })
 
   it('names the exact command when no launcher can be found', async () => {
@@ -265,13 +284,19 @@ describe('the timeout is a bound, not a request', () => {
     // The bug this pins: SIGTERM followed by an indefinite wait is not a bound,
     // and the profile lock is held until this promise settles.
     const stubborn = "process.on('SIGTERM', () => {}); setInterval(() => {}, 50)"
-    const result = await spawnCaptured(nodeProgram(stubborn), [], { timeoutMs: 120, killGraceMs: 120 })
+    const result = await spawnCaptured(
+      processContext.subprocess,
+      nodeProgram(stubborn),
+      [],
+      { timeoutMs: 120, killGraceMs: 120 },
+    )
     expect(result.code).not.toBe(0)
     expect(result.output).toContain('stopping the child')
   }, 10_000)
 
   it('settles on an ordinary child that exits on its own', async () => {
     const result = await spawnCaptured(
+      processContext.subprocess,
       nodeProgram("process.stdout.write('hello'); process.exit(3)"),
       [],
       { timeoutMs: 5_000 },
@@ -280,8 +305,21 @@ describe('the timeout is a bound, not a request', () => {
     expect(result.output).toContain('hello')
   }, 10_000)
 
+  it('restores the Host-resolved DSH_HOME for the nested launcher', async () => {
+    const result = await spawnCaptured(
+      processContext.subprocess,
+      nodeProgram("process.stdout.write(process.env.DSH_HOME ?? 'missing')"),
+      [],
+      { timeoutMs: 5_000 },
+      '/tmp/dshline-harness-home',
+    )
+    expect(result.code).toBe(0)
+    expect(result.output).toBe('/tmp/dshline-harness-home')
+  }, 10_000)
+
   it('reports a launcher that cannot be executed at all', async () => {
     const result = await spawnCaptured(
+      processContext.subprocess,
       { command: '/nonexistent/launcher', prefix: [], describe: 'missing' },
       [],
       { timeoutMs: 5_000 },
@@ -292,7 +330,7 @@ describe('the timeout is a bound, not a request', () => {
   it('holds only a bounded tail of a noisy child', async () => {
     // 4MB of output must not become 4MB of retained string.
     const noisy = "for (let i = 0; i < 60000; i += 1) process.stdout.write('x'.repeat(70) + '\\n')"
-    const result = await spawnCaptured(nodeProgram(noisy), [], { timeoutMs: 20_000 })
+    const result = await spawnCaptured(processContext.subprocess, nodeProgram(noisy), [], { timeoutMs: 20_000 })
     expect(result.code).toBe(0)
     expect(result.output.length).toBeLessThanOrEqual(16_384)
   }, 25_000)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@deepseek-ai/dsh-subagent':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(ab7edd746cefa0d35a3cd8e4a2c76fa4)
+      '@deepseek-ai/dsh-subprocess':
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-system-prompt':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))


### PR DESCRIPTION
Prepares `riesbri/dshline` for dsh.so submission, where the static security scanner currently reports **4 Critical** findings. After investigation against the current `deepseek-ai/deepseek-harness` architecture (published `@deepseek-ai/dsh-subprocess@0.1.1-rc.2` + `@deepseek-ai/dsh-subprocess-local`), two of the four were real ownership problems; two were scanner artifacts of a security test's own fixture.

## Final behavior

- **Harness subprocess owns the lifecycle/security boundary.** `/profiles` mutations still forward to `dsh plugin` (there is no published Harness service for profile mutation), but every process concern — executable lookup, environment policy, detached process trees, platform-correct signalling, TERM→KILL escalation — belongs to `ctx.subprocess`, provided locally by `dsh-subprocess-local`. No `node:child_process` remains under `src/`.
- **Package-manager-owned auth namespaces are restored explicitly** through the seam's `spec.env` channel: `NPM_*`, `PNPM_*`, `COREPACK_*`, `NODE_AUTH_TOKEN`. Private registries configured through these namespaces (`_authToken=${NPM_TOKEN}` in user-level `.npmrc`, scoped `npm_config_//host/:_authToken=…` / `pnpm_config__auth={…}` env forms) authenticate exactly as before.
- **Arbitrary credential-shaped variables remain scrubbed.** Nothing outside those namespaces reaches installs: harness/model secrets (`DEEPSEEK_API_KEY`) and unrelated `*KEY*`/`*TOKEN*`/`*SECRET*`/`*PASSWORD*` names never enter package lifecycle scripts. Custom names (`${MY_COMPANY_TOKEN}`) are excluded on purpose — config files are user-writable by anything running as the user, so honoring their references would let one poisoned config promote an ambient secret into the next install (the same exfiltration shape pnpm itself closed by ignoring project-level auth settings since 11.5.3). Supported path: reference `${NPM_TOKEN}` from *user-level* config and provide it at launch (`NPM_TOKEN="$MY_COMPANY_TOKEN" dshline …`) — environment-only delivery, nothing weaker stored. Ecosystem variables such as `CODEARTIFACT_AUTH_TOKEN` are enumerated nowhere because their official tooling writes literal rotating credentials into user config (AWS CodeArtifact) or its own CLI config (JFrog), not through raw pnpm.
- **`DSH_HOME` is restored from Harness**: taken from the Host's resolved `ctx.dshHomePath()` service rather than copied from ambient env, so nested `dsh plugin` operations always target the home this frontend was launched from, while every other ambient `DSH_*` name stays scrubbed.
- **A relative `$DSH_BIN` is normalized to an absolute path before subprocess resolution** (`src/launcher.ts`): the cwd-relative answer the lookup always supported is pinned in with lexical `path.resolve`, diagnostics still quote what the user wrote, wrong paths remain misconfiguration sentences. `bin/dshline.mjs` is untouched.

Everything else about `/profiles` is preserved exactly: structured argv (never shell-interpreted), bounded rolling output tail (16 KB), output/command redaction, failure-reason extraction, timeout classification vocabulary (127/124), checkout-launcher `cwd`, and the injectable test seams. The capability is read tolerantly via `ctx.get('subprocess')`: an incomplete Host boots fine, and `/profiles` reports "capability unavailable" with the exact command to run by hand instead of taking process ownership it no longer has.

## What changed, file by file

- `src/profiles/actions.ts` — the hand-rolled spawn/process-group/signal ladder is replaced by `SubprocessRuntime.spawn` specs (explicit argv/cwd/stdio/grace/env) and `handle.terminate()`; caller keeps its ten-minute deadline and a hard settle bound so the profile lock can never wait indefinitely. `childEnvironment()` computes the restore set above.
- `src/profiles/index.ts` — reads `ctx.subprocess` and `ctx.dshHomePath` tolerantly and passes them into `runProfileOperation`.
- `src/launcher.ts` — relative `$DSH_BIN` absolutized at resolution time.
- `tests/profiles-actions.spec.ts` — quoting fixture changed from `rm -rf /` to `echo harmless-fixture` (assertion strength unchanged); lifecycle tests now drive the real published provider (`LocalSubprocessRuntime`): stubborn-child TERM→KILL bound, unresolvable launcher, noisy-output tail bound, `DSH_HOME` restoration, credential-namespace restore (`NPM_TOKEN`, `NODE_AUTH_TOKEN` through), harness-secret non-forwarding (`DEEPSEEK_API_KEY`, `GITHUB_TOKEN` kept out), incomplete-Host handling.
- `tests/launcher-policy.spec.ts` — coverage for relative-`$DSH_BIN` pinning and unchanged misconfiguration wording.
- `packages/dshline/package.json` / `pnpm-lock.yaml` — type-only `@deepseek-ai/dsh-subprocess` devDependency pinned like its siblings; patch changeset included.

## Scanner findings

- ✅ Disappear: the `spawn` import in `src/profiles/actions.ts`; both Criticals from the `rm -rf /` literal → **4 → 1 Critical**
- 🔒 Intentionally remains: `bin/dshline.mjs`'s `spawn` — runs before any Harness context exists; sole job is handing the terminal to the real `dsh` launcher with structured argv and inherited stdio
- ℹ️ Intentionally remains: `process.env` Info findings

## Deliberately not changed

- `bin/dshline.mjs` architecture (pre-context launcher handover; per AGENTS.md a wrapper and nothing more)
- No obfuscation, indirection, or new dependencies to satisfy heuristics
- The duplicated launcher policy between wrapper and `src/launcher.ts` stays guarded by `launcher-policy.spec.ts`

## Verification

`pnpm build` ✓ · `pnpm typecheck` ✓ · `pnpm test` ✓ (**1,588 passed**, 1 pre-existing skip) · `pnpm run verify-docs` ✓ (9 pairs consistent) · `pnpm security` ✓ (audit clean; zizmor clean). Parity assertions were developed red-green against prior revisions. npm/pnpm behavior claims were verified empirically twice independently (local registry-header probe + transport-boundary instrumentation) on npm 12.0.2 / pnpm 11.22.0.

🤝 Co-authored by the ox-alpha agent and its codex background subagent.
