### PR TITLE
compat: adopt Harness user-question waterfall

### DIFF
--- a/.changeset/user-questions-waterfall.md
+++ b/.changeset/user-questions-waterfall.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': patch
+---
+
+`ask_user_question` now answers correctly against both the Harness 0.1.1 `ctx.userQuestions.registerProvider()` single-provider slot and the 0.1.2+ Agent-scoped Cordis waterfall (`ctx.on('user-questions/request', …)`) that replaced it, detected at runtime by whether `registerProvider` exists rather than by package version. Plan review, generic questions, and abort handling are unchanged; dshline always claims a request under the new registration mode, since it has no other answerer to defer to.

--- a/.changeset/user-questions-waterfall.md
+++ b/.changeset/user-questions-waterfall.md
@@ -2,4 +2,4 @@
 '@dshline/dshline': patch
 ---
 
-`ask_user_question` now answers correctly against both the Harness 0.1.1 `ctx.userQuestions.registerProvider()` single-provider slot and the 0.1.2+ Agent-scoped Cordis waterfall (`ctx.on('user-questions/request', …)`) that replaced it, detected at runtime by whether `registerProvider` exists rather than by package version. Plan review, generic questions, and abort handling are unchanged; dshline always claims a request under the new registration mode, since it has no other answerer to defer to.
+`ask_user_question` now answers correctly against both Harness's older single-provider `ctx.userQuestions.registerProvider()` and its current Agent-scoped waterfall registration, detected at runtime rather than by package version. Presentation is unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,9 @@ every pull request and push to `main`; all three (plus the sync job) run on
 **Actions → ci → Run workflow**. Each lane additionally runs
 `node tools/capability-report.mjs`, which reports an initial set of Harness
 capability seams dshline consumes (`sessionQuery`, `jobs`, `subagents`,
-`sessionProjections` today) by name — see `tools/capability-probes.mjs` and
-docs/architecture.md, "Upstream compatibility". The harness-sync job still
+`sessionProjections`, `userQuestions` today) by name — see
+`tools/capability-probes.mjs` and docs/architecture.md, "Upstream
+compatibility". The harness-sync job still
 opens the rolling automated pull request when the published line moves; it
 neither changes the supported registry version nor publishes anything, and
 it — like every job above that

--- a/docs/architecture.i18n.yaml
+++ b/docs/architecture.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/architecture.md
-architecture.md: 2336b327b4d71698918a806386d14ded00730de8
-architecture.zh.md: 6720428ba5af138600b3921e646c53862374d5b2
+architecture.md: 22d934212a73803370e0fc6caaac75d3af2b000a
+architecture.zh.md: 5b00365cd25f6c028ded85cebd9db5d9657aaac4

--- a/docs/architecture.i18n.yaml
+++ b/docs/architecture.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/architecture.md
-architecture.md: 22d934212a73803370e0fc6caaac75d3af2b000a
-architecture.zh.md: 5b00365cd25f6c028ded85cebd9db5d9657aaac4
+architecture.md: 2f5d5ed388a924ec8a04c175abd421907454931b
+architecture.zh.md: fe4702595f20551c5a37f83f18ffef9eca530a2f

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,7 @@ Prefer a standard Harness surface over a concrete package or provider:
 | obtaining a credential | `ctx.authorization` | Render the seam's neutral notice and prompt vocabulary; own no login protocol. |
 | human commands | `ctx.commands` | Discover and execute the registered command contract. |
 | tools | `ctx.tools` | Render tool-owned presentation intents, not tool-name cases. |
+| human answers | `ctx.userQuestions` | Register a terminal answerer under whichever registration mode the mounted Harness version publishes (a single-provider slot, or an Agent-scoped waterfall); never assume the request was addressed only to this frontend. |
 | sessions | `ctx.sessionQuery` | Query Harness's live-preferred session corpus; do not build another database. Its full-text methods are abstract, so treat content search as optional. |
 | attachments | `ctx.attachments` | Use durable, authorized attachment references; do not save paths or base64. |
 | log-derived state | `ctx.sessionProjections` | Consume registered domain snapshots and changes. |
@@ -558,19 +559,34 @@ compatibility decision rather than a surprise release break.
 
 All three additionally run `tools/capability-report.mjs`, which turns a
 seam's real Harness contract — a real `SessionQueryEngine`, a real
-`SubagentRuntime`, a real abstract `JobRegistry` subclass, never a
-dshline-shaped fake — into a named pass/fail per capability. Coverage today is
-initial, not exhaustive: `sessionQuery`, `jobs`, `subagents`, and
-`sessionProjections`, chosen because each already has (or could cheaply gain)
-a test built against the real class rather than a hand-typed fake. An upstream
-change to one of these reads as `sessionQuery contract changed` rather than
-only a generic `pnpm typecheck failed`; a seam not yet in the table still has
+`SubagentRuntime`, a real abstract `JobRegistry` subclass, a real
+`UserQuestionService`, never a dshline-shaped fake — into a named pass/fail
+per capability. Coverage today is initial, not exhaustive: `sessionQuery`,
+`jobs`, `subagents`, `sessionProjections`, and `userQuestions`, chosen because
+each already has (or could cheaply gain) a test built against the real class
+rather than a hand-typed fake. An upstream change to one of these reads as
+`sessionQuery contract changed` rather than only a generic
+`pnpm typecheck failed`; a seam not yet in the table still has
 `pnpm typecheck`/`pnpm test` as its backstop. `tools/capability-probes.mjs` is
 a pointer table, not a second copy of the contract: it names which existing or
 purpose-built test already exercises each seam, so growing this coverage means
 adding a line to that table (or a small new probe under
 `packages/dshline/tests/capability/`), never teaching this module the seam's
 shape itself.
+
+`userQuestions` is this radar's first proof against a real break rather than a
+hypothetical one: Harness 0.1.2 replaced `ctx.userQuestions`'s single
+`registerProvider()` slot with an Agent-scoped Cordis waterfall
+(`ctx.on('user-questions/request', (request, next) => …)`), so several
+answerers — including one relayed to a connected remote client — can compose.
+`installQuestionProvider` feature-detects which shape is mounted (whether
+`registerProvider` exists on `ctx.userQuestions`, never a package-version
+check) and always claims a request under the new shape, since dshline is a
+self-contained terminal frontend with no other answerer to defer to. The one
+piece of this that cannot come from either package's real types at once — the
+0.1.2 waterfall event, absent from the 0.1.1 types Minimum still resolves —
+is a narrow, explicitly-cast local interface in `packages/dshline/src/questions.ts`,
+deletable once the Minimum floor moves past 0.1.1.
 
 Released also compares the currently published line against the newest
 official `dsh-v*` GitHub Release (not merely a tag — a Release DeepSeek

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ Prefer a standard Harness surface over a concrete package or provider:
 | obtaining a credential | `ctx.authorization` | Render the seam's neutral notice and prompt vocabulary; own no login protocol. |
 | human commands | `ctx.commands` | Discover and execute the registered command contract. |
 | tools | `ctx.tools` | Render tool-owned presentation intents, not tool-name cases. |
-| human answers | `ctx.userQuestions` | Register a terminal answerer under whichever registration mode the mounted Harness version publishes (a single-provider slot, or an Agent-scoped waterfall); never assume the request was addressed only to this frontend. |
+| human answers | `ctx.userQuestions` | Register a terminal answerer; claim a request this frontend can present, never assuming it was addressed only to this frontend. |
 | sessions | `ctx.sessionQuery` | Query Harness's live-preferred session corpus; do not build another database. Its full-text methods are abstract, so treat content search as optional. |
 | attachments | `ctx.attachments` | Use durable, authorized attachment references; do not save paths or base64. |
 | log-derived state | `ctx.sessionProjections` | Consume registered domain snapshots and changes. |
@@ -574,19 +574,13 @@ adding a line to that table (or a small new probe under
 `packages/dshline/tests/capability/`), never teaching this module the seam's
 shape itself.
 
-`userQuestions` is this radar's first proof against a real break rather than a
-hypothetical one: Harness 0.1.2 replaced `ctx.userQuestions`'s single
-`registerProvider()` slot with an Agent-scoped Cordis waterfall
-(`ctx.on('user-questions/request', (request, next) => …)`), so several
-answerers — including one relayed to a connected remote client — can compose.
-`installQuestionProvider` feature-detects which shape is mounted (whether
-`registerProvider` exists on `ctx.userQuestions`, never a package-version
-check) and always claims a request under the new shape, since dshline is a
-self-contained terminal frontend with no other answerer to defer to. The one
-piece of this that cannot come from either package's real types at once — the
-0.1.2 waterfall event, absent from the 0.1.1 types Minimum still resolves —
-is a narrow, explicitly-cast local interface in `packages/dshline/src/questions.ts`,
-deletable once the Minimum floor moves past 0.1.1.
+`userQuestions` is this radar's first proof against a real break: Harness's
+`ctx.userQuestions` registration shape moved between the installable line and
+Edge, and `packages/dshline/src/questions.ts` currently bridges both with one
+small runtime check rather than a package-version test. That bridge is
+temporary by design — see its module comment for the deletion condition —
+because dshline supports the current installable Harness line plus current
+Edge, not indefinite historical compatibility.
 
 Released also compares the currently published line against the newest
 official `dsh-v*` GitHub Release (not merely a tag — a Release DeepSeek

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -46,7 +46,7 @@ native terminal
 | 获取凭据 | `ctx.authorization` | 渲染 seam 的中立通知与提示词汇；不拥有登录协议。 |
 | 人类命令 | `ctx.commands` | 发现并执行已注册的命令约定。 |
 | 工具 | `ctx.tools` | 渲染工具拥有的呈现意图，而不是工具名的特例。 |
-| 人类应答 | `ctx.userQuestions` | 在已挂载的 Harness 版本所发布的任一注册方式下（单一提供方槽位，或按 agent 限定作用域的 waterfall）注册一个终端应答者；绝不假设该请求只发给了本前端。 |
+| 人类应答 | `ctx.userQuestions` | 注册一个终端应答者；认领本前端能够呈现的请求，绝不假设该请求只发给了本前端。 |
 | 会话 | `ctx.sessionQuery` | 查询 Harness 偏好活动的会话语料库；不构建另一个数据库。其全文方法是抽象的，因此把内容搜索视为可选。 |
 | 附件 | `ctx.attachments` | 使用持久、授权的附件引用；不保存路径或 base64。 |
 | 日志派生的状态 | `ctx.sessionProjections` | 消费已注册的领域快照与变更。 |
@@ -270,7 +270,7 @@ Harness 发展很快，因此与其已发布接口的兼容性是头等工程事
 
 三条车道都会额外运行 `tools/capability-report.mjs`，它把一个 seam 的真实 Harness 约定——真实的 `SessionQueryEngine`、真实的 `SubagentRuntime`、真实的抽象 `JobRegistry` 子类、真实的 `UserQuestionService`，绝不是 dshline 臆造的假对象——转化为按能力命名的通过/失败结果。目前的覆盖是初始的，而非穷尽的：`sessionQuery`、`jobs`、`subagents`、`sessionProjections` 与 `userQuestions`，之所以选择它们，是因为每一个都已经有（或能够低成本获得）一个针对真实类而非手工伪造对象构建的测试。上游对其中一个的变更读起来是 `sessionQuery contract changed`，而不只是笼统的 `pnpm typecheck failed`；尚未进入这张表的 seam，仍以 `pnpm typecheck`/`pnpm test` 作为后备。`tools/capability-probes.mjs` 是一张指针表，不是约定的第二份拷贝：它只指出哪个既有或新建的测试已经在验证每个 seam，因此扩大这一覆盖意味着往那张表里加一行（或在 `packages/dshline/tests/capability/` 下新增一个小探针），而绝不是让这个模块自己学会该 seam 的形状。
 
-`userQuestions` 是这套雷达第一次证明它能发现真实的、而非假设性的破坏：Harness 0.1.2 把 `ctx.userQuestions` 原来单一的 `registerProvider()` 槽位替换成了按 agent 限定作用域的 Cordis waterfall（`ctx.on('user-questions/request', (request, next) => …)`），使多个应答者——包括中继给已连接远程客户端的那一个——得以组合。`installQuestionProvider` 在运行时探测已挂载的是哪种形态（`ctx.userQuestions` 上是否存在 `registerProvider`，而绝不检查包版本），并且在新形态下总是直接认领请求，因为 dshline 是一个自成一体的终端前端，没有别的应答者可以委托。唯一无法同时从两个包的真实类型里得到的部分——0.1.2 的 waterfall 事件，在 Minimum 仍然解析到的 0.1.1 类型里并不存在——是 `packages/dshline/src/questions.ts` 中一个狭窄的、显式转换的本地接口，一旦 Minimum 下限移到 0.1.1 之后即可删除。
+`userQuestions` 是这套雷达第一次证明它能发现真实的破坏：Harness 的 `ctx.userQuestions` 注册方式在可安装产品线与 Edge 之间发生了变化，`packages/dshline/src/questions.ts` 目前用一个小的运行时判断——而不是包版本检测——把两者桥接起来。这一桥接按设计是临时的——删除条件见其模块注释——因为 dshline 支持的是当前可安装的 Harness 产品线加上当前的 Edge，而不是无限期的历史兼容。
 
 Released 还会把当前已发布的产品线与最新的官方 `dsh-v*` GitHub Release 相比较（不只是一个标签——而是 DeepSeek 真正发布的 Release，预发布版本也算），因为 DeepSeek 会在产品线到达 npm 之前先发布 Release，所以这是唯一能看到这一差距的方式。比较本身在每次触发时都会运行；把该 release 检出并构建则只保留给每日计划任务与手动分发，并且和 Edge 一样保持不阻塞——一个尚未发布的 release 同样还不是任何消费方能够安装的东西。当该 release 与 Edge 正在 `master` 上探测的提交相同时——这是常见情形，因为一个 release 通常就是从 master 的最新提交切出的——它会直接借用 Edge 的结论，而不是在同一次运行里把同一棵 Harness 源码树构建两遍。
 

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -46,6 +46,7 @@ native terminal
 | 获取凭据 | `ctx.authorization` | 渲染 seam 的中立通知与提示词汇；不拥有登录协议。 |
 | 人类命令 | `ctx.commands` | 发现并执行已注册的命令约定。 |
 | 工具 | `ctx.tools` | 渲染工具拥有的呈现意图，而不是工具名的特例。 |
+| 人类应答 | `ctx.userQuestions` | 在已挂载的 Harness 版本所发布的任一注册方式下（单一提供方槽位，或按 agent 限定作用域的 waterfall）注册一个终端应答者；绝不假设该请求只发给了本前端。 |
 | 会话 | `ctx.sessionQuery` | 查询 Harness 偏好活动的会话语料库；不构建另一个数据库。其全文方法是抽象的，因此把内容搜索视为可选。 |
 | 附件 | `ctx.attachments` | 使用持久、授权的附件引用；不保存路径或 base64。 |
 | 日志派生的状态 | `ctx.sessionProjections` | 消费已注册的领域快照与变更。 |
@@ -267,7 +268,9 @@ Harness 发展很快，因此与其已发布接口的兼容性是头等工程事
 
 这一覆盖分为三条并存于 `.github/workflows/ci.yml` 的车道。**Minimum（下限）** 把每个 `dsh-*` devDependency 固定到一个确定的下限版本——peer 范围仍然承诺支持的最旧发布版本——并检查该依赖图仍能解析、构建与类型检查。**Released（已发布）** 按照 `tools/sync-harness.mjs` 与 `tools/check-peer-currency.mjs` 已经使用的方式解析当前已发布的产品线（注册表的 `next` dist-tag，cordis 自身的 `latest` 例外），把两个清单中的每个 Harness devDependency 固定到该版本，运行完整套件，并在真实配置文件中把打包的插件放在已发布启动器旁启动。**Edge（前沿）** 在独立检出中构建 `deepseek-ai/deepseek-harness@master`，并只在一次性 runner 内链接它，方式与 `tools/link-harness.mjs` 为手动开发链接本地检出完全相同。它可以保持不阻塞，且从不在 pull request 上运行，但它的失败应当促使明确的兼容性决策，而不是意外的发布损坏。
 
-三条车道都会额外运行 `tools/capability-report.mjs`，它把一个 seam 的真实 Harness 约定——真实的 `SessionQueryEngine`、真实的 `SubagentRuntime`、真实的抽象 `JobRegistry` 子类，绝不是 dshline 臆造的假对象——转化为按能力命名的通过/失败结果。目前的覆盖是初始的，而非穷尽的：`sessionQuery`、`jobs`、`subagents` 与 `sessionProjections`，之所以选择它们，是因为每一个都已经有（或能够低成本获得）一个针对真实类而非手工伪造对象构建的测试。上游对其中一个的变更读起来是 `sessionQuery contract changed`，而不只是笼统的 `pnpm typecheck failed`；尚未进入这张表的 seam，仍以 `pnpm typecheck`/`pnpm test` 作为后备。`tools/capability-probes.mjs` 是一张指针表，不是约定的第二份拷贝：它只指出哪个既有或新建的测试已经在验证每个 seam，因此扩大这一覆盖意味着往那张表里加一行（或在 `packages/dshline/tests/capability/` 下新增一个小探针），而绝不是让这个模块自己学会该 seam 的形状。
+三条车道都会额外运行 `tools/capability-report.mjs`，它把一个 seam 的真实 Harness 约定——真实的 `SessionQueryEngine`、真实的 `SubagentRuntime`、真实的抽象 `JobRegistry` 子类、真实的 `UserQuestionService`，绝不是 dshline 臆造的假对象——转化为按能力命名的通过/失败结果。目前的覆盖是初始的，而非穷尽的：`sessionQuery`、`jobs`、`subagents`、`sessionProjections` 与 `userQuestions`，之所以选择它们，是因为每一个都已经有（或能够低成本获得）一个针对真实类而非手工伪造对象构建的测试。上游对其中一个的变更读起来是 `sessionQuery contract changed`，而不只是笼统的 `pnpm typecheck failed`；尚未进入这张表的 seam，仍以 `pnpm typecheck`/`pnpm test` 作为后备。`tools/capability-probes.mjs` 是一张指针表，不是约定的第二份拷贝：它只指出哪个既有或新建的测试已经在验证每个 seam，因此扩大这一覆盖意味着往那张表里加一行（或在 `packages/dshline/tests/capability/` 下新增一个小探针），而绝不是让这个模块自己学会该 seam 的形状。
+
+`userQuestions` 是这套雷达第一次证明它能发现真实的、而非假设性的破坏：Harness 0.1.2 把 `ctx.userQuestions` 原来单一的 `registerProvider()` 槽位替换成了按 agent 限定作用域的 Cordis waterfall（`ctx.on('user-questions/request', (request, next) => …)`），使多个应答者——包括中继给已连接远程客户端的那一个——得以组合。`installQuestionProvider` 在运行时探测已挂载的是哪种形态（`ctx.userQuestions` 上是否存在 `registerProvider`，而绝不检查包版本），并且在新形态下总是直接认领请求，因为 dshline 是一个自成一体的终端前端，没有别的应答者可以委托。唯一无法同时从两个包的真实类型里得到的部分——0.1.2 的 waterfall 事件，在 Minimum 仍然解析到的 0.1.1 类型里并不存在——是 `packages/dshline/src/questions.ts` 中一个狭窄的、显式转换的本地接口，一旦 Minimum 下限移到 0.1.1 之后即可删除。
 
 Released 还会把当前已发布的产品线与最新的官方 `dsh-v*` GitHub Release 相比较（不只是一个标签——而是 DeepSeek 真正发布的 Release，预发布版本也算），因为 DeepSeek 会在产品线到达 npm 之前先发布 Release，所以这是唯一能看到这一差距的方式。比较本身在每次触发时都会运行；把该 release 检出并构建则只保留给每日计划任务与手动分发，并且和 Edge 一样保持不阻塞——一个尚未发布的 release 同样还不是任何消费方能够安装的东西。当该 release 与 Edge 正在 `master` 上探测的提交相同时——这是常见情形，因为一个 release 通常就是从 master 的最新提交切出的——它会直接借用 Edge 的结论，而不是在同一次运行里把同一棵 Harness 源码树构建两遍。
 

--- a/packages/dshline/src/questions.ts
+++ b/packages/dshline/src/questions.ts
@@ -1,33 +1,24 @@
 /**
  * The `ask_user_question` answerer.
  *
- * This is the seam a terminal frontend uniquely restores. The service validates
- * the request before it arrives (aborted signals, empty question lists, a
- * `plan-review` intent naming a real option, caller liveness), so this answerer
- * only renders, collects, and honours the signal.
+ * The service validates the request before it arrives (aborted signals, empty
+ * question lists, a `plan-review` intent naming a real option, caller
+ * liveness), so this answerer only renders, collects, and honours the signal.
  *
- * ## Registration compatibility (Harness 0.1.1 vs 0.1.2+)
+ * dshline is one concrete terminal answerer on Harness's `user-questions/request`
+ * seam: when a request reaches it and its active terminal surface can present
+ * that request, it claims the request by returning the structured answer. It
+ * never calls `next()` — not because no other answerer could exist, but
+ * because the terminal it presents through is always available to answer
+ * whatever reaches it.
  *
- * Harness 0.1.1 gave `ctx.userQuestions` exactly ONE provider slot
- * (`registerProvider()`, throwing `DUPLICATE_PROVIDER` on a second caller).
- * Harness 0.1.2 replaced that with an Agent-scoped Cordis waterfall
- * (`ctx.on('user-questions/request', (request, next) => …)`) so several
- * answerers — including one relayed to a connected remote client — can compose;
- * returning an answer claims the request, calling `next()` delegates. dshline
- * is a self-contained terminal frontend with no other answerer to defer to
- * (the earlier one-provider-per-process constraint already kept it out of any
- * composition that also mounted the web host's own provider), so it always
- * claims — it never calls `next()`.
- *
- * {@link installQuestionProvider} detects which shape is mounted at runtime
- * (`registerProvider` present or not) rather than checking a package version,
- * because the two shapes cannot both be described by one pinned dependency's
- * types: Minimum (0.1.1) declares no `'user-questions/request'` event at all,
- * so calling `ctx.on` for it needs the narrow, local {@link WaterfallContext}
- * bridge below instead of the real (version-specific) Cordis `Events` merge.
- * Delete {@link WaterfallContext}, {@link asWaterfallContext}, and the
- * `registerProvider` branch together once the Minimum floor moves to 0.1.2 or
- * later, where the real types already describe the waterfall.
+ * {@link registerQuestionAnswerer} bridges the installable line's registration
+ * shape (`ctx.userQuestions.registerProvider()`) and current Edge's
+ * (`ctx.on('user-questions/request', …)`) with one runtime check — the old
+ * package literally cannot publish the new event type, so neither shape can
+ * be described from one pinned dependency's declarations at once. Delete it,
+ * along with its cast, once Minimum/Released no longer resolve to a line
+ * whose `ctx.userQuestions` still has `registerProvider`.
  * @module dshline/questions
  */
 
@@ -35,53 +26,11 @@ import type { Context } from '@deepseek-ai/cordis'
 import type { AskUserQuestionAnswerItem, AskUserQuestionItem } from '@deepseek-ai/dsh-user-questions/types'
 // `AskUserQuestionRequest`/`AskUserQuestionAnswer` carry an `Agent`, so they live
 // on the service entry point rather than the wire-safe `/types` module;
-// importing from here also carries the `ctx.userQuestions` Context merge. Both
-// types are unchanged in shape across 0.1.1 and 0.1.2, so they need no bridge.
+// importing from here also carries the `ctx.userQuestions` Context merge.
 import { UserQuestionError } from '@deepseek-ai/dsh-user-questions'
 import type { AskUserQuestionAnswer, AskUserQuestionRequest } from '@deepseek-ai/dsh-user-questions'
 import { createPlanReviewOverlay } from './plan-review.ts'
 import { promptSelect } from './select.ts'
-
-/** Harness ≤0.1.1's single-provider registration shape. */
-interface LegacyUserQuestionService {
-  registerProvider(provider: { ask(request: AskUserQuestionRequest): Promise<AskUserQuestionAnswer> }): () => void
-}
-
-/**
- * Structural guard for the legacy shape, rather than a version-string check:
- * Harness 0.1.2 removed `registerProvider` entirely, so its presence alone
- * tells us which registration mode is mounted.
- * @param service - `ctx.userQuestions`, of whichever version is installed.
- * @returns the service narrowed to its legacy shape, or undefined.
- */
-function asLegacyUserQuestionService(service: unknown): LegacyUserQuestionService | undefined {
-  return typeof service === 'object' && service !== null && typeof (service as LegacyUserQuestionService).registerProvider === 'function'
-    ? service as LegacyUserQuestionService
-    : undefined
-}
-
-/**
- * The one Cordis waterfall event this file needs from Harness ≥0.1.2, declared
- * locally rather than imported: the real `Events` merge for it lives only in
- * 0.1.2's own package types, which are not what Minimum (0.1.1) resolves to at
- * compile time. This is a compatibility bridge for exactly one event, not a
- * copy of the upstream `Events` interface.
- */
-interface WaterfallContext {
-  on(
-    event: 'user-questions/request',
-    listener: (request: AskUserQuestionRequest, next: () => Promise<AskUserQuestionAnswer>) => Promise<AskUserQuestionAnswer>,
-  ): () => void
-}
-
-/**
- * Narrow, explicit cast to the waterfall bridge above — never a broad `any`.
- * @param ctx - the plugin context, of whichever Harness version is installed.
- * @returns the same context, typed for exactly the one event this file registers.
- */
-function asWaterfallContext(ctx: Context): WaterfallContext {
-  return ctx as unknown as WaterfallContext
-}
 
 /** Offered when a question carries no options of its own. */
 const ACKNOWLEDGE = [{ value: 'ok', label: 'OK' }] as const
@@ -181,20 +130,30 @@ async function answerRequest(ctx: Context, request: AskUserQuestionRequest): Pro
 }
 
 /**
- * Register this frontend as a user-questions answerer, under whichever
- * registration mode the mounted Harness version publishes — see the module
- * comment for why this is feature-detected rather than version-checked.
+ * Register `answer` as a user-questions answerer, under whichever public
+ * registration shape `ctx.userQuestions` actually publishes — see the module
+ * comment for the two shapes and this bridge's deletion condition.
+ * @param ctx - the plugin context, of whichever Harness version is mounted.
+ * @param answer - the answerer to register.
+ * @returns the disposer removing it.
+ */
+function registerQuestionAnswerer(
+  ctx: Context,
+  answer: (request: AskUserQuestionRequest) => Promise<AskUserQuestionAnswer>,
+): () => void {
+  const legacy = ctx.userQuestions as unknown as { registerProvider?(provider: { ask: typeof answer }): () => void }
+  if (typeof legacy.registerProvider === 'function') return legacy.registerProvider({ ask: answer })
+  const waterfall = ctx as unknown as {
+    on(event: 'user-questions/request', listener: (request: AskUserQuestionRequest, next: () => Promise<AskUserQuestionAnswer>) => Promise<AskUserQuestionAnswer>): () => void
+  }
+  return waterfall.on('user-questions/request', request => answer(request))
+}
+
+/**
+ * Register this frontend as a user-questions answerer.
  * @param ctx - the plugin context owning the registration.
  * @returns the disposer unregistering the answerer.
  */
 export function installQuestionProvider(ctx: Context): () => void {
-  const legacy = asLegacyUserQuestionService(ctx.userQuestions)
-  if (legacy !== undefined) {
-    return legacy.registerProvider({ ask: request => answerRequest(ctx, request) })
-  }
-  // Untagged (unscoped) registration: dsh-scope admits an untagged listener
-  // for both an agent-scoped dispatch and an unscoped one, so this single
-  // registration answers every request this process's one attached session
-  // can raise without needing to track that session's own agent scope.
-  return asWaterfallContext(ctx).on('user-questions/request', request => answerRequest(ctx, request))
+  return registerQuestionAnswerer(ctx, request => answerRequest(ctx, request))
 }

--- a/packages/dshline/src/questions.ts
+++ b/packages/dshline/src/questions.ts
@@ -1,28 +1,87 @@
 /**
- * The `ask_user_question` provider.
+ * The `ask_user_question` answerer.
  *
- * This is the seam a terminal frontend uniquely restores. `ctx.userQuestions`
- * accepts exactly ONE provider per context and throws `DUPLICATE_PROVIDER` on a
- * second registration, and the web host's API proxy already claims that slot —
- * so a composition that stacked this bundle over the web bundle would fail to
- * mount. The two frontends are separate profiles by construction, not by
- * convention.
+ * This is the seam a terminal frontend uniquely restores. The service validates
+ * the request before it arrives (aborted signals, empty question lists, a
+ * `plan-review` intent naming a real option, caller liveness), so this answerer
+ * only renders, collects, and honours the signal.
  *
- * The service validates the request before it arrives (aborted signals, empty
- * question lists, a `plan-review` intent naming a real option, caller liveness),
- * so this provider only renders, collects, and honours the signal.
+ * ## Registration compatibility (Harness 0.1.1 vs 0.1.2+)
+ *
+ * Harness 0.1.1 gave `ctx.userQuestions` exactly ONE provider slot
+ * (`registerProvider()`, throwing `DUPLICATE_PROVIDER` on a second caller).
+ * Harness 0.1.2 replaced that with an Agent-scoped Cordis waterfall
+ * (`ctx.on('user-questions/request', (request, next) => …)`) so several
+ * answerers — including one relayed to a connected remote client — can compose;
+ * returning an answer claims the request, calling `next()` delegates. dshline
+ * is a self-contained terminal frontend with no other answerer to defer to
+ * (the earlier one-provider-per-process constraint already kept it out of any
+ * composition that also mounted the web host's own provider), so it always
+ * claims — it never calls `next()`.
+ *
+ * {@link installQuestionProvider} detects which shape is mounted at runtime
+ * (`registerProvider` present or not) rather than checking a package version,
+ * because the two shapes cannot both be described by one pinned dependency's
+ * types: Minimum (0.1.1) declares no `'user-questions/request'` event at all,
+ * so calling `ctx.on` for it needs the narrow, local {@link WaterfallContext}
+ * bridge below instead of the real (version-specific) Cordis `Events` merge.
+ * Delete {@link WaterfallContext}, {@link asWaterfallContext}, and the
+ * `registerProvider` branch together once the Minimum floor moves to 0.1.2 or
+ * later, where the real types already describe the waterfall.
  * @module dshline/questions
  */
 
 import type { Context } from '@deepseek-ai/cordis'
 import type { AskUserQuestionAnswerItem, AskUserQuestionItem } from '@deepseek-ai/dsh-user-questions/types'
-// `AskUserQuestionRequest` carries an `Agent`, so it lives on the service entry
-// point rather than the wire-safe `/types` module; importing it also carries the
-// `ctx.userQuestions` Context merge.
+// `AskUserQuestionRequest`/`AskUserQuestionAnswer` carry an `Agent`, so they live
+// on the service entry point rather than the wire-safe `/types` module;
+// importing from here also carries the `ctx.userQuestions` Context merge. Both
+// types are unchanged in shape across 0.1.1 and 0.1.2, so they need no bridge.
 import { UserQuestionError } from '@deepseek-ai/dsh-user-questions'
-import type { AskUserQuestionRequest } from '@deepseek-ai/dsh-user-questions'
+import type { AskUserQuestionAnswer, AskUserQuestionRequest } from '@deepseek-ai/dsh-user-questions'
 import { createPlanReviewOverlay } from './plan-review.ts'
 import { promptSelect } from './select.ts'
+
+/** Harness ≤0.1.1's single-provider registration shape. */
+interface LegacyUserQuestionService {
+  registerProvider(provider: { ask(request: AskUserQuestionRequest): Promise<AskUserQuestionAnswer> }): () => void
+}
+
+/**
+ * Structural guard for the legacy shape, rather than a version-string check:
+ * Harness 0.1.2 removed `registerProvider` entirely, so its presence alone
+ * tells us which registration mode is mounted.
+ * @param service - `ctx.userQuestions`, of whichever version is installed.
+ * @returns the service narrowed to its legacy shape, or undefined.
+ */
+function asLegacyUserQuestionService(service: unknown): LegacyUserQuestionService | undefined {
+  return typeof service === 'object' && service !== null && typeof (service as LegacyUserQuestionService).registerProvider === 'function'
+    ? service as LegacyUserQuestionService
+    : undefined
+}
+
+/**
+ * The one Cordis waterfall event this file needs from Harness ≥0.1.2, declared
+ * locally rather than imported: the real `Events` merge for it lives only in
+ * 0.1.2's own package types, which are not what Minimum (0.1.1) resolves to at
+ * compile time. This is a compatibility bridge for exactly one event, not a
+ * copy of the upstream `Events` interface.
+ */
+interface WaterfallContext {
+  on(
+    event: 'user-questions/request',
+    listener: (request: AskUserQuestionRequest, next: () => Promise<AskUserQuestionAnswer>) => Promise<AskUserQuestionAnswer>,
+  ): () => void
+}
+
+/**
+ * Narrow, explicit cast to the waterfall bridge above — never a broad `any`.
+ * @param ctx - the plugin context, of whichever Harness version is installed.
+ * @returns the same context, typed for exactly the one event this file registers.
+ */
+function asWaterfallContext(ctx: Context): WaterfallContext {
+  return ctx as unknown as WaterfallContext
+}
 
 /** Offered when a question carries no options of its own. */
 const ACKNOWLEDGE = [{ value: 'ok', label: 'OK' }] as const
@@ -105,21 +164,37 @@ async function askOne(
 }
 
 /**
- * Register this frontend as the single user-questions provider.
+ * Answer one request: every question in order, honouring the signal.
+ * @param ctx - the plugin context owning the overlay.
+ * @param request - the pending question batch.
+ * @returns the structured answer.
+ */
+async function answerRequest(ctx: Context, request: AskUserQuestionRequest): Promise<AskUserQuestionAnswer> {
+  const answers: AskUserQuestionAnswerItem[] = []
+  // Questions are asked one at a time and in order: the overlay stack shows
+  // only its top, so rendering several at once would hide all but the last.
+  for (const item of request.questions) {
+    if (request.signal?.aborted === true) break
+    answers.push(await askOne(ctx, item, request.signal))
+  }
+  return { answers }
+}
+
+/**
+ * Register this frontend as a user-questions answerer, under whichever
+ * registration mode the mounted Harness version publishes — see the module
+ * comment for why this is feature-detected rather than version-checked.
  * @param ctx - the plugin context owning the registration.
- * @returns the disposer unregistering the provider.
+ * @returns the disposer unregistering the answerer.
  */
 export function installQuestionProvider(ctx: Context): () => void {
-  return ctx.userQuestions.registerProvider({
-    ask: async (request: AskUserQuestionRequest) => {
-      const answers: AskUserQuestionAnswerItem[] = []
-      // Questions are asked one at a time and in order: the overlay stack shows
-      // only its top, so rendering several at once would hide all but the last.
-      for (const item of request.questions) {
-        if (request.signal?.aborted === true) break
-        answers.push(await askOne(ctx, item, request.signal))
-      }
-      return { answers }
-    },
-  })
+  const legacy = asLegacyUserQuestionService(ctx.userQuestions)
+  if (legacy !== undefined) {
+    return legacy.registerProvider({ ask: request => answerRequest(ctx, request) })
+  }
+  // Untagged (unscoped) registration: dsh-scope admits an untagged listener
+  // for both an agent-scoped dispatch and an unscoped one, so this single
+  // registration answers every request this process's one attached session
+  // can raise without needing to track that session's own agent scope.
+  return asWaterfallContext(ctx).on('user-questions/request', request => answerRequest(ctx, request))
 }

--- a/packages/dshline/tests/capability/user-questions.probe.spec.ts
+++ b/packages/dshline/tests/capability/user-questions.probe.spec.ts
@@ -4,12 +4,14 @@
  * Exercises the exact seam `installQuestionProvider` consumes against the
  * real `@deepseek-ai/dsh-user-questions` service — not a dshline-shaped fake
  * — through a real `TuiSlots` overlay stack, so a real request reaches a real
- * terminal-provider boundary and a real structured answer comes back. This is
- * also the one probe whose two registration branches (Harness ≤0.1.1's
- * `registerProvider`, ≥0.1.2's `user-questions/request` waterfall) are both
- * exercised automatically: `installQuestionProvider` feature-detects at
- * runtime, so this same file proves whichever shape the linked/pinned
- * package actually publishes, without knowing which one that is.
+ * terminal-provider boundary and a real structured answer comes back.
+ * `installQuestionProvider` feature-detects its registration shape at
+ * runtime, so this one file automatically proves whichever the
+ * linked/pinned package actually publishes (Minimum's `registerProvider`, or
+ * Edge's `user-questions/request` waterfall) without knowing which one that
+ * is. Presentation behavior (plan-review, cancellation, …) is covered by the
+ * ordinary `tests/questions.spec.ts`; this file is only the capability
+ * contract.
  * @module
  */
 
@@ -18,11 +20,6 @@ import UserQuestionService from '@deepseek-ai/dsh-user-questions'
 import { describe, expect, it } from 'vitest'
 import { installQuestionProvider } from '../../src/questions.ts'
 import { TuiSlots } from '../../src/slots.ts'
-
-/** Let a registration/dispatch settle across whatever the mounted Harness version's own async boundaries are. */
-async function settled(): Promise<void> {
-  for (let turn = 0; turn < 8; turn += 1) await Promise.resolve()
-}
 
 describe('capability: userQuestions', () => {
   it('carries a real Harness question request to a real terminal answer', async () => {
@@ -34,38 +31,13 @@ describe('capability: userQuestions', () => {
       const answer = ctx.userQuestions.ask({
         questions: [{ id: 'confirm', question: 'Proceed?', options: [{ label: 'yes' }] }],
       })
-      await settled()
-      expect(ctx.tuiSlots.activeOverlay).toBeDefined()
+      // Dispatch is synchronous up to the overlay push on both registration
+      // shapes (cordis's own registerProvider and waterfall dispatch never
+      // insert a microtask before calling the first listener), so the
+      // overlay is already mounted here — no wait needed.
       ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
       await expect(answer).resolves.toEqual({ answers: [{ id: 'confirm', selected: ['yes'] }] })
       expect(ctx.tuiSlots.activeOverlay).toBeUndefined()
-    } finally {
-      dispose()
-      await ctx.fiber.dispose()
-    }
-  })
-
-  it('the dedicated plan-review overlay still renders through the real seam', async () => {
-    const ctx = new Context()
-    await ctx.plugin(TuiSlots)
-    await ctx.plugin(UserQuestionService)
-    const dispose = installQuestionProvider(ctx)
-    try {
-      const answer = ctx.userQuestions.ask({
-        questions: [{
-          id: 'plan-review',
-          header: 'Plan review',
-          question: 'Approve this plan and leave plan mode?',
-          detail: '# Clear outcome\n\n- read every line',
-          options: [{ label: 'Approve' }, { label: 'Keep planning' }],
-          intent: { kind: 'plan-review', approve: 'Approve' },
-        }],
-      })
-      await settled()
-      const shown = ctx.tuiSlots.activeOverlay?.render(80).join('\n') ?? ''
-      expect(shown).toContain('Clear outcome')
-      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
-      await expect(answer).resolves.toEqual({ answers: [{ id: 'plan-review', selected: ['Approve'] }] })
     } finally {
       dispose()
       await ctx.fiber.dispose()

--- a/packages/dshline/tests/capability/user-questions.probe.spec.ts
+++ b/packages/dshline/tests/capability/user-questions.probe.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Capability probe: `ctx.userQuestions`.
+ *
+ * Exercises the exact seam `installQuestionProvider` consumes against the
+ * real `@deepseek-ai/dsh-user-questions` service — not a dshline-shaped fake
+ * — through a real `TuiSlots` overlay stack, so a real request reaches a real
+ * terminal-provider boundary and a real structured answer comes back. This is
+ * also the one probe whose two registration branches (Harness ≤0.1.1's
+ * `registerProvider`, ≥0.1.2's `user-questions/request` waterfall) are both
+ * exercised automatically: `installQuestionProvider` feature-detects at
+ * runtime, so this same file proves whichever shape the linked/pinned
+ * package actually publishes, without knowing which one that is.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import UserQuestionService from '@deepseek-ai/dsh-user-questions'
+import { describe, expect, it } from 'vitest'
+import { installQuestionProvider } from '../../src/questions.ts'
+import { TuiSlots } from '../../src/slots.ts'
+
+/** Let a registration/dispatch settle across whatever the mounted Harness version's own async boundaries are. */
+async function settled(): Promise<void> {
+  for (let turn = 0; turn < 8; turn += 1) await Promise.resolve()
+}
+
+describe('capability: userQuestions', () => {
+  it('carries a real Harness question request to a real terminal answer', async () => {
+    const ctx = new Context()
+    await ctx.plugin(TuiSlots)
+    await ctx.plugin(UserQuestionService)
+    const dispose = installQuestionProvider(ctx)
+    try {
+      const answer = ctx.userQuestions.ask({
+        questions: [{ id: 'confirm', question: 'Proceed?', options: [{ label: 'yes' }] }],
+      })
+      await settled()
+      expect(ctx.tuiSlots.activeOverlay).toBeDefined()
+      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
+      await expect(answer).resolves.toEqual({ answers: [{ id: 'confirm', selected: ['yes'] }] })
+      expect(ctx.tuiSlots.activeOverlay).toBeUndefined()
+    } finally {
+      dispose()
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('the dedicated plan-review overlay still renders through the real seam', async () => {
+    const ctx = new Context()
+    await ctx.plugin(TuiSlots)
+    await ctx.plugin(UserQuestionService)
+    const dispose = installQuestionProvider(ctx)
+    try {
+      const answer = ctx.userQuestions.ask({
+        questions: [{
+          id: 'plan-review',
+          header: 'Plan review',
+          question: 'Approve this plan and leave plan mode?',
+          detail: '# Clear outcome\n\n- read every line',
+          options: [{ label: 'Approve' }, { label: 'Keep planning' }],
+          intent: { kind: 'plan-review', approve: 'Approve' },
+        }],
+      })
+      await settled()
+      const shown = ctx.tuiSlots.activeOverlay?.render(80).join('\n') ?? ''
+      expect(shown).toContain('Clear outcome')
+      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
+      await expect(answer).resolves.toEqual({ answers: [{ id: 'plan-review', selected: ['Approve'] }] })
+    } finally {
+      dispose()
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('disposes cleanly: no answerer remains registered afterward', async () => {
+    const ctx = new Context()
+    await ctx.plugin(TuiSlots)
+    await ctx.plugin(UserQuestionService)
+    const dispose = installQuestionProvider(ctx)
+    dispose()
+    dispose() // idempotent, matching Harness's own HMR-safe disposal contract
+    try {
+      await expect(ctx.userQuestions.ask({ questions: [{ id: 'confirm', question: 'Proceed?' }] }))
+        .rejects.toMatchObject({ code: 'NO_PROVIDER' })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+})

--- a/packages/dshline/tests/questions.spec.ts
+++ b/packages/dshline/tests/questions.spec.ts
@@ -1,6 +1,6 @@
 /** Plan-review questions take their dedicated overlay instead of a generic detail picker. */
 
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import type { Context } from '@deepseek-ai/cordis'
 import type { AskUserQuestionAnswer, AskUserQuestionRequest } from '@deepseek-ai/dsh-user-questions'
 import { stripAnsi } from '@dshline/renderer'
@@ -8,8 +8,7 @@ import type { TuiOverlay } from '../src/slots.ts'
 import { installQuestionProvider } from '../src/questions.ts'
 
 /**
- * A context just large enough to retain the questions provider and its overlay,
- * faking Harness ≤0.1.1's single-provider `registerProvider()` shape.
+ * A context just large enough to retain the questions provider and its overlay.
  * @returns the context plus readers for the provider and active overlay.
  */
 function questionContext(): {
@@ -35,49 +34,6 @@ function questionContext(): {
     },
   } as unknown as Context
   return { ctx, ask: () => provider?.ask, overlay: () => active }
-}
-
-/** A listener registered through `ctx.on('user-questions/request', …)`. */
-type WaterfallListener = (request: AskUserQuestionRequest, next: () => Promise<AskUserQuestionAnswer>) => Promise<AskUserQuestionAnswer>
-
-/**
- * A context faking Harness ≥0.1.2's waterfall shape: `ctx.userQuestions` has no
- * `registerProvider` at all, so {@link installQuestionProvider} must fall
- * through to `ctx.on('user-questions/request', …)`.
- * @returns the context plus readers for the registered listener and active overlay.
- */
-function waterfallQuestionContext(): {
-  ctx: Context
-  next: ReturnType<typeof vi.fn>
-  request(req: AskUserQuestionRequest): Promise<AskUserQuestionAnswer> | undefined
-  overlay(): TuiOverlay | undefined
-} {
-  let listener: WaterfallListener | undefined
-  let active: TuiOverlay | undefined
-  const next = vi.fn(() => Promise.reject(new Error('no further answerer: dshline must claim, never delegate')))
-  const ctx = {
-    // Deliberately no registerProvider: this is exactly the shape that made
-    // Harness 0.1.2 remove it.
-    userQuestions: {},
-    on(event: string, fn: WaterfallListener) {
-      if (event !== 'user-questions/request') throw new Error(`unexpected event ${event}`)
-      listener = fn
-      return () => { listener = undefined }
-    },
-    tuiSlots: {
-      invalidate: () => {},
-      pushOverlay(overlay: TuiOverlay) {
-        active = overlay
-        return () => { active = undefined }
-      },
-    },
-  } as unknown as Context
-  return {
-    ctx,
-    next,
-    request: req => listener?.(req, next),
-    overlay: () => active,
-  }
 }
 
 describe('plan-review questions', () => {
@@ -139,56 +95,5 @@ describe('plan-review questions', () => {
     abort.abort()
     await expect(answer).rejects.toMatchObject({ code: 'ASK_ABORTED' })
     expect(overlay()).toBeUndefined()
-  })
-})
-
-describe('waterfall registration (Harness 0.1.2+)', () => {
-  it('falls back to ctx.on when no legacy registerProvider is present', async () => {
-    const { ctx, request } = waterfallQuestionContext()
-    installQuestionProvider(ctx)
-    const answer = request({
-      questions: [{ id: 'confirm', question: 'Proceed?', options: [{ label: 'yes' }] }],
-    } as AskUserQuestionRequest)
-    expect(answer).toBeDefined()
-  })
-
-  it('always claims: next() is never called for a request dshline can present', async () => {
-    const { ctx, next, request, overlay } = waterfallQuestionContext()
-    installQuestionProvider(ctx)
-    const answer = request({
-      questions: [{ id: 'confirm', question: 'Proceed?', options: [{ label: 'yes' }] }],
-    } as AskUserQuestionRequest)
-    overlay()?.handleKey({ kind: 'key', name: 'enter' })
-    await expect(answer).resolves.toEqual({ answers: [{ id: 'confirm', selected: ['yes'] }] })
-    expect(next).not.toHaveBeenCalled()
-  })
-
-  it('still uses the dedicated plan-review overlay under waterfall registration', async () => {
-    const { ctx, request, overlay } = waterfallQuestionContext()
-    installQuestionProvider(ctx)
-    const answer = request({
-      questions: [{
-        id: 'plan-review',
-        header: 'Plan review',
-        question: 'Approve this plan and leave plan mode?',
-        detail: '# Clear outcome\n\n- read every line',
-        options: [{ label: 'Approve' }, { label: 'Keep planning' }],
-        intent: { kind: 'plan-review', approve: 'Approve' },
-      }],
-    } as AskUserQuestionRequest)
-    const shown = stripAnsi(overlay()?.render(80).join('\n') ?? '')
-    expect(shown).toContain('Plan review')
-    expect(shown).toContain('Clear outcome')
-
-    overlay()?.handleKey({ kind: 'key', name: 'enter' })
-    await expect(answer).resolves.toEqual({ answers: [{ id: 'plan-review', selected: ['Approve'] }] })
-  })
-
-  it('disposes cleanly: a disposed answerer is no longer registered', () => {
-    const { ctx, request } = waterfallQuestionContext()
-    const dispose = installQuestionProvider(ctx)
-    dispose()
-    dispose() // idempotent, matching Harness's own HMR-safe disposal contract
-    expect(request({ questions: [{ id: 'confirm', question: 'Proceed?' }] } as AskUserQuestionRequest)).toBeUndefined()
   })
 })

--- a/packages/dshline/tests/questions.spec.ts
+++ b/packages/dshline/tests/questions.spec.ts
@@ -1,6 +1,6 @@
 /** Plan-review questions take their dedicated overlay instead of a generic detail picker. */
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { Context } from '@deepseek-ai/cordis'
 import type { AskUserQuestionAnswer, AskUserQuestionRequest } from '@deepseek-ai/dsh-user-questions'
 import { stripAnsi } from '@dshline/renderer'
@@ -8,7 +8,8 @@ import type { TuiOverlay } from '../src/slots.ts'
 import { installQuestionProvider } from '../src/questions.ts'
 
 /**
- * A context just large enough to retain the questions provider and its overlay.
+ * A context just large enough to retain the questions provider and its overlay,
+ * faking Harness ≤0.1.1's single-provider `registerProvider()` shape.
  * @returns the context plus readers for the provider and active overlay.
  */
 function questionContext(): {
@@ -34,6 +35,49 @@ function questionContext(): {
     },
   } as unknown as Context
   return { ctx, ask: () => provider?.ask, overlay: () => active }
+}
+
+/** A listener registered through `ctx.on('user-questions/request', …)`. */
+type WaterfallListener = (request: AskUserQuestionRequest, next: () => Promise<AskUserQuestionAnswer>) => Promise<AskUserQuestionAnswer>
+
+/**
+ * A context faking Harness ≥0.1.2's waterfall shape: `ctx.userQuestions` has no
+ * `registerProvider` at all, so {@link installQuestionProvider} must fall
+ * through to `ctx.on('user-questions/request', …)`.
+ * @returns the context plus readers for the registered listener and active overlay.
+ */
+function waterfallQuestionContext(): {
+  ctx: Context
+  next: ReturnType<typeof vi.fn>
+  request(req: AskUserQuestionRequest): Promise<AskUserQuestionAnswer> | undefined
+  overlay(): TuiOverlay | undefined
+} {
+  let listener: WaterfallListener | undefined
+  let active: TuiOverlay | undefined
+  const next = vi.fn(() => Promise.reject(new Error('no further answerer: dshline must claim, never delegate')))
+  const ctx = {
+    // Deliberately no registerProvider: this is exactly the shape that made
+    // Harness 0.1.2 remove it.
+    userQuestions: {},
+    on(event: string, fn: WaterfallListener) {
+      if (event !== 'user-questions/request') throw new Error(`unexpected event ${event}`)
+      listener = fn
+      return () => { listener = undefined }
+    },
+    tuiSlots: {
+      invalidate: () => {},
+      pushOverlay(overlay: TuiOverlay) {
+        active = overlay
+        return () => { active = undefined }
+      },
+    },
+  } as unknown as Context
+  return {
+    ctx,
+    next,
+    request: req => listener?.(req, next),
+    overlay: () => active,
+  }
 }
 
 describe('plan-review questions', () => {
@@ -95,5 +139,56 @@ describe('plan-review questions', () => {
     abort.abort()
     await expect(answer).rejects.toMatchObject({ code: 'ASK_ABORTED' })
     expect(overlay()).toBeUndefined()
+  })
+})
+
+describe('waterfall registration (Harness 0.1.2+)', () => {
+  it('falls back to ctx.on when no legacy registerProvider is present', async () => {
+    const { ctx, request } = waterfallQuestionContext()
+    installQuestionProvider(ctx)
+    const answer = request({
+      questions: [{ id: 'confirm', question: 'Proceed?', options: [{ label: 'yes' }] }],
+    } as AskUserQuestionRequest)
+    expect(answer).toBeDefined()
+  })
+
+  it('always claims: next() is never called for a request dshline can present', async () => {
+    const { ctx, next, request, overlay } = waterfallQuestionContext()
+    installQuestionProvider(ctx)
+    const answer = request({
+      questions: [{ id: 'confirm', question: 'Proceed?', options: [{ label: 'yes' }] }],
+    } as AskUserQuestionRequest)
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'confirm', selected: ['yes'] }] })
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('still uses the dedicated plan-review overlay under waterfall registration', async () => {
+    const { ctx, request, overlay } = waterfallQuestionContext()
+    installQuestionProvider(ctx)
+    const answer = request({
+      questions: [{
+        id: 'plan-review',
+        header: 'Plan review',
+        question: 'Approve this plan and leave plan mode?',
+        detail: '# Clear outcome\n\n- read every line',
+        options: [{ label: 'Approve' }, { label: 'Keep planning' }],
+        intent: { kind: 'plan-review', approve: 'Approve' },
+      }],
+    } as AskUserQuestionRequest)
+    const shown = stripAnsi(overlay()?.render(80).join('\n') ?? '')
+    expect(shown).toContain('Plan review')
+    expect(shown).toContain('Clear outcome')
+
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'plan-review', selected: ['Approve'] }] })
+  })
+
+  it('disposes cleanly: a disposed answerer is no longer registered', () => {
+    const { ctx, request } = waterfallQuestionContext()
+    const dispose = installQuestionProvider(ctx)
+    dispose()
+    dispose() // idempotent, matching Harness's own HMR-safe disposal contract
+    expect(request({ questions: [{ id: 'confirm', question: 'Proceed?' }] } as AskUserQuestionRequest)).toBeUndefined()
   })
 })

--- a/tools/capability-probes.mjs
+++ b/tools/capability-probes.mjs
@@ -49,6 +49,10 @@ export const CAPABILITY_PROBES = [
     files: ['packages/dshline/tests/todos.spec.ts'],
     note: 'rides on the todos acceptance test',
   },
+  {
+    name: 'userQuestions',
+    files: ['packages/dshline/tests/capability/user-questions.probe.spec.ts'],
+  },
 ]
 
 /** Every test file any probe names, for the runner to pass to vitest in one pass. */


### PR DESCRIPTION
## Summary

Harness 0.1.2 removed `ctx.userQuestions.registerProvider()` (0.1.1's single-provider slot) for an Agent-scoped Cordis waterfall — `ctx.on('user-questions/request', (request, next) => …)` — so several answerers, including one relayed to a connected remote client, can compose. This is #114's compatibility radar finding its first real break: `Harness compatibility · Edge` reported `TS2339: Property 'registerProvider' does not exist on type 'UserQuestionService'` against `master` (same commit as the `dsh-v0.1.2-alpha.1` GitHub Release).

`registerQuestionAnswerer()` (in `packages/dshline/src/questions.ts`) feature-detects which shape `ctx.userQuestions` publishes at runtime and always claims a request it can present — not because no other answerer could exist, but because dshline's terminal is always available to answer whatever reaches it. **Clean dual compatibility with 0.1.1 was achievable, so the Minimum floor does not move.**

Net diff since `main`: **+158/-40 across 8 files** (revised down from an initial +330/-42 after review — see below).

## Keeping dshline thin

- One function, `registerQuestionAnswerer()`, holds the entire temporary version-shape distinction — not four separate named types/casts. Two inline anonymous cast types, one runtime check.
- `questions.spec.ts` is back to its pre-#115 content: it tests dshline-owned presentation (plan-review, cancellation, abort), not Harness registration mechanics. Registration mechanics are proven once, for real, by the capability probe — Minimum proves the legacy branch, Edge proves the waterfall branch, because `registerQuestionAnswerer` feature-detects rather than being told which branch to take.
- The capability probe itself is two tests: one real request→answer round trip, one disposal/lifecycle check. No plan-review-specific case (that's ordinary UI behavior, covered above) and no microtask-spinning wait — reading cordis's own `waterfall()`/`dispatch()` source confirmed dispatch is fully synchronous up to the first listener on both registration shapes, so the overlay is mounted immediately, same as the plain `questions.spec.ts` tests already assumed.
- `docs/architecture.md`/`.zh.md` carry one short paragraph naming the bridge and pointing at its module comment for the deletion condition, not a re-narration of the 0.1.1→0.1.2 migration.
- Explicit deletion policy, next to the bridge: delete `registerQuestionAnswerer`'s legacy branch (and its cast) once Minimum/Released no longer resolve to a line whose `ctx.userQuestions` still has `registerProvider`. This project's policy is current-installable + current-Edge, not indefinite historical support.

## Results (verified on real GitHub Actions, not just locally)

| Lane | Target | Result |
| --- | --- | --- |
| Minimum | 0.1.1-rc.2 | build/typecheck/full suite/capability probes pass (legacy branch) |
| Released | npm `next`, currently 0.1.1-rc.2 | same |
| Edge | `master` (= `dsh-v0.1.2-alpha.1` source) | build/typecheck clean (waterfall branch); full suite and all 5 capability probes pass |

Both the PR-triggered run and a full `workflow_dispatch` (all lanes, including Edge) are green. `pnpm run clean` runs before every post-link typecheck against `master` — the step whose absence caused a false pass reviewed in #114.

## 0.1.2 capability audit (observation only — nothing implemented here)

- **A. Automatically inherited from Harness**: `tool-subagent`'s richer child launch config (provider/model route, reasoning effort, output tokens, persona, tool filter, depth limits) is owned by Harness's model-facing tool and agent-preset composition already. dshline reproduces none of it and shouldn't.
- **B. Already-exposed facts, re-verified on master**: `/work`'s consumed contracts — `SubagentRunInfo`, `JobSnapshot`, and `SubagentListEntry` (lifecycle, local, label, mode, activity, `hasChildren`) — are byte-identical between `dsh-v0.1.1-rc.2` and current `master` (diffed directly), and the full suite passes against linked `master`, so no regression.
- **C. Newly exposed generic facts dshline should add**: none found that are both authoritative and cheaply/cleanly adjacent to this change.
- **D. Facts Harness still does not expose**: child `reasoningEffort`/model selection is settable via `AgentOptions` at subagent start but is still absent from `SubagentRunInfo`/`listChildren()` (confirmed against master's `control-types.ts`), so Work still cannot present it. No descriptor-parsing workaround added; waiting for an authoritative observation seam.

## Package metadata

Unchanged. `0.1.2-alpha.1` is a GitHub Release, not yet on npm's `next` dist-tag, so Minimum/Released stay on the installable `0.1.1-rc.2` line.

## Test plan

- [x] `pnpm run build` / `typecheck` / `test` (101 files, 2022 tests, 1 opt-in skipped) — pinned 0.1.1-rc.2
- [x] Same, linked to real Harness `master` with `pnpm run clean` before re-typechecking — both clean
- [x] `pnpm run verify-docs` / `pnpm run security` — clean
- [x] Real PR-triggered GitHub Actions (Core ×3, Docs, Minimum, Released) — green; Edge/sync correctly skipped
- [x] Real `workflow_dispatch` (all 8 jobs including Edge) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)