### PR TITLE
fix(dshline): drop reasoning effort a model switch's target does not support

### DIFF
--- a/.changeset/reasoning-effort-model-switch.md
+++ b/.changeset/reasoning-effort-model-switch.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': patch
+---
+
+`/model` now clears a carried reasoning effort when the target model does not advertise it, preventing model switches from failing with `UNSUPPORTED_REASONING_EFFORT`. `/reasoning default` can also clear a stale effort on models that advertise no reasoning levels.

--- a/packages/dshline/src/model.ts
+++ b/packages/dshline/src/model.ts
@@ -11,6 +11,7 @@
 
 import type { Context } from '@deepseek-ai/cordis'
 import type { ModelSelectionRef } from '@deepseek-ai/dsh-agent'
+import type { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
 import { promptSelect } from './select.ts'
 import type { SelectChoice } from './select.ts'
 import { rememberSelection } from './selection.ts'
@@ -159,8 +160,38 @@ export async function pickModel(
 }
 
 /**
+ * Whether the target route still accepts an effort the previous route had
+ * selected.
+ *
+ * Resolution failure answers "unknown", not "unsupported": the target's
+ * capability could not be proven either way, so the deliberate choice is kept
+ * rather than cleared on a guess. This is the same distinction the adapter's
+ * own `UNSUPPORTED_REASONING_EFFORT` rejection draws \u2014 an exact-model fact,
+ * not one this frontend approximates.
+ * @param ctx - context carrying the llm registry.
+ * @param chosen - the model being switched to.
+ * @param wanted - the effort the previous selection carried.
+ * @returns `wanted` when the target advertises it, or when capability
+ *   resolution fails and support is therefore unknown; undefined when exact
+ *   model resolution succeeds but the target does not advertise `wanted`,
+ *   including when it exposes no reasoning metadata at all.
+ */
+async function stillSupported(
+  ctx: Context,
+  chosen: ModelOption,
+  wanted: ReasoningEffortId,
+): Promise<ReasoningEffortId | undefined> {
+  try {
+    const info = await ctx.llm.resolveModelInfo(chosen.provider, chosen.model)
+    return info.reasoning?.efforts.some(effort => effort.id === wanted) === true ? wanted : undefined
+  } catch {
+    return wanted
+  }
+}
+
+/**
  * Point the selection at one model, and remember it.
- * @param ctx - context carrying the default-model service.
+ * @param ctx - context carrying the default-model service and the llm registry.
  * @param selection - the agent's mutable selection ref.
  * @param chosen - the model to select.
  * @param current - the selection being replaced, for what it carries forward.
@@ -172,17 +203,22 @@ async function apply(
   chosen: ModelOption,
   current: ModelSelectionRef['current'],
 ): Promise<string> {
-  // Preserve the reasoning effort: it belongs to the selection, and dropping it
-  // on a model switch would silently reset a deliberate choice.
+  // Preserve the reasoning effort across the switch, but only when the target
+  // route still advertises it \u2014 carrying forward one it does not would send
+  // the very next turn straight into UNSUPPORTED_REASONING_EFFORT.
+  const wanted = current?.reasoningEffort
+  const reasoningEffort = wanted === undefined ? undefined : await stillSupported(ctx, chosen, wanted)
   const next = {
     provider: chosen.provider,
     model: chosen.model,
-    ...current?.reasoningEffort === undefined ? {} : { reasoningEffort: current.reasoningEffort },
+    ...reasoningEffort === undefined ? {} : { reasoningEffort },
   }
   // The ref is written FIRST and unconditionally. The turn about to run reads it,
   // and a storage failure is no reason for that turn to use the old model.
   selection.current = next
+  const said = [`model set to ${chosen.provider} / ${chosen.model}`]
+  if (wanted !== undefined && reasoningEffort === undefined) said.push('reasoning reset to provider default')
   const note = await rememberSelection(ctx, next)
-  const said = `model set to ${chosen.provider} / ${chosen.model}`
-  return note === undefined ? said : `${said} \u00b7 ${note}`
+  if (note !== undefined) said.push(note)
+  return said.join(' \u00b7 ')
 }

--- a/packages/dshline/src/reasoning.ts
+++ b/packages/dshline/src/reasoning.ts
@@ -137,15 +137,18 @@ export async function pickReasoning(
 ): Promise<string | undefined> {
   if (selection.current === undefined) return 'no model is selected; choose one with /model first'
   const efforts = reasoning?.efforts ?? []
+  const wanted = argument.trim()
+  // `default` is not one of the adapter's levels — it deletes the stored
+  // effort — so it must work even when the route advertises none, including a
+  // route reached with a stale effort a previous model's switch left behind.
+  if (wanted.toLowerCase() === DEFAULT_CHOICE) return apply(ctx, selection, undefined)
   // An unresolved route and one that genuinely reasons at a fixed level look the
   // same from here, so the message names the route rather than claiming either.
   if (efforts.length === 0) {
     return `${selection.current.model} advertises no reasoning levels`
   }
 
-  const wanted = argument.trim()
   if (wanted !== '') {
-    if (wanted.toLowerCase() === DEFAULT_CHOICE) return apply(ctx, selection, undefined)
     const effort = resolveEffort(wanted, efforts)
     // Naming what IS accepted is the whole value of the message: a bare rejection
     // leaves the user typing guesses at a list only the adapter knows.

--- a/packages/dshline/tests/model.spec.ts
+++ b/packages/dshline/tests/model.spec.ts
@@ -3,6 +3,7 @@ import type { Context } from '@deepseek-ai/cordis'
 import { stripAnsi } from '@dshline/renderer'
 import type { TuiOverlay } from '../src/slots.ts'
 import type { ModelSelection, ModelSelectionRef } from '@deepseek-ai/dsh-agent'
+import type { LlmResolvedModelInfo } from '@deepseek-ai/dsh-llm'
 import type { ModelOption } from '../src/model.ts'
 import { listModelOptions, pickModel, resolveModel } from '../src/model.ts'
 
@@ -23,10 +24,16 @@ const OPTIONS: readonly ModelOption[] = [
 ]
 
 /**
+ * One target route's answer to `resolveModelInfo`: the reasoning efforts it
+ * advertises, or `'fail'` when resolution itself should reject.
+ */
+type ReasoningByRoute = Record<string, readonly string[] | 'fail'>
+
+/**
  * A context offering the llm registry and a slot registry that records pushes.
  * @returns the context, whether an overlay was pushed, and the one that was.
  */
-function llmContext(): {
+function llmContext(reasoning: ReasoningByRoute = {}): {
   ctx: Context
   pushed: () => boolean
   overlay: () => TuiOverlay | undefined
@@ -43,6 +50,13 @@ function llmContext(): {
     llm: {
       listProviders: () => Object.keys(CATALOG).map(id => ({ id, name: id })),
       listModels: async (provider: string) => CATALOG[provider] ?? [],
+      resolveModelInfo: async (provider: string, model: string): Promise<LlmResolvedModelInfo> => {
+        const entry = reasoning[`${provider}/${model}`]
+        if (entry === 'fail') throw new Error('model info unavailable')
+        const info = { provider, id: model, name: model }
+        if (entry === undefined) return info
+        return { ...info, reasoning: { efforts: entry.map(id => ({ id, name: id })) } }
+      },
     },
     tuiSlots: {
       pushOverlay: (overlay: TuiOverlay) => {
@@ -148,10 +162,11 @@ describe('pickModel() with an argument', () => {
     expect(pushed()).toBe(false)
   })
 
-  it('keeps the reasoning effort across the switch', async () => {
+  it('keeps the reasoning effort when the target still advertises it', async () => {
     // The effort belongs to the selection, and dropping it on a model switch
-    // would silently reset a deliberate choice.
-    const { ctx } = llmContext()
+    // would silently reset a deliberate choice — but only when the target can
+    // actually serve it.
+    const { ctx } = llmContext({ 'deepseek-official/deepseek-v4-pro': ['high', 'max'] })
     const selection = selectionOn('max')
     await pickModel(ctx, selection, 'deepseek-v4-pro')
     expect(selection.current?.reasoningEffort).toBe('max')
@@ -159,10 +174,16 @@ describe('pickModel() with an argument', () => {
 
   it('stores the switch as the default every surface reads', async () => {
     // What makes a model chosen here the one the web interface opens with.
-    const { ctx, saved } = llmContext()
+    const { ctx, saved } = llmContext({ 'deepseek-official/deepseek-v4-pro': ['high', 'max'] })
     const outcome = await pickModel(ctx, selectionOn('max'), 'deepseek-v4-pro')
     expect(saved).toEqual([{ provider: 'deepseek-official', model: 'deepseek-v4-pro', reasoningEffort: 'max' }])
     expect(outcome).toContain('also the default for new sessions')
+  })
+
+  it('does not touch reasoning when the current selection carries none', async () => {
+    const { ctx, saved } = llmContext()
+    await pickModel(ctx, selectionOn(), 'deepseek-v4-pro')
+    expect(saved).toEqual([{ provider: 'deepseek-official', model: 'deepseek-v4-pro' }])
   })
 
   it('stores nothing when the name matched nothing', async () => {
@@ -187,5 +208,42 @@ describe('pickModel() with an argument', () => {
     // happens only after discovery has awaited every route's catalog.
     void pickModel(ctx, selectionOn(), '')
     await vi.waitFor(() => { expect(pushed()).toBe(true) })
+  })
+})
+
+describe('reasoning effort across a model switch', () => {
+  it('clears an effort the target does not advertise', async () => {
+    // Carrying it forward would send the next turn straight into Harness's
+    // own UNSUPPORTED_REASONING_EFFORT rejection.
+    const { ctx, saved } = llmContext({ 'deepseek-official/deepseek-v4-pro': ['off', 'high'] })
+    const selection = selectionOn('max')
+    const outcome = await pickModel(ctx, selection, 'deepseek-v4-pro')
+    expect(selection.current?.reasoningEffort).toBeUndefined()
+    expect(saved).toEqual([{ provider: 'deepseek-official', model: 'deepseek-v4-pro' }])
+    expect(outcome).toContain('reasoning reset to provider default')
+  })
+
+  it('clears an effort when the target resolves with no reasoning field at all', async () => {
+    // A route exposing no selectable reasoning metadata resolves with
+    // `reasoning: undefined`, never an explicit empty `efforts` array — Harness
+    // rejects that shape as INVALID_MODEL_REASONING. This is also the shape the
+    // default `/connect` custom route resolves to when no reasoning efforts are
+    // configured.
+    const { ctx, saved } = llmContext()
+    const selection = selectionOn('high')
+    await pickModel(ctx, selection, 'deepseek-v4-pro')
+    expect(selection.current?.reasoningEffort).toBeUndefined()
+    expect(saved).toEqual([{ provider: 'deepseek-official', model: 'deepseek-v4-pro' }])
+  })
+
+  it('keeps the effort when the target route cannot be resolved', async () => {
+    // Resolution failure means unknown, not unsupported: the target's
+    // capability was never actually disproved, so the deliberate choice
+    // survives rather than being cleared on a guess.
+    const { ctx, saved } = llmContext({ 'deepseek-official/deepseek-v4-pro': 'fail' })
+    const selection = selectionOn('max')
+    await pickModel(ctx, selection, 'deepseek-v4-pro')
+    expect(selection.current?.reasoningEffort).toBe('max')
+    expect(saved).toEqual([{ provider: 'deepseek-official', model: 'deepseek-v4-pro', reasoningEffort: 'max' }])
   })
 })

--- a/packages/dshline/tests/reasoning.spec.ts
+++ b/packages/dshline/tests/reasoning.spec.ts
@@ -196,6 +196,32 @@ describe('pickReasoning()', () => {
     })
   })
 
+  it('says so on a bare /reasoning too, when the route advertises no levels', () => {
+    const selection = selectionOn()
+    return pickReasoning(ctx, selection, undefined, '').then(outcome => {
+      expect(outcome).toContain('deepseek-v4-flash')
+      expect(outcome).toContain('advertises no reasoning levels')
+    })
+  })
+
+  it('clears a stale effort via /reasoning default even when the route advertises no levels', () => {
+    // `default` deletes the stored effort; it is not one of the adapter's
+    // levels, so a route naming none — reached with an effort a previous
+    // model's switch left behind — must still be able to reach it.
+    const selection = selectionOn('high')
+    return pickReasoning(ctx, selection, undefined, 'default').then(outcome => {
+      expect(outcome).toContain('cleared')
+      expect(selection.current?.reasoningEffort).toBeUndefined()
+    })
+  })
+
+  it('saves the complete selection without reasoningEffort when defaulted on a levelless route', () => {
+    const named = slotContext()
+    return pickReasoning(named.ctx, selectionOn('high'), undefined, 'default').then(() => {
+      expect(named.saved).toEqual([{ provider: 'deepseek-official', model: 'deepseek-v4-flash' }])
+    })
+  })
+
   it('asks for a model first when none is selected', () => {
     const selection = { current: undefined, assembled: undefined } as ModelSelectionRef
     return pickReasoning(ctx, selection, REASONING, 'max').then(outcome => {


### PR DESCRIPTION
## Summary

- `/model` unconditionally carried the current `reasoningEffort` across a switch. Switching from a model with `high`/`max` to a route that names no reasoning levels at all (the default hand-declared `/connect` custom route shape, which does not declare reasoning efforts unless one is configured by hand — e.g. `qwen3.8:27b-mlx` via `openai-completions`) produced an invalid selection: `/model` reported success and `agentDefaultModel.saveSelection()` persisted the invalid pair as the default for new sessions, but the next turn was correctly rejected by Harness with `UNSUPPORTED_REASONING_EFFORT`.
- `/model` now resolves the target route's own reasoning metadata via `ctx.llm.resolveModelInfo()` — the same seam `window.ts` already calls for the status line — before committing the switch, and keeps the effort only when the target still advertises that exact id (matches Harness's own `reasoning.efforts.some(effort => effort.id === wanted)` check in `dsh-llm`). Resolution failure is treated as unknown, not unsupported, so the effort is kept rather than cleared on a guess.
- `/reasoning default` could not recover a stale effort on a route advertising zero reasoning levels — fixed by checking the `default` word before the zero-levels early return, since `default` deletes the stored effort rather than selecting one of the route's own levels.

No provider-specific code, no hardcoded reasoning table, no new capability seam, no direct settings mutation — persistence still goes through the unchanged `rememberSelection()` → `agentDefaultModel.saveSelection()` path.

Verified against the real installed `dsh-llm`/`dsh-llm-pi-ai` (`0.1.1-rc.2`, also this repo's pinned `HARNESS_MINIMUM_VERSION` floor) that a hand-declared model with no configured `reasoningEfforts` resolves with `reasoning: undefined` — never an explicit empty `efforts` array, which Harness itself rejects as `INVALID_MODEL_REASONING` — confirming the fix clears correctly in the exact reported case.

## Test plan

- [x] `pnpm --filter @dshline/dshline exec tsc -b --force` — clean
- [x] `pnpm --filter @dshline/dshline exec vitest run` — 1835 passed, 1 skipped
- [x] Updated `tests/model.spec.ts`: two existing model-switch tests now supply target reasoning data (previously asserted unconditional preservation); added cases for unsupported-effort clearing, no-reasoning-field clearing (using the real `reasoning: undefined` shape, not an invalid empty-`efforts` fixture), resolution-failure preservation, and no-current-effort no-op
- [x] Added `tests/reasoning.spec.ts` cases for `/reasoning default` on a route advertising zero levels
- [x] Manually traced the real Ollama repro end to end against installed Harness source (not simulated): `resolveModelInfo('ollama', 'qwen3.8:27b-mlx')` resolves with no `reasoning` key, so the fix clears the stale effort and the next turn no longer trips `UNSUPPORTED_REASONING_EFFORT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)