### PR TITLE
fix(dshline): say subagents when the status counts subagents

### DIFF
--- a/.changeset/name-subagent-count.md
+++ b/.changeset/name-subagent-count.md
@@ -1,0 +1,6 @@
+---
+"@dshline/dshline": patch
+"@dshline/renderer": patch
+---
+
+Call snapshot-derived subagent counts “subagents” in the status line and `/work` overlay.

--- a/.changeset/name-subagent-count.md
+++ b/.changeset/name-subagent-count.md
@@ -3,4 +3,4 @@
 "@dshline/renderer": patch
 ---
 
-Call snapshot-derived subagent counts “subagents” in the status line and `/work` overlay.
+Clarify snapshot-derived work wording with singular-aware subagent and job counts, and label parallel activity suffixes as calls.

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/usage.md
-usage.md: 706672d145a8e2a5aa6d37fba29c2e5ae6c3274f
-usage.zh.md: 85c0c69cc50c3e1b40a7ccee81693a049d075872
+usage.md: 1cdc8688e683012b5c14118f0e7c719148196698
+usage.zh.md: a28d43025c598eb646101113deb94dda25908094

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -597,12 +597,12 @@ The whole selection is stored together — route and reasoning level — because
 ### While a turn is running
 
 ```
-⠙ working 14m 26s · run_shell_command +2 · x-preview-f-free · ↑2.3M ↓21k · ▌░░░░░░░ 68k/1.0M · goal armed · todo 5/11 · ctrl-c interrupt
+⠙ working 14m 26s · run_shell_command +2 calls · x-preview-f-free · ↑2.3M ↓21k · ▌░░░░░░░ 68k/1.0M · goal armed · todo 5/11 · ctrl-c interrupt
 ```
 
 Beside the elapsed time is the tool the turn is waiting on. A long turn with nothing named beside it reads the same whether a command is running or the session has stopped responding, so the name is the difference between waiting and worrying. It is the first thing given up when the terminal narrows.
 
-`+2` means two more tools are running alongside it — the harness dispatches calls that are safe to run together in parallel, so several can be outstanding at once. The name is the most recently started of them.
+`+2 calls` means two more tools are running alongside it — the harness dispatches calls that are safe to run together in parallel, so several can be outstanding at once. The name is the most recently started of them.
 
 The time is the **turn's**, not that tool's. Nothing here claims how long any one call has been running, because the harness does not publish that.
 

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -475,12 +475,12 @@ dshline:
 ### 一轮进行中
 
 ```
-⠙ working 14m 26s · run_shell_command +2 · x-preview-f-free · ↑2.3M ↓21k · ▌░░░░░░░ 68k/1.0M · goal armed · todo 5/11 · ctrl-c interrupt
+⠙ working 14m 26s · run_shell_command +2 calls · x-preview-f-free · ↑2.3M ↓21k · ▌░░░░░░░ 68k/1.0M · goal armed · todo 5/11 · ctrl-c interrupt
 ```
 
 在已用时间旁边是这一轮等待的工具。长轮旁边没有名字时，无论命令在运行还是会话已停止响应，读起来都一样，因此名字是等待与担心之间的区别。它是终端变窄时第一个被放弃的东西。
 
-`+2` 表示还有两个工具在并行运行——Harness 调度可以安全并行运行的调用，因此几个可以同时未完成。名字是其中最新启动的一个。
+`+2 calls` 表示还有两个工具在并行运行——Harness 调度可以安全并行运行的调用，因此几个可以同时未完成。名字是其中最新启动的一个。
 
 时间是**这一轮**的，不是那个工具的。这里没有任何内容声称某个调用跑了多久，因为 Harness 不发布它。
 

--- a/packages/dshline/src/views.ts
+++ b/packages/dshline/src/views.ts
@@ -372,12 +372,12 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
       //
       // Its own segment rather than part of the timer, because the elapsed time is
       // the TURN's and not this call's: the harness publishes no per-call duration,
-      // and `working 14m 26s run_shell_command` would claim one. `+2` counts the
-      // other calls running in parallel — naming one of six would be a smaller
-      // number of tools, not a shorter way of saying six.
+      // and `working 14m 26s run_shell_command` would claim one. `+2 calls`
+      // counts the other calls running in parallel — naming one of six would be
+      // a smaller number of tools, not a shorter way of saying six.
       const activity = current.busy && current.activity !== undefined
         ? paint(
-          `${escapeControls(current.activity.name)}${current.activity.others > 0 ? ` +${String(current.activity.others)}` : ''}`,
+          `${escapeControls(current.activity.name)}${current.activity.others > 0 ? ` +${String(current.activity.others)} ${current.activity.others === 1 ? 'call' : 'calls'}` : ''}`,
           'subdued',
         )
         : undefined

--- a/packages/dshline/src/work/model.ts
+++ b/packages/dshline/src/work/model.ts
@@ -49,11 +49,11 @@ export interface WorkStopResult {
  * @returns a whole-segment status label, or undefined when there is no work.
  */
 export function workSummary(snapshot: WorkSnapshot): string | undefined {
-  const agents = snapshot.subagents.length
+  const subagents = snapshot.subagents.length
   const jobs = snapshot.jobs.length
-  if (agents === 0 && jobs === 0) return undefined
+  if (subagents === 0 && jobs === 0) return undefined
   const parts: string[] = []
-  if (agents > 0) parts.push(`${String(agents)} ${agents === 1 ? 'agent' : 'agents'}`)
+  if (subagents > 0) parts.push(`${String(subagents)} ${subagents === 1 ? 'subagent' : 'subagents'}`)
   if (jobs > 0) parts.push(`${String(jobs)} ${jobs === 1 ? 'job' : 'jobs'}`)
   return parts.join(' · ')
 }

--- a/packages/dshline/src/work/overlay.ts
+++ b/packages/dshline/src/work/overlay.ts
@@ -243,11 +243,13 @@ function compactFallback(
   if (notice?.failed === true) {
     return [paint(truncateToWidth(escapeControls(notice.text), Math.max(1, columns)), 'error')]
   }
+  const subagents = snapshot.subagents.length
+  const jobs = snapshot.jobs.length
   const summary = !snapshot.available
     ? 'Work unavailable · esc close'
-    : snapshot.jobs.length === 0 && snapshot.subagents.length === 0
+    : jobs === 0 && subagents === 0
       ? 'No active work · esc close'
-      : `${String(snapshot.subagents.length)} subagents · ${String(snapshot.jobs.length)} jobs · esc close`
+      : `${String(subagents)} ${subagents === 1 ? 'subagent' : 'subagents'} · ${String(jobs)} ${jobs === 1 ? 'job' : 'jobs'} · esc close`
   // On a narrow fallback, keeping the way out matters more than naming work
   // that cannot be inspected in that geometry.
   const shown = columns < displayWidth(summary) ? 'esc close' : summary

--- a/packages/dshline/src/work/overlay.ts
+++ b/packages/dshline/src/work/overlay.ts
@@ -247,7 +247,7 @@ function compactFallback(
     ? 'Work unavailable · esc close'
     : snapshot.jobs.length === 0 && snapshot.subagents.length === 0
       ? 'No active work · esc close'
-      : `${String(snapshot.subagents.length)} agents · ${String(snapshot.jobs.length)} jobs · esc close`
+      : `${String(snapshot.subagents.length)} subagents · ${String(snapshot.jobs.length)} jobs · esc close`
   // On a narrow fallback, keeping the way out matters more than naming work
   // that cannot be inspected in that geometry.
   const shown = columns < displayWidth(summary) ? 'esc close' : summary

--- a/packages/dshline/tests/views.spec.ts
+++ b/packages/dshline/tests/views.spec.ts
@@ -562,14 +562,14 @@ describe('the status line', () => {
   })
 
   it('names optional generic work without creating another status row', () => {
-    expect(status({ work: '2 agents · 1 job' })).toContain('2 agents · 1 job')
-    expect(status()).not.toContain('agents')
+    expect(status({ work: '2 subagents · 1 job' })).toContain('2 subagents · 1 job')
+    expect(status()).not.toContain('subagents')
   })
 
   it('drops Todo before Work and behavior-changing modes, without cutting it', () => {
     const state = {
       todo: 'todo 2/5',
-      work: '2 agents · 1 job',
+      work: '2 subagents · 1 job',
       plan: true,
       goal: { label: 'goal 12/256', short: 'goal 12/256', running: true },
       tokens: 130_000,
@@ -578,7 +578,7 @@ describe('the status line', () => {
     expect(status(state, 100)).toContain('todo 2/5')
     const line = status(state, 68)
     expect(line).not.toContain('todo 2/5')
-    expect(line).toContain('2 agents · 1 job')
+    expect(line).toContain('2 subagents · 1 job')
     expect(line).toContain('plan')
     expect(line).toContain('goal 12/256')
     for (const columns of [20, 30, 40, 50, 60, 80]) {
@@ -590,7 +590,7 @@ describe('the status line', () => {
 
   it('drops optional work before a mode that changes behavior', () => {
     const state = {
-      work: '2 agents · 1 job',
+      work: '2 subagents · 1 job',
       plan: true,
       goal: { label: 'goal 12/256', short: 'goal 12/256', running: true },
       tokens: 130_000,
@@ -599,21 +599,21 @@ describe('the status line', () => {
     const line = status(state, 50)
     expect(line).toContain('plan')
     expect(line).toContain('goal 12/256')
-    expect(line).not.toContain('2 agents · 1 job')
+    expect(line).not.toContain('2 subagents · 1 job')
   })
 
   it('drops the optional work summary whole on narrow terminals', () => {
     for (const columns of [20, 30, 40, 60, 80, 120]) {
       const line = status({
-        work: '2 agents · 1 job',
+        work: '2 subagents · 1 job',
         plan: true,
         goal: { label: 'goal 12/256', short: 'goal 12/256', running: true },
         tokens: 130_000,
         contextWindow: 1_000_000,
       }, columns)
       expect(displayWidth(line), `${String(columns)} columns`).toBeLessThanOrEqual(columns)
-      expect(line.includes('2 agents') && !line.includes('2 agents · 1 job')).toBe(false)
-      expect(line.includes('1 job') && !line.includes('2 agents · 1 job')).toBe(false)
+      expect(line.includes('2 subagents') && !line.includes('2 subagents · 1 job')).toBe(false)
+      expect(line.includes('1 job') && !line.includes('2 subagents · 1 job')).toBe(false)
     }
   })
 

--- a/packages/dshline/tests/views.spec.ts
+++ b/packages/dshline/tests/views.spec.ts
@@ -507,8 +507,8 @@ describe('the status line', () => {
 
   it('shows an escape sequence in a tool name instead of obeying it', () => {
     // A tool name comes from the harness registry, which a plugin writes.
-    expect(status({ busy: true, elapsedMs: 4_000, activity: { name: 'evil\u001b[2Jtool', others: 0 } }))
-      .toContain('^[[2J')
+    expect(status({ busy: true, elapsedMs: 4_000, activity: { name: 'evil\u001b[2Jtool', others: 2 } }))
+      .toContain('evil^[[2Jtool +2 calls')
   })
 
   it('drops a display preference before a mode that changes behaviour', () => {

--- a/packages/dshline/tests/views.spec.ts
+++ b/packages/dshline/tests/views.spec.ts
@@ -497,7 +497,9 @@ describe('the status line', () => {
     // The harness dispatches concurrency-safe calls together. `grep` alone would
     // report one tool running where three are.
     expect(status({ busy: true, elapsedMs: 4_000, activity: { name: 'grep', others: 2 } }))
-      .toContain('grep +2')
+      .toContain('grep +2 calls')
+    expect(status({ busy: true, elapsedMs: 4_000, activity: { name: 'grep', others: 1 } }))
+      .toContain('grep +1 call')
     // One call is the common case and carries no count at all.
     expect(status({ busy: true, elapsedMs: 4_000, activity: { name: 'grep', others: 0 } }))
       .not.toContain('grep +')

--- a/packages/dshline/tests/work.spec.ts
+++ b/packages/dshline/tests/work.spec.ts
@@ -181,11 +181,11 @@ describe('generic Harness Work capability projection', () => {
 })
 
 describe('the Work status summary', () => {
-  it('names snapshot subagents without counting the root agent', () => {
+  it('derives the summary solely from the snapshot arrays', () => {
     const oneSubagent = [item({ id: 'subagent-1', source: 'subagent' })]
     const twoSubagents = [...oneSubagent, item({ id: 'subagent-2', source: 'subagent' })]
-    const rootOnly = { ...EMPTY, available: true, mainAgent: agent }
-    expect(workSummary(rootOnly)).toBeUndefined()
+    expect(workSummary(EMPTY)).toBeUndefined()
+    expect(workSummary({ ...EMPTY, available: true })).toBeUndefined()
     expect(workSummary({
       available: true,
       subagents: oneSubagent,
@@ -237,22 +237,28 @@ describe('the Work live-region overlay', () => {
     expect(lines.every(line => displayWidth(line) <= 30)).toBe(true)
   })
 
-  it('names snapshot counts as subagents and jobs in the compact headline', () => {
-    const snapshot: WorkSnapshot = {
-      available: true,
-      subagents: [
-        item({ id: 'subagent-1', source: 'subagent' }),
-        item({ id: 'subagent-2', source: 'subagent' }),
-      ],
-      jobs: [item({ source: 'job' })],
-    }
+  it('pluralizes snapshot counts in the compact headline', () => {
+    let snapshot: WorkSnapshot = EMPTY
     const overlay = createWorkOverlay({
       snapshot: () => snapshot,
       stop: () => STOP_REQUESTED,
       close: () => {},
       invalidate: () => {},
     })
-    expect(stripAnsi(overlay.render(80, 6)[0] ?? '')).toBe('2 subagents · 1 jobs · esc close')
+    const cases = [
+      [1, 1, '1 subagent · 1 job · esc close'],
+      [1, 2, '1 subagent · 2 jobs · esc close'],
+      [2, 1, '2 subagents · 1 job · esc close'],
+      [2, 2, '2 subagents · 2 jobs · esc close'],
+    ] as const
+    for (const [subagents, jobs, expected] of cases) {
+      snapshot = {
+        available: true,
+        subagents: Array.from({ length: subagents }, (_, index) => item({ id: `subagent-${String(index)}`, source: 'subagent' })),
+        jobs: Array.from({ length: jobs }, (_, index) => item({ id: `job-${String(index)}`, source: 'job' })),
+      }
+      expect(stripAnsi(overlay.render(80, 6)[0] ?? '')).toBe(expected)
+    }
   })
 
   it('shows a stop hint only for the selected stoppable item', () => {

--- a/packages/dshline/tests/work.spec.ts
+++ b/packages/dshline/tests/work.spec.ts
@@ -182,25 +182,25 @@ describe('generic Harness Work capability projection', () => {
 
 describe('the Work status summary', () => {
   it('derives the summary solely from the snapshot arrays', () => {
-    const oneSubagent = [item({ id: 'subagent-1', source: 'subagent' })]
-    const twoSubagents = [...oneSubagent, item({ id: 'subagent-2', source: 'subagent' })]
     expect(workSummary(EMPTY)).toBeUndefined()
     expect(workSummary({ ...EMPTY, available: true })).toBeUndefined()
-    expect(workSummary({
-      available: true,
-      subagents: oneSubagent,
-      jobs: [],
-    })).toBe('1 subagent')
-    expect(workSummary({
-      available: true,
-      subagents: twoSubagents,
-      jobs: [],
-    })).toBe('2 subagents')
-    expect(workSummary({
-      available: true,
-      subagents: twoSubagents,
-      jobs: [item({ source: 'job' })],
-    })).toBe('2 subagents · 1 job')
+    const cases = [
+      [0, 1, '1 job'],
+      [0, 2, '2 jobs'],
+      [1, 0, '1 subagent'],
+      [2, 0, '2 subagents'],
+      [1, 1, '1 subagent · 1 job'],
+      [1, 2, '1 subagent · 2 jobs'],
+      [2, 1, '2 subagents · 1 job'],
+      [2, 2, '2 subagents · 2 jobs'],
+    ] as const
+    for (const [subagents, jobs, expected] of cases) {
+      expect(workSummary({
+        available: true,
+        subagents: Array.from({ length: subagents }, (_, index) => item({ id: `subagent-${String(index)}`, source: 'subagent' })),
+        jobs: Array.from({ length: jobs }, (_, index) => item({ id: `job-${String(index)}`, source: 'job' })),
+      })).toBe(expected)
+    }
   })
 })
 
@@ -246,6 +246,11 @@ describe('the Work live-region overlay', () => {
       invalidate: () => {},
     })
     const cases = [
+      [0, 0, 'No active work · esc close'],
+      [0, 1, '0 subagents · 1 job · esc close'],
+      [0, 2, '0 subagents · 2 jobs · esc close'],
+      [1, 0, '1 subagent · 0 jobs · esc close'],
+      [2, 0, '2 subagents · 0 jobs · esc close'],
       [1, 1, '1 subagent · 1 job · esc close'],
       [1, 2, '1 subagent · 2 jobs · esc close'],
       [2, 1, '2 subagents · 1 job · esc close'],

--- a/packages/dshline/tests/work.spec.ts
+++ b/packages/dshline/tests/work.spec.ts
@@ -11,7 +11,7 @@ import { createEmulator } from '../../../tests/emulator.ts'
 import { HarnessWork } from '../src/work/index.ts'
 import { createWorkOverlay } from '../src/work/overlay.ts'
 import type { WorkItem, WorkSnapshot, WorkStopResult } from '../src/work/model.ts'
-import { activeWorkCount } from '../src/work/model.ts'
+import { activeWorkCount, workSummary } from '../src/work/model.ts'
 
 /** The root agent shape the capability contracts use for ownership. */
 const agent = { session: { id: 'root' } } as unknown as Agent
@@ -180,6 +180,30 @@ describe('generic Harness Work capability projection', () => {
   })
 })
 
+describe('the Work status summary', () => {
+  it('names snapshot subagents without counting the root agent', () => {
+    const oneSubagent = [item({ id: 'subagent-1', source: 'subagent' })]
+    const twoSubagents = [...oneSubagent, item({ id: 'subagent-2', source: 'subagent' })]
+    const rootOnly = { ...EMPTY, available: true, mainAgent: agent }
+    expect(workSummary(rootOnly)).toBeUndefined()
+    expect(workSummary({
+      available: true,
+      subagents: oneSubagent,
+      jobs: [],
+    })).toBe('1 subagent')
+    expect(workSummary({
+      available: true,
+      subagents: twoSubagents,
+      jobs: [],
+    })).toBe('2 subagents')
+    expect(workSummary({
+      available: true,
+      subagents: twoSubagents,
+      jobs: [item({ source: 'job' })],
+    })).toBe('2 subagents · 1 job')
+  })
+})
+
 describe('the Work live-region overlay', () => {
   it('never exceeds its physical terminal height across narrow state and size matrices', () => {
     const states: readonly WorkSnapshot[] = [
@@ -211,6 +235,24 @@ describe('the Work live-region overlay', () => {
     expect(plain).toContain('提供者')
     expect(plain).toContain('^[')
     expect(lines.every(line => displayWidth(line) <= 30)).toBe(true)
+  })
+
+  it('names snapshot counts as subagents and jobs in the compact headline', () => {
+    const snapshot: WorkSnapshot = {
+      available: true,
+      subagents: [
+        item({ id: 'subagent-1', source: 'subagent' }),
+        item({ id: 'subagent-2', source: 'subagent' }),
+      ],
+      jobs: [item({ source: 'job' })],
+    }
+    const overlay = createWorkOverlay({
+      snapshot: () => snapshot,
+      stop: () => STOP_REQUESTED,
+      close: () => {},
+      invalidate: () => {},
+    })
+    expect(stripAnsi(overlay.render(80, 6)[0] ?? '')).toBe('2 subagents · 1 jobs · esc close')
   })
 
   it('shows a stop hint only for the selected stoppable item', () => {


### PR DESCRIPTION
## What changed

Status wording only: the count that comes from `snapshot.subagents` is now labelled **"N subagent(s)"** instead of "N agent(s)".

- Status line segment (via `workSummary()`): `2 agents · 1 job` → `2 subagents · 1 job`
- `/work` compact fallback headline: `2 agents · 1 jobs · esc close` → `2 subagents · 1 jobs · esc close`

## Semantics preserved (no Harness-behavior change)

- **No counting change**: `workSummary` still reads only `snapshot.subagents.length` and `snapshot.jobs.length`; the main agent was never counted and still is not — the existing `working` state represents it. A new test names that promise: *names snapshot subagents without counting the root agent*.
- **Jobs and Subagents remain separate Harness authorities**: nothing correlates or merges them; `activeWorkCount` still sums both capabilities without relating them, which answers only the lifecycle question it exists for.
- **`/work` stays provider-neutral**, built solely from `ctx.subagents` and `ctx.jobs` snapshots. No provider/tool-specific logic touched.
- No architecture, overlay-model, or broader UX changes in this PR.

## Tests

- New focused coverage pins `workSummary` output: one → `1 subagent`, several → `N subagents`, mixed → `N subagents · M job(s)`, empty → `undefined`.
- Plain-text assertion added for the `/work` fallback headline wording; stale status-line fixtures moved to the new vocabulary so they do not reintroduce the old word.
- Full suite: `pnpm build`, `pnpm typecheck`, `pnpm test` — **1608 passed, 1 skipped**.
- Break-fix proof: temporarily restoring `agent/agents` fails *names snapshot subagents without counting the root agent* with `expected '1 agent' to be '1 subagent'`; restored after confirming.

## Docs & changeset

- No documentation changes needed: a search found no rendered example showing the old `N agents` wording in any doc pair; `pnpm run verify-docs` reports all 9 bilingual pairs consistent.
- One changeset, **patch** bump (user-visible wording fix), covering both fixed-version packages.

Co-authored-by: ox-alpha <ox-alpha@users.noreply.github.com>


## Review round (c72c59f)

Three findings from independent review, fixed on this branch:

- **`/work` footer pluralization** — the compact fallback printed `1 subagents · 1 jobs`; both counts now decline properly (`1 subagent · 1 job` … `N subagents · M jobs`), with all four combinations tested.
- **Invented `mainAgent` field removed** — the summary test had constructed a `WorkSnapshot` with a `mainAgent` property no projection carries (spread literals bypass TS excess-property checks). The test now states the real contract: *the summary derives solely from the snapshot arrays*; empty arrays → `undefined`, whatever else exists.
- **Unambiguous parallel-call suffix** — the status line's activity segment showed e.g. `subagent_codex +1`, readable as "+1 subagent". That suffix comes from `cards.inFlight()` and counts other pending tool **calls**, so it now renders `+1 call` / `+2 calls`. Accounting unchanged; jobs, subagents, and tool calls remain separate authorities; nothing Codex-specific. Usage docs (EN + ZH) example frame and explanation updated.

Break-fix proofs for each are in the commit body. Full suite 1608 passed · verify-docs 9/9 pairs.
