### PR TITLE
chore(release): gate latest on adopted Harness

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -6,3 +6,24 @@ opens the `Version Packages` pull request.
 
 Both published packages are in a fixed group, so each changeset versions
 `@dshline/dshline` and `@dshline/renderer` together.
+
+## Release readiness
+
+Changesets accumulate normally even while `main` tracks a Harness generation
+newer than the one npm serves by default, and the generated `Version Packages`
+pull request may sit release-not-ready for as long as that lasts. That is the
+design, not a problem to route around: `main` adopting a generation early is
+the point, and dshline never carries compatibility code for the previous one.
+
+Do not merge that pull request until its **Release readiness · Harness latest**
+check passes. It compares `HARNESS_TARGET.version` with
+`@deepseek-ai/dsh@latest` by exact equality, because the documented install
+resolves both packages through npm's default tag and publishing a mismatched
+pair would break it. The same check runs again before the release tag and
+before the first publish.
+
+If it is red, either wait for DeepSeek to promote the adopted generation, or
+migrate `HARNESS_TARGET` onto whichever generation it actually promoted — a
+default channel that has moved past the adopted target fails too. Never widen a
+peer range, point the check at another dist-tag, or move dshline off `latest`
+to get around it.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,14 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: node tools/check-release-tag.mjs
 
+      # Defense in depth for the release channel: `@deepseek-ai/dsh@latest` can
+      # move between the green Version Packages check, the tag, and this run,
+      # and a manually pushed or recovered tag skips both earlier gates. Placed
+      # before the first irreversible npm write, so a moved pointer costs a red
+      # release rather than a `latest` that resolves an unsupported pair.
+      - name: the default Harness install must be the adopted generation
+        run: node tools/check-release-harness.mjs
+
       # Exchange both package identities before either package is published. A
       # recursive publish authenticates one at a time, so discovering that only
       # the second package was configured after the renderer went out would leave

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,91 @@
+name: release-readiness
+
+# Whether a release may become the DEFAULT dshline install — a different
+# question from every lane in ci.yml, and kept in its own file so the two can
+# never be confused for one another.
+#
+#   ci.yml                does dshline work against HARNESS_TARGET?
+#                         → an exact commit and an exact version. No dist-tag,
+#                           ever. A pointer DeepSeek moves must not decide
+#                           whether unrelated work is mergeable.
+#
+#   this workflow         is it safe to make this source `@dshline/dshline@latest`?
+#                         → the one place a dist-tag legitimately decides
+#                           something, because `latest` is exactly what the
+#                           documented install resolves.
+#
+# The documented install is two unqualified names, so both sides resolve
+# through npm's default tag:
+#
+#   npm install -g @deepseek-ai/dsh @dshline/dshline
+#
+# `@deepseek-ai/dsh` pins the whole `dsh-*` line to its own generation, so
+# publishing dshline as `latest` while that launcher's `latest` is a different
+# generation would make one documented command install an unsupported pair.
+#
+# A red result here means DO NOT MERGE THIS RELEASE YET. It does not mean main
+# is broken: main is expected to run ahead of the default Harness release
+# between adopting a generation and DeepSeek promoting it, and waiting is the
+# whole design — dshline supports one generation and never carries
+# compatibility code for the previous one.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-readiness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  harness-latest:
+    # Identity, never the PR title. A title is attacker-supplied text on any
+    # fork PR, while pushing `changeset-release/main` to this repository
+    # requires write access — so the branch, the head repository, and the base
+    # are what decide, and every clause is an AND. An ordinary feature pull
+    # request must never reach this job: that would make a pointer DeepSeek
+    # moves a merge gate for unrelated work, which is the architecture the
+    # adopted-target policy exists to keep deleted.
+    if: >-
+      github.event.pull_request.base.ref == 'main'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.head.ref == 'changeset-release/main'
+    name: Release readiness · Harness latest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read HARNESS_TARGET; the registry read needs nothing
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # No pnpm, no install: the gate reads one repository file and asks npm
+      # one question, so a release decision never depends on a dependency tree
+      # this workflow would have to trust first.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: the default Harness install must be the adopted generation
+        run: node tools/check-release-harness.mjs
+
+      - name: what a red result means
+        if: failure()
+        run: |
+          {
+            echo '### Release readiness: not yet'
+            echo
+            echo 'This does **not** mean `main` is broken, and it is not a compatibility'
+            echo 'failure. It means merging THIS release pull request would publish'
+            echo '`@dshline/dshline@latest` against a Harness generation that is not what'
+            echo '`@deepseek-ai/dsh@latest` currently serves, so the documented install'
+            echo 'would resolve a pair dshline does not support.'
+            echo
+            echo 'Ordinary development continues against `HARNESS_TARGET`. Either wait for'
+            echo 'DeepSeek to promote the adopted generation, or migrate `HARNESS_TARGET`'
+            echo 'onto whichever generation it actually promoted — never widen a peer'
+            echo 'range, and never move dshline off `latest` to dodge this.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -216,6 +216,17 @@ jobs:
           RELEASE_TAG: v${{ steps.renderer-version.outputs.version }}
         run: node tools/check-release-tag.mjs
 
+      # The primary irreversible-boundary protection for the release CHANNEL,
+      # as distinct from the tree check above. A tag cannot be taken back, and
+      # publish.yml refusing later would leave one behind pointing at a release
+      # that must not become `latest`. Failing here leaves no tag, nothing
+      # published, and nothing to clean up: the maintainer retries once
+      # `@deepseek-ai/dsh@latest` is the adopted generation, or migrates
+      # HARNESS_TARGET onto whichever generation Harness promoted.
+      - name: the default Harness install must be the adopted generation
+        if: steps.tag-source.outputs.source != ''
+        run: node tools/check-release-harness.mjs
+
       - name: check for an existing release tag
         id: existing-tag
         if: steps.tag-source.outputs.source != ''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,10 +177,46 @@ with both values before it spends anything on a build.
   says so and validates nothing. GitHub source moves first and npm catches up
   later, and that lag is never a reason to support an older published line.
 
-Nothing in CI reads an npm dist-tag. `next`, `alpha`, and `rc` are upstream
-distribution channels that change without the architecture changing; the
-target is an exact commit and an exact version, and the published lane asks
-only whether that exact version exists on the registry yet.
+Development compatibility CI does not follow npm dist-tags. `next`, `alpha`,
+and `rc` are upstream distribution channels that change without the
+architecture changing; the target is an exact commit and an exact version, and
+the published lane asks only whether that exact version exists on the registry
+yet.
+
+### `HARNESS_TARGET` is development; a dist-tag is only the release channel
+
+Two authorities, and conflating them is how this policy gets undone:
+
+```text
+HARNESS_TARGET       controls development compatibility — always, everywhere
+@deepseek-ai/dsh@latest   controls only whether a release may become `latest`
+```
+
+`main` may adopt a Harness generation before DeepSeek promotes it to npm's
+default tag, and normally will. That gap creates no obligation to keep working
+against the older default. The documented install is two unqualified names, so
+both resolve through `latest` and `@deepseek-ai/dsh` pins the whole `dsh-*`
+line to its own generation; publishing dshline as `latest` against a different
+generation would break that one command. So publication waits — nothing in the
+source changes.
+
+`tools/check-release-harness.mjs` enforces it by exact string equality at three
+boundaries: the generated `Version Packages` pull request, before the immutable
+`v*` tag in `version.yml`, and before the first publish in `publish.yml`. A
+default channel that has moved PAST the adopted target fails too; "newer" is
+not "supported".
+
+A red release gate means **do not merge that release PR yet**. It never means
+`main` is broken, and it is never fixed in source. Specifically, do not:
+
+- widen a peer range, or add a second arm to one
+- restore support for the previous Harness generation, or feature-detect it
+- point the gate at `alpha`, `next`, or any tag other than `latest`
+- exclude Harness from the gate, or make the step advisory
+- publish dshline under a different dist-tag to dodge it
+
+The only two legitimate responses are to wait for the promotion, or to migrate
+`HARNESS_TARGET` onto the generation Harness actually promoted.
 
 Each Harness lane runs `node tools/capability-report.mjs`, which reports the
 Harness capability seams dshline consumes (`sessionQuery`, `jobs`,
@@ -200,6 +236,9 @@ a write token or a secret.
 5. Set the `dsh-*` peer versions to the same exact version in the same commit.
 6. `Harness target` goes green; `Harness published` follows once npm publishes
    that generation.
+7. Releases wait, source does not: the generated `Version Packages` PR stays
+   release-not-ready until `@deepseek-ai/dsh@latest` is that same generation.
+   Ordinary PRs are unaffected and keep merging throughout.
 
 ## Style
 

--- a/docs/architecture.i18n.yaml
+++ b/docs/architecture.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/architecture.md
-architecture.md: 90d01ef3cb6ed706e4502f074c94e4ae45190d3c
-architecture.zh.md: 0acdf14a71b84fa1c9ba0a6a91932300fa1941cc
+architecture.md: b99852b20accbe7fb8b4671d35cc587372f0f39d
+architecture.zh.md: febc56d57cabecdf9c829d80c1c37cb13810fc08

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -755,15 +755,72 @@ be worth nothing. **Harness published** answers the question source cannot: can
 a normal user install this and does it boot, against the real published
 launcher pinned to the adopted version.
 
-Nothing in CI reads an npm dist-tag. `next`, `alpha`, and `rc` are upstream
-distribution channels, not dshline architectural concepts: they change without
-the architecture changing, and CI keyed on a channel name would need
-redesigning every time one moved. The target is an exact commit and an exact
-version, and the published lane asks only whether that exact version exists on
-the registry yet. GitHub source moves first and npm catches up afterwards; when
-it has not caught up, that lane says so and validates nothing. "Not published
-yet" is a release-readiness fact, and it is never a reason to write
-compatibility code for an older published generation.
+Development compatibility CI does not follow npm dist-tags. `next`, `alpha`,
+and `rc` are upstream distribution channels, not dshline architectural
+concepts: they change without the architecture changing, and a compatibility
+lane keyed on a channel name would need redesigning every time one moved. The
+target is an exact commit and an exact version, and the published lane asks
+only whether that exact version exists on the registry yet. GitHub source moves
+first and npm catches up afterwards; when it has not caught up, that lane says
+so and validates nothing. "Not published yet" is a release-readiness fact, and
+it is never a reason to write compatibility code for an older published
+generation.
+
+### The release channel is a separate question
+
+That release-readiness fact does eventually decide something, and exactly one
+thing: whether a dshline release may become the DEFAULT install. The two
+concerns are easy to conflate and must not be, because they have opposite
+answers to the same event.
+
+The documented installation is two unqualified names, so both sides resolve
+through npm's default tag:
+
+```sh
+npm install -g @deepseek-ai/dsh @dshline/dshline
+```
+
+`@deepseek-ai/dsh` pins the whole `dsh-*` line to its own generation, so
+whichever version that tag serves IS the Harness generation an ordinary install
+ends up running. The invariant is therefore about channels, not about code:
+
+> `@dshline/dshline@latest` must never advance to a build whose adopted Harness
+> generation differs from what `@deepseek-ai/dsh@latest` serves.
+
+`main` may adopt a Harness release generation before DeepSeek promotes that
+generation to npm's default tag, and routinely will — tracking aggressively is
+the point. That gap does **not** create an obligation to keep working against
+the older default: nothing is widened, no peer range grows a second arm, and no
+runtime feature test appears. Publication waits instead. Changesets accumulate
+normally, the generated `Version Packages` pull request may sit release-not-
+ready for as long as it takes, and ordinary development against the adopted
+generation is unaffected throughout.
+
+`tools/check-release-harness.mjs` is that gate, and it compares
+`HARNESS_TARGET.version` with `@deepseek-ai/dsh@latest` by exact string
+equality. Exactness matters in both directions: dshline supports one
+generation, so a default channel that has moved PAST the adopted target fails
+too — "newer" is not "supported", and the response there is to migrate
+`HARNESS_TARGET` onto whichever generation Harness actually promoted, never to
+assume forward compatibility. A registry that cannot be reached fails closed
+as well, reported as an unanswered question rather than as a mismatch.
+
+It runs at the three boundaries where the answer could still change something:
+on the generated `Version Packages` pull request, so release readiness is
+visible before a human merges it; in `.github/workflows/version.yml` before the
+immutable `v*` tag is created, which is the primary irreversible boundary —
+failing there leaves no tag, nothing published, and nothing to clean up; and in
+`.github/workflows/publish.yml` before the first package is published, because
+the tag can move green to red in between. It is identified by branch and
+repository rather than by pull-request title, and holds no write permission and
+no secret: it reads one repository file and asks npm one question.
+
+This is a release gate, not a compatibility lane, and none of it changes the
+sentence above — a pull request that is not the generated release PR never
+resolves a dist-tag, so a pointer DeepSeek moves can still never make unrelated
+work unmergeable. Once the two defaults agree, an ordinary unqualified install
+resolves a coherent pair again, which is the only thing the gate was ever
+protecting.
 
 Each Harness lane additionally runs `tools/capability-report.mjs`, which turns a
 seam's real Harness contract — a real `SessionQueryEngine`, a real

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -352,7 +352,29 @@ dshline 对 Harness 的策略是激进跟踪、窄口支持：它一次只针对
 
 覆盖被拆为四个彼此独立的问题，全部位于 `.github/workflows/ci.yml`。**Core** 是 dshline 自身在每个受支持 Node 上的正确性，针对已采纳那一代的已发布包。**Harness target** 按那个确切提交从源码检出已采纳的上游修订版，构建它，并用 `tools/link-harness.mjs` 链接——方式与为手动开发链接本地检出完全相同——只做类型检查加能力探针，而不是把整套测试再跑一遍。它是阻塞的，也是确定性的：一个完整的 commit sha 不会在本仓库同一提交的两次运行之间发生变化。**Harness upstream** 对 `deepseek-ai/deepseek-harness@master` 做同样的事，记录被测试的确切 SHA，并给出与已采纳目标的比较链接。它仅供参考，且从不在 pull request 或对 `main` 的 push 上运行——一个由 DeepSeek 控制的分支不应让无关工作无法合并——但在真实不兼容时它仍会以非零状态退出，因为一条永远报告绿色的车道毫无价值。**Harness published** 回答源码无法回答的问题：普通用户能否安装它、它能否启动，针对固定在已采纳版本上的真实已发布启动器。
 
-CI 中没有任何地方读取 npm dist-tag。`next`、`alpha`、`rc` 是上游的分发渠道，而不是 dshline 的架构概念：它们会在架构不变的情况下变化，而以渠道名为键的 CI 每次渠道变动都需要重新设计。目标是一个确切提交与一个确切版本，已发布车道只询问该确切版本是否已经存在于注册表上。GitHub 源码先行移动，npm 随后跟上；当它尚未跟上时，该车道会如实说明并且不验证任何东西。"尚未发布"是一个发布就绪性的事实，它绝不构成为更旧的已发布代编写兼容代码的理由。
+开发兼容性 CI 不跟随 npm dist-tag。`next`、`alpha`、`rc` 是上游的分发渠道，而不是 dshline 的架构概念：它们会在架构不变的情况下变化，而以渠道名为键的兼容性车道每次渠道变动都需要重新设计。目标是一个确切提交与一个确切版本，已发布车道只询问该确切版本是否已经存在于注册表上。GitHub 源码先行移动，npm 随后跟上；当它尚未跟上时，该车道会如实说明并且不验证任何东西。"尚未发布"是一个发布就绪性的事实，它绝不构成为更旧的已发布代编写兼容代码的理由。
+
+### 发布渠道是另一个问题
+
+那个"发布就绪性"的事实最终确实会决定一件事，而且只有一件：某个 dshline 发布是否可以成为**默认**安装。这两种关切很容易混为一谈，而绝不能混为一谈，因为面对同一个事件它们给出相反的答案。
+
+文档记载的安装方式是两个不带限定的包名，因此两侧都通过 npm 的默认 tag 解析：
+
+```sh
+npm install -g @deepseek-ai/dsh @dshline/dshline
+```
+
+`@deepseek-ai/dsh` 把整条 `dsh-*` 线固定到它自己那一代，因此该 tag 提供的版本**就是**一次普通安装最终运行的 Harness 代。所以这条不变量关乎渠道，而不关乎代码：
+
+> `@dshline/dshline@latest` 绝不能推进到某个构建，其已采纳的 Harness 代与 `@deepseek-ai/dsh@latest` 所提供的不同。
+
+`main` 可以在 DeepSeek 把某一代提升到 npm 默认 tag 之前就采纳它，而且这会经常发生——激进跟踪正是要点所在。这个时间差**并不**产生继续兼容更旧默认代的义务：不放宽任何东西，peer 范围不长出第二条分支，也不出现运行时特性检测。取而代之的是发布等待。changeset 照常累积，生成的 `Version Packages` pull request 可以在"尚未就绪发布"的状态下停留任意久，而针对已采纳那一代的日常开发全程不受影响。
+
+`tools/check-release-harness.mjs` 就是这道闸门，它以确切字符串相等比较 `HARNESS_TARGET.version` 与 `@deepseek-ai/dsh@latest`。两个方向上的确切性都重要：dshline 只支持一代，因此默认渠道**越过**已采纳目标同样会失败——"更新"不等于"受支持"，此时的应对是把 `HARNESS_TARGET` 迁移到 Harness 实际提升的那一代，而绝不是假定向前兼容。注册表无法访问时同样按失败关闭，并报告为"无法确立"而不是"不匹配"。
+
+它在三个答案仍可能改变结果的边界上运行：在生成的 `Version Packages` pull request 上，使发布就绪性在人类合并之前可见；在 `.github/workflows/version.yml` 中于创建不可变的 `v*` tag 之前——这是首要的不可逆边界，在那里失败会留下没有 tag、没有发布、也无需清理的状态；以及在 `.github/workflows/publish.yml` 中于发布第一个包之前，因为在这期间 tag 可能由绿转红。它通过分支与仓库身份识别，而不是通过 pull request 标题；它不持有任何写权限、也不持有任何 secret：它只读取仓库中的一个文件，并向 npm 提出一个问题。
+
+这是一道发布闸门，不是兼容性车道，并且它丝毫不改变上面那句话——不是生成的发布 PR 的 pull request 永远不会解析 dist-tag，因此由 DeepSeek 移动的指针仍然永远无法让无关工作无法合并。一旦两个默认值一致，普通的不带限定安装就重新解析出一致的一对，而这正是这道闸门始终在保护的唯一东西。
 
 每条 Harness 车道都会额外运行 `tools/capability-report.mjs`，它把一个 seam 的真实 Harness 约定——真实的 `SessionQueryEngine`、真实的 `SubagentRuntime`、真实的抽象 `JobRegistry` 子类、真实的 `UserQuestionService`、在真实 `Session` 之上的真实抽象 `WorkflowEngine` 子类，绝不是 dshline 臆造的假对象——转化为按能力命名的通过/失败结果。目前的覆盖是初始的，而非穷尽的：`sessionQuery`、`jobs`、`subagents`、`sessionProjections`、`workflows`、`userQuestions`、`tokenMeter`（真实 `SessionStore` 之上的真实 `TokenMeter`）、`compaction`（真实的 `CompactionEngine` 子类）与 `skills`（真实的按作用域分层的 `SkillRegistry`，以及把打出的 `/name` 一行变成注入的真实 `dsh-tool-skill` pre-step 边界），之所以选择它们，是因为每一个都已经有（或能够低成本获得）一个针对真实类而非手工伪造对象构建的测试。上游对其中一个的变更读起来是 `sessionQuery contract changed`，而不只是笼统的 `pnpm typecheck failed`；尚未进入这张表的 seam，仍以 `pnpm typecheck`/`pnpm test` 作为后备。`tools/capability-probes.mjs` 是一张指针表，不是约定的第二份拷贝：它只指出哪个既有或新建的测试已经在验证每个 seam，因此扩大这一覆盖意味着往那张表里加一行（或在 `packages/dshline/tests/capability/` 下新增一个小探针），而绝不是让这个模块自己学会该 seam 的形状。
 

--- a/tools/check-release-harness.mjs
+++ b/tools/check-release-harness.mjs
@@ -1,0 +1,174 @@
+/**
+ * Refuse to make a dshline release the default install while the default
+ * Harness install is a different generation.
+ *
+ * This is a RELEASE-channel check, not a compatibility one, and the difference
+ * is the whole point. Development correctness is settled by `HARNESS_TARGET`:
+ * an exact upstream commit and the exact version cut from it, which every
+ * `dsh-*` spec carries literally and which `.github/workflows/ci.yml` proves
+ * from source. None of that reads a dist-tag, and none of it should — a
+ * channel pointer moves without the architecture moving.
+ *
+ * A release is the one moment where a pointer someone else owns does decide
+ * something. The documented install is two unqualified names:
+ *
+ * ```sh
+ * npm install -g @deepseek-ai/dsh @dshline/dshline
+ * ```
+ *
+ * Both resolve through npm's default `latest`, and `@deepseek-ai/dsh` pins the
+ * whole `dsh-*` line to its own generation, so whatever version `latest`
+ * serves IS the Harness generation an ordinary install ends up running. If
+ * `@dshline/dshline@latest` advanced to a build adopting a different
+ * generation, that one command would resolve a pair dshline does not support —
+ * not because dshline regressed, but because the two defaults disagree.
+ *
+ * The answer is to wait, never to widen. dshline supports one generation, so
+ * the comparison is exact string equality in both directions: a Harness
+ * `latest` NEWER than the adopted target fails too, because "newer" is not
+ * "supported" and the fix there is to migrate `HARNESS_TARGET` forward onto
+ * the generation Harness actually promoted.
+ *
+ * `main` is free to run ahead of this the entire time. A red result means "do
+ * not merge this release yet", never "main is broken".
+ *
+ * Exit codes are distinct on purpose, because the two failures need different
+ * responses: `1` is a real mismatch that a human resolves by waiting or
+ * migrating, `2` is an inability to establish the fact at all. Both fail
+ * closed — a release must never proceed on an unanswered question — but only
+ * one of them means anything is actually wrong with the release.
+ *
+ * ```text
+ * 0  adopted == @deepseek-ai/dsh@latest
+ * 1  they differ, in either direction
+ * 2  npm could not be asked, or answered something that is not a version
+ * ```
+ * @module tools/check-release-harness
+ */
+
+import { execFileSync } from 'node:child_process'
+
+import { LAUNCHER_PACKAGE, readTarget } from './harness-target.mjs'
+
+/**
+ * A version string npm can actually serve.
+ *
+ * Anchored and newline-free, so a multi-line or decorated answer is treated as
+ * "could not establish" rather than silently compared. `npm view <pkg>@latest
+ * version` prints one bare line for a tag that resolves to a single version;
+ * anything else means the question was not answered the way this expects, and
+ * guessing at that is how a release gate becomes a coin flip.
+ */
+const VERSION_SHAPE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u
+
+/**
+ * Ask npm what its default dist-tag serves for the launcher.
+ *
+ * `npm view` rather than a hand-rolled packument fetch: resolving a dist-tag is
+ * npm's own job, it already honours whatever registry and auth the environment
+ * configures, and reimplementing it here would mean owning a second answer to
+ * a question npm is authoritative for. One call, no retry — a release gate
+ * that hammered the registry to turn a network failure into a pass would be
+ * the opposite of failing closed.
+ * @returns the raw stdout of the lookup.
+ * @throws when npm exits non-zero, including an unreachable registry.
+ */
+function npmLatestVersion() {
+  return execFileSync('npm', ['view', `${LAUNCHER_PACKAGE}@latest`, 'version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+}
+
+/**
+ * What happened when the release question was asked.
+ * @typedef {{ kind: 'ready', adopted: string, latest: string }
+ *   | { kind: 'mismatch', adopted: string, latest: string }
+ *   | { kind: 'unverifiable', adopted: string, reason: string }} ReleaseReadiness
+ */
+
+/**
+ * Whether publishing this tree as the default dshline release would leave the
+ * documented unqualified install resolving a coherent pair.
+ *
+ * Deliberately NOT a semver comparison. There is no "at least" here: dshline
+ * carries no compatibility code for a neighbouring generation, so the only
+ * relation that means anything is identity.
+ * @param adopted - `HARNESS_TARGET.version`, the generation this tree is built against.
+ * @param options - injectable registry lookup, for tests.
+ * @param options.readLatest - returns npm's answer for the launcher's default tag.
+ * @returns the readiness verdict.
+ */
+export function releaseReadiness(adopted, { readLatest = npmLatestVersion } = {}) {
+  let answer
+  try {
+    answer = readLatest()
+  } catch (error) {
+    return { kind: 'unverifiable', adopted, reason: error instanceof Error ? error.message : String(error) }
+  }
+  const latest = typeof answer === 'string' ? answer.trim() : ''
+  if (!VERSION_SHAPE.test(latest)) {
+    return {
+      kind: 'unverifiable',
+      adopted,
+      reason: `npm answered ${JSON.stringify(latest)}, which is not a single version`,
+    }
+  }
+  return { kind: latest === adopted ? 'ready' : 'mismatch', adopted, latest }
+}
+
+/**
+ * The verdict as a maintainer needs to read it, and the exit code it earns.
+ *
+ * Both failures say plainly that this is about the release channel, because
+ * the natural misreading — "dshline is broken against Harness" — would send
+ * someone to write exactly the compatibility code this policy exists to
+ * refuse.
+ * @param result - the readiness verdict.
+ * @returns the report text and the process exit code.
+ */
+export function formatReadiness(result) {
+  if (result.kind === 'ready') {
+    return {
+      code: 0,
+      text: `check-release-harness: ${LAUNCHER_PACKAGE}@latest is ${result.latest}, matching the adopted Harness target.\n`
+        + 'An unqualified install of both packages resolves one coherent generation.\n',
+    }
+  }
+  if (result.kind === 'unverifiable') {
+    return {
+      code: 2,
+      text: `Could not verify ${LAUNCHER_PACKAGE}@latest from npm.\n`
+        + 'Release readiness cannot be established, so this is not a mismatch — it is an\n'
+        + 'unanswered question, and a release does not proceed on one. Retry when the\n'
+        + `registry is reachable.\n\n  reason: ${result.reason}\n`,
+    }
+  }
+  const labels = ['adopted Harness (HARNESS_TARGET):', `${LAUNCHER_PACKAGE}@latest:`]
+  const column = Math.max(...labels.map(label => label.length))
+  return {
+    code: 1,
+    text: 'dshline release is not ready.\n\n'
+      + `  ${labels[0].padEnd(column)}  ${result.adopted}\n`
+      + `  ${labels[1].padEnd(column)}  ${result.latest}\n\n`
+      + 'This is a RELEASE-channel failure, not a source-compatibility one. Development\n'
+      + 'against the adopted generation is unaffected and main is not broken: the whole\n'
+      + 'point of adopting a generation early is that main may run ahead of the default\n'
+      + 'Harness release.\n\n'
+      + 'What it does mean is that publishing this as the default dshline release would\n'
+      + 'make `npm install -g @deepseek-ai/dsh @dshline/dshline` resolve two packages\n'
+      + 'built for different Harness generations.\n\n'
+      + 'Resolve it one of two ways, and never by widening what dshline supports:\n'
+      + `  - wait until ${LAUNCHER_PACKAGE}@latest is the adopted generation; or\n`
+      + '  - migrate HARNESS_TARGET onto the generation Harness actually promoted.\n\n'
+      + 'Do not widen a peer range, restore support for the previous generation, point\n'
+      + 'this check at another dist-tag, or move dshline off `latest` to dodge it.\n',
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  const target = await readTarget()
+  const { code, text } = formatReadiness(releaseReadiness(target.version))
+  process[code === 0 ? 'stdout' : 'stderr'].write(text)
+  process.exit(code)
+}

--- a/tools/check-release-harness.spec.mjs
+++ b/tools/check-release-harness.spec.mjs
@@ -1,0 +1,297 @@
+/**
+ * The release-channel gate: its verdicts, and the three boundaries it holds.
+ *
+ * Two separate things are checked here, and they fail for different reasons.
+ * The first half is the decision itself — exact equality, in both directions,
+ * with a lookup failure kept distinct from a mismatch — driven through an
+ * injected registry reader so nothing in this file touches npm.
+ *
+ * The second half is placement, which is the part that actually makes the
+ * policy true. A correct script wired into the wrong step is worth nothing: a
+ * gate after the tag is pushed cannot prevent an immutable tag, a gate after
+ * the first publish cannot prevent an irreversible version, and a gate that
+ * ordinary pull requests run would put every feature branch at the mercy of a
+ * pointer DeepSeek moves — the exact architecture #133 removed.
+ */
+
+import { readFile } from 'node:fs/promises'
+
+import { describe, expect, it } from 'vitest'
+
+import { formatReadiness, releaseReadiness } from './check-release-harness.mjs'
+
+/** The one script all three boundaries must invoke. */
+const GUARD = 'node tools/check-release-harness.mjs'
+
+/**
+ * Read one workflow file from the repository rather than a fixture.
+ * @param name - the workflow's file name under `.github/workflows`.
+ * @returns the workflow file text.
+ */
+async function readWorkflow(name) {
+  return readFile(new URL(`../.github/workflows/${name}`, import.meta.url), 'utf8')
+}
+
+/**
+ * Extract one top-level job's YAML block by name, with `#`-comment lines
+ * stripped so prose mentioning a step does not read as the workflow running it.
+ * Mirrors `tools/ci-workflow.spec.mjs`, which owns the same trick for ci.yml.
+ * @param workflow - the full workflow file text.
+ * @param jobName - the job key under `jobs:`.
+ * @returns the block's code, comments removed.
+ */
+function extractJob(workflow, jobName) {
+  const match = workflow.match(new RegExp(`\\n  ${jobName}:\\n([\\s\\S]*?)(?=\\n  \\S|$)`))
+  if (match === null) throw new Error(`job not found in workflow: ${jobName}`)
+  return match[1].split('\n').filter(line => !line.trim().startsWith('#')).join('\n')
+}
+
+/**
+ * One job's `if:` expression, folded block scalars included.
+ *
+ * A three-clause condition reads far better as YAML's `>-` than as one long
+ * line, so the assertions must see what the folded form actually means rather
+ * than the two characters that introduce it.
+ * @param job - one job's comment-stripped block.
+ * @returns the condition as a single expression, or undefined when absent.
+ */
+function jobCondition(job) {
+  const inline = job.match(/^ {4}if:[ \t]*(\S.*)$/mu)
+  if (inline === null) return undefined
+  const head = inline[1].trim()
+  if (!/^[>|][-+]?$/u.test(head)) return head
+  const rest = job.slice(job.indexOf(inline[0]) + inline[0].length + 1)
+  const folded = []
+  for (const line of rest.split('\n')) {
+    if (!/^ {6}\S/u.test(line)) break
+    folded.push(line.trim())
+  }
+  return folded.join(' ')
+}
+
+/**
+ * One job's steps, whole, in declaration order.
+ *
+ * Ordering is the entire assertion for two of the three boundaries, so it is
+ * read positionally rather than by searching the file for two substrings and
+ * hoping the earlier one came first. Split on the `- ` step marker rather than
+ * matched with one expression per step: a step body is multi-line shell, and a
+ * pattern that ended at a line boundary would silently compare only each
+ * step's first line — which looks like it works right up until the text being
+ * searched for is on the second.
+ * @param job - one job's comment-stripped block.
+ * @returns each step's full text, in order.
+ */
+function jobSteps(job) {
+  const steps = []
+  for (const line of job.split('\n')) {
+    if (/^ {6}- /u.test(line)) steps.push([line])
+    else if (steps.length > 0) steps.at(-1).push(line)
+  }
+  return steps.map(lines => lines.join('\n'))
+}
+
+/**
+ * Index of the first step containing `needle`.
+ * @param job - one job's comment-stripped block.
+ * @param needle - text to find in a step.
+ * @returns the step index, or -1.
+ */
+function stepIndex(job, needle) {
+  return jobSteps(job).findIndex(step => step.includes(needle))
+}
+
+describe('the release verdict is exact equality, in both directions', () => {
+  it('is ready when the adopted generation is what an unqualified install resolves', () => {
+    const result = releaseReadiness('1.2.3', { readLatest: () => '1.2.3\n' })
+    expect(result).toEqual({ kind: 'ready', adopted: '1.2.3', latest: '1.2.3' })
+    expect(formatReadiness(result).code).toBe(0)
+  })
+
+  it('fails, naming both values, when the adopted target is ahead of the default channel', () => {
+    const result = releaseReadiness('2.0.0-beta.1', { readLatest: () => '1.9.0\n' })
+    expect(result).toMatchObject({ kind: 'mismatch', adopted: '2.0.0-beta.1', latest: '1.9.0' })
+    const { code, text } = formatReadiness(result)
+    expect(code).toBe(1)
+    expect(text).toContain('2.0.0-beta.1')
+    expect(text).toContain('1.9.0')
+  })
+
+  it('fails just as hard when the registry is AHEAD of the adopted target', () => {
+    // The one that a semver comparison would wave through. dshline carries no
+    // compatibility code for a neighbouring generation, so a newer Harness
+    // `latest` is not a satisfied floor — it is a generation this tree was
+    // never built against, and the fix is to migrate HARNESS_TARGET forward.
+    const result = releaseReadiness('2.0.0-alpha.4', { readLatest: () => '2.0.0-alpha.5\n' })
+    expect(result).toMatchObject({ kind: 'mismatch', latest: '2.0.0-alpha.5' })
+    expect(formatReadiness(result).code).toBe(1)
+  })
+
+  it('never compares by precedence: a prerelease of the same tuple is still a mismatch', () => {
+    expect(releaseReadiness('1.0.0', { readLatest: () => '1.0.0-rc.1\n' }).kind).toBe('mismatch')
+    expect(releaseReadiness('1.0.0-rc.1', { readLatest: () => '1.0.0\n' }).kind).toBe('mismatch')
+  })
+
+  it('says plainly that a mismatch is about the release channel, not compatibility', () => {
+    const { text } = formatReadiness(releaseReadiness('2.0.0', { readLatest: () => '1.0.0\n' }))
+    expect(text).toContain('RELEASE-channel failure')
+    expect(text).toContain('main is not broken')
+    // The two legitimate resolutions, and none of the illegitimate ones.
+    expect(text).toContain('migrate HARNESS_TARGET')
+    expect(text).toMatch(/Do not widen a peer range/)
+  })
+})
+
+describe('the scenario this gate was built for', () => {
+  it('refuses a release adopting a generation the default channel has not promoted', () => {
+    // The concrete case, with real values rather than placeholders: main
+    // adopts a Harness generation while npm's default tag still serves the
+    // previous one. Development is fine and CI is green; releasing would not
+    // be. Pinned as a fixture so the behaviour is provable without editing
+    // HARNESS_TARGET or waiting on the registry.
+    const result = releaseReadiness('0.1.2-alpha.4', { readLatest: () => '0.1.1-rc.2\n' })
+    expect(result).toEqual({ kind: 'mismatch', adopted: '0.1.2-alpha.4', latest: '0.1.1-rc.2' })
+    expect(formatReadiness(result).code).toBe(1)
+  })
+
+  it('still refuses when the default channel skips the adopted generation entirely', () => {
+    // DeepSeek promoting a generation dshline did NOT adopt is not a green
+    // light. The response is to migrate HARNESS_TARGET onto it, not to assume
+    // the newer one works.
+    const result = releaseReadiness('0.1.2-alpha.4', { readLatest: () => '0.1.2-alpha.5\n' })
+    expect(result.kind).toBe('mismatch')
+    expect(formatReadiness(result).text).toContain('migrate HARNESS_TARGET')
+  })
+})
+
+describe('an unanswered question fails closed, and says so differently', () => {
+  it('reports a lookup failure as unverifiable rather than as a mismatch', () => {
+    const result = releaseReadiness('1.2.3', {
+      readLatest: () => { throw new Error('getaddrinfo ENOTFOUND registry.npmjs.org') },
+    })
+    expect(result.kind).toBe('unverifiable')
+    const { code, text } = formatReadiness(result)
+    // Non-zero — a release never proceeds on an unanswered question — but a
+    // distinct code and a distinct sentence, because the response differs.
+    expect(code).toBe(2)
+    expect(text).toContain('Could not verify')
+    expect(text).toContain('ENOTFOUND')
+    expect(text).not.toContain('release is not ready')
+  })
+
+  it.each([
+    ['empty output', ''],
+    ['whitespace only', '   \n'],
+    ['an npm error on stdout', 'npm ERR! code E404\n'],
+    ['two versions', '1.0.0\n1.0.1\n'],
+    ['a decorated line', "version = '1.0.0'\n"],
+  ])('treats %s as unverifiable rather than passing or comparing it', (_label, answer) => {
+    const result = releaseReadiness('1.0.0', { readLatest: () => answer })
+    expect(result.kind).toBe('unverifiable')
+    expect(formatReadiness(result).code).toBe(2)
+  })
+
+  it('cannot be satisfied by a non-string answer', () => {
+    expect(releaseReadiness('1.0.0', { readLatest: () => undefined }).kind).toBe('unverifiable')
+  })
+})
+
+describe('boundary A: only the generated Version Packages PR runs the live gate', () => {
+  it('is a job of its own, outside the development compatibility workflow', async () => {
+    // Placement is the architecture: ci.yml decides whether dshline works
+    // against HARNESS_TARGET, and must never resolve a dist-tag to do it.
+    const ci = await readWorkflow('ci.yml')
+    expect(ci).not.toContain(GUARD)
+    expect(ci).not.toContain('@latest')
+    const workflow = await readWorkflow('release-readiness.yml')
+    expect(workflow).toContain(GUARD)
+  })
+
+  it('runs only for the generated branch, on this repository, targeting main', async () => {
+    const guardExpression = jobCondition(extractJob(await readWorkflow('release-readiness.yml'), 'harness-latest'))
+    expect(guardExpression, 'the job must carry a job-level if:').toBeDefined()
+    // Identity, not the title: a PR title is attacker-supplied text, while
+    // pushing `changeset-release/main` to this repository needs write access.
+    expect(guardExpression).toContain("github.event.pull_request.head.ref == 'changeset-release/main'")
+    expect(guardExpression).toContain('github.event.pull_request.head.repo.full_name == github.repository')
+    expect(guardExpression).toContain("github.event.pull_request.base.ref == 'main'")
+  })
+
+  it('cannot be reached by an ordinary feature pull request', async () => {
+    const guardExpression = jobCondition(extractJob(await readWorkflow('release-readiness.yml'), 'harness-latest'))
+    // Every clause is an AND: no `||` can admit a branch that is not the
+    // generated one, which is what would put a feature PR at the mercy of a
+    // pointer DeepSeek moves.
+    expect(guardExpression).not.toContain('||')
+  })
+
+  it('carries a stable descriptive name with no version baked into it', async () => {
+    const job = extractJob(await readWorkflow('release-readiness.yml'), 'harness-latest')
+    const name = job.match(/^\s{4}name:\s*(.+)$/mu)
+    expect(name).not.toBeNull()
+    expect(name[1].trim()).toBe('Release readiness · Harness latest')
+    expect(name[1]).not.toMatch(/\d+\.\d+\.\d+/u)
+  })
+
+  it('needs no write access and no secret to read a public registry', async () => {
+    const workflow = await readWorkflow('release-readiness.yml')
+    expect(workflow).not.toMatch(/:\s*write/u)
+    expect(workflow).not.toContain('secrets.')
+    expect(workflow).toMatch(/permissions:\n\s+contents:\s*read/u)
+    expect([...workflow.matchAll(/uses: actions\/checkout@/gu)])
+      .toHaveLength([...workflow.matchAll(/persist-credentials: false/gu)].length)
+  })
+})
+
+describe('boundary B: the gate precedes the immutable tag', () => {
+  it('runs before the tag is created and pushed', async () => {
+    const job = extractJob(await readWorkflow('version.yml'), 'tag')
+    const gate = stepIndex(job, GUARD)
+    // The ref-creating API call, not the string `refs/tags/` — that also
+    // appears in the earlier read-only existence check, and passing against
+    // that step would prove something weaker than it looks.
+    const tagging = stepIndex(job, 'git/refs')
+    expect(gate, 'the tag job must run the release gate').toBeGreaterThanOrEqual(0)
+    expect(tagging, 'the tag job must still create a tag').toBeGreaterThanOrEqual(0)
+    expect(jobSteps(job)[tagging], 'the located step must be the one that writes the ref')
+      .toContain('--method POST')
+    // A tag cannot be taken back, so a gate after it would only be able to
+    // describe the mistake.
+    expect(gate).toBeLessThan(tagging)
+  })
+
+  it('runs on the merged release tree, after the tree itself is validated', async () => {
+    const job = extractJob(await readWorkflow('version.yml'), 'tag')
+    expect(stepIndex(job, 'tools/check-release-tag.mjs')).toBeLessThan(stepIndex(job, GUARD))
+  })
+})
+
+describe('boundary C: the gate precedes the first irreversible npm write', () => {
+  it('runs before anything is published', async () => {
+    const job = extractJob(await readWorkflow('publish.yml'), 'publish')
+    const gate = stepIndex(job, GUARD)
+    const publishing = stepIndex(job, 'pnpm -r publish')
+    expect(gate, 'the publish job must run the release gate').toBeGreaterThanOrEqual(0)
+    expect(publishing, 'the publish job must still publish').toBeGreaterThanOrEqual(0)
+    // Defense in depth: `latest` can move between the green Version Packages
+    // PR, the tag, and this run.
+    expect(gate).toBeLessThan(publishing)
+  })
+})
+
+describe('the gate is never advisory', () => {
+  it.each(['release-readiness.yml', 'version.yml', 'publish.yml'])(
+    '%s runs it without a bypass, a soft failure, or a swallowed exit code',
+    async (name) => {
+      const workflow = await readWorkflow(name)
+      const invocations = [...workflow.matchAll(new RegExp(`^.*${GUARD}.*$`, 'gmu'))].map(match => match[0])
+      expect(invocations.length).toBeGreaterThan(0)
+      for (const line of invocations) {
+        // `|| true`, `|| echo`, or a pipe would turn a refused release into a
+        // green one; `continue-on-error` would do it from the step instead.
+        expect(line).not.toMatch(/\|\||[;&]\s*(true|exit 0)|\|\s*\w/u)
+      }
+      expect(workflow).not.toContain('continue-on-error')
+    },
+  )
+})

--- a/tools/harness-target.mjs
+++ b/tools/harness-target.mjs
@@ -44,8 +44,16 @@ const WORKSPACE_MANIFEST = join(repoRoot, 'package.json')
 const MANIFESTS = [BUNDLE_MANIFEST, WORKSPACE_MANIFEST]
 const REGISTRY_HOST = 'https://registry.npmjs.org'
 
-/** The package a consumer installs, and therefore the one whose publication decides whether the target is reachable. */
-const LAUNCHER_PACKAGE = '@deepseek-ai/dsh'
+/**
+ * The package a consumer installs, and therefore the one whose publication
+ * decides whether the target is reachable.
+ *
+ * Exported because `tools/check-release-harness.mjs` asks a different question
+ * of the same package — not "does this exact version exist" but "is this the
+ * version an unqualified install resolves" — and the two must never disagree
+ * about which package the launcher is.
+ */
+export const LAUNCHER_PACKAGE = '@deepseek-ai/dsh'
 
 /**
  * Manifest fields `--pin` rewrites. `peerDependencies` is deliberately absent:


### PR DESCRIPTION
## The invariant

> dshline may adopt a Harness release generation on `main` before that generation becomes the default Harness npm release. Development remains pinned to `HARNESS_TARGET`; publishing waits until `@deepseek-ai/dsh@latest` exactly matches that target, keeping the documented unqualified install coherent without carrying compatibility code for the previous Harness generation.

The documented installation is two unqualified names:

```sh
npm install -g @deepseek-ai/dsh @dshline/dshline
```

Both resolve through npm's default tag, and `@deepseek-ai/dsh` pins the whole `dsh-*` line to its own generation — verified against the published manifests, not assumed. So whichever version that tag serves **is** the Harness generation an ordinary install ends up running. If `@dshline/dshline@latest` advanced to a build adopting a different generation, that one command would resolve a pair dshline does not support.

**This is release-channel coherence, not runtime compatibility.** Nothing here widens a peer range, feature-detects a Harness API, or teaches dshline to support two generations. `main` may run ahead the entire time. Publication waits instead.

## The gate

`tools/check-release-harness.mjs` — one question, exact string equality:

```text
HARNESS_TARGET.version  ==  @deepseek-ai/dsh@latest
```

Exact in **both** directions. A default channel that has moved *past* the adopted target fails too: "newer" is not "supported", and the response there is to migrate `HARNESS_TARGET` onto whichever generation Harness actually promoted. There is no semver comparison anywhere in it.

| outcome | exit | meaning |
|---|---|---|
| equal | `0` | an unqualified install resolves one coherent generation |
| differ, either direction | `1` | release-channel mismatch, both values printed |
| npm unreachable, or a non-version answer | `2` | readiness could not be established |

Both failures fail closed, but with **different codes and different prose**, because they need different responses — a network failure is an unanswered question, not evidence of a mismatch. The mismatch diagnostic says in as many words that this is a release failure and that `main` is not broken, then names the only two legitimate resolutions. The natural misreading would send someone to write exactly the compatibility code this policy exists to refuse.

It reuses `harness-target.mjs` for both the `HARNESS_TARGET` parser and the launcher package name (now exported) rather than growing a second source of truth, and resolves the tag with `npm view` rather than a hand-rolled packument read — resolving a dist-tag is npm's own job. One call, no retry: a gate that hammered the registry to turn a network failure into a pass would be the opposite of failing closed.

## Three boundaries

**A — the generated Version Packages PR.** A new `release-readiness.yml`, job name **`Release readiness · Harness latest`**, suitable for branch protection and carrying no version in its name. Deliberately its *own* workflow so `ci.yml` keeps containing no dist-tag read at all.

It is identified by **branch and repository identity, never the PR title** — a title is attacker-supplied text on any fork PR, while pushing `changeset-release/main` to this repository requires write access:

```yaml
github.event.pull_request.base.ref == 'main'
&& github.event.pull_request.head.repo.full_name == github.repository
&& github.event.pull_request.head.ref == 'changeset-release/main'
```

Every clause is an AND. **Ordinary pull requests — including the pending Harness migration #134 — cannot reach it.** That is the point: making a pointer DeepSeek moves into a merge gate for unrelated work is precisely the architecture #133 removed. A red result here means *do not merge this release yet*, and a `failure()` step writes that sentence into the job summary so nobody reads it as "main is broken".

**B — before the immutable tag.** In `version.yml`'s `tag` job, after the release tree is validated and before the tag is created. This is the primary irreversible-boundary protection: failing here leaves no tag, nothing published, and nothing to clean up. Creating the tag and relying on `publish.yml` to stop later would leave a tag behind pointing at a release that must not become `latest`.

**C — before the first publish.** In `publish.yml`, before `pnpm -r publish`. Defense in depth: `latest` can move between the green PR, the tag, and the run, and a manually pushed or recovered tag skips both earlier gates.

## Not the same thing as `Harness published`

That lane asks a product question — can a user install this and does it boot. This gate asks only *may this release become the default dshline release*. Both touch npm; they are not merged. `HARNESS_TARGET` remains the sole development authority, and no `latest`/`next`/`alpha` lane returns to development CI.

## Tests

`tools/check-release-harness.spec.mjs`, 25 cases, **nothing touching the live registry** — the lookup is injected at the narrowest seam, matching `verify-published.mjs`'s convention.

Verdicts: exact match; target ahead; **registry ahead** (the case a semver comparison would wave through); prerelease-vs-release of the same tuple in both directions; lookup throw; and five malformed answers (empty, whitespace, an npm error on stdout, two versions, a decorated line) — none of which may pass or be compared. Plus the concrete pending-migration scenario pinned as a fixture, proving the alpha-vs-current pair fails without editing `HARNESS_TARGET` or waiting on the registry.

Placement: ordinary PRs cannot reach the gate; the generated PR does; pre-tag precedes tag creation; pre-publish precedes the first publish; and no `|| true`, pipe, swallowed exit, or `continue-on-error` makes any invocation advisory.

Five mutations confirm none of it is vacuous — each fails the suite as intended: moving the pre-tag guard after tag creation, moving the pre-publish guard after publish, deleting the pre-tag guard, adding `|| true`, and widening the Version-PR condition with `||`.

One bug found and fixed while writing them: the first step-extraction regex used a multiline `$`, so every step body was truncated to its first line and the ordering assertions were comparing far less than they appeared to. Replaced with a real split on the step marker.

## Validation

`build`, `typecheck`, **2506 tests**, 9 bilingual doc pairs, `pnpm audit` clean, `zizmor` clean across all five workflows including the new one.

Live against the real registry, on this branch:

```text
check-release-harness: @deepseek-ai/dsh@latest is 0.1.1-rc.2, matching the adopted Harness target.
An unqualified install of both packages resolves one coherent generation.
```

Exit 0 — `main` currently targets the same generation npm serves by default, so the gate passes today and would not have blocked the last release.

## Permissions

`contents: read` only, on every job. No secret, no npm token, no write scope added anywhere. The gate reads one repository file and asks npm one public question.

## Docs

`docs/architecture.md` + its Chinese pair gain a release-channel section under *Upstream compatibility*, and the line *"Nothing in CI reads an npm dist-tag"* is refined to *"Development compatibility CI does not follow npm dist-tags"* — now the precise claim, since the release gate is technically CI but is never reached by a development pull request. Pair re-recorded through the normal tool. `.changeset/README.md` tells a maintainer what a not-ready release PR means and not to bypass it. `AGENTS.md` states the two authorities and names the prohibited "fixes".

**README is unchanged, deliberately.** The gate exists so ordinary users never have to reason about release-channel mechanics; a warning box would advertise a problem the machinery is there to prevent, and no permanent doc hardcodes a version or reads the registry.

## Relationship to #134

Untouched and not merged. Once this lands, #134 rebases onto the guarded `main`. Worth noting for that rebase: the `alpha` dist-tag has since moved to a generation *past* the one #134 adopts, which is exactly the "newer is not supported" case — see the report accompanying this PR.
