### PR TITLE
refactor(goal): take durable goal state from the `goal` projection

### DIFF
--- a/.changeset/goal-projection-authority-split.md
+++ b/.changeset/goal-projection-authority-split.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': patch
+---
+
+Read the status line's durable goal state from the Harness `goal` session projection instead of from `ctx.goals`. Objective, phase, round count, and round cap now come out of the same validated snapshot cut the status frame already takes for Todo and context occupancy, through the shared session-scoped projection observer, so Goal adds no second direct dshline snapshot. The goal service is consulted for one process-local fact no replay can reconstruct — continuation activation — and only for a projected goal that is durably active; that read stays live and uncached because `disarm()` changes it with no durable event. An activation that cannot be obtained reports `goal idle` rather than a running goal. The service call reads a whole view because the adopted Harness generation publishes no activation-only accessor, and `GoalService.get()` resolves its own durable half through `sessionProjections.stateOf()` internally; `.activation` is the only field dshline consumes from it. No change to the status wording, ordering, or degradation behavior.

--- a/ROADMAP.i18n.yaml
+++ b/ROADMAP.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write ROADMAP.md
-ROADMAP.md: dcd5cb1486961ffa51d3e9cb9d7e2b769129af4a
-ROADMAP.zh.md: 4c4a0b5854166b3c4e6fbfb668372d2fda436795
+ROADMAP.md: ac5e59885204f606296a39691e738c7c2371aee8
+ROADMAP.zh.md: 2ce1cb1e932cc7e407cd02239fec1fb72543dc0d

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,9 +83,18 @@ feature replay the same session log.
    internal session-scoped observer. The whole-list `todo/write` state,
    lifecycle, and persistence remain Harness-owned; dshline parses neither
    calls, cards, nor tool output and owns no Todo state machine.
-2. **Next, refine Goal.** Use the durable `goal` projection for log-derived
-   state and `ctx.goals` where live, process-local continuation authority is
-   required.
+2. **Goal — implemented.** The status line's durable goal reading — objective,
+   phase, round count, round cap — comes from the Harness `goal` projection
+   through that same observer, on the same snapshot cut Todo uses, so Goal adds
+   no second direct dshline snapshot. `ctx.goals` is consulted for one
+   process-local fact that no replay can reconstruct, continuation activation,
+   and only for a projected goal that is durably active. It is read live and
+   never cached, because `disarm()` changes it with no durable event; an
+   activation that cannot be read reports `goal idle` rather than a running
+   goal. That call reads a whole view because the adopted generation publishes
+   no activation-only accessor — `GoalService.get()` consults its own `goal`
+   projection state internally — and `.activation` is the only field dshline
+   takes from it.
 3. **Plan remains Harness-governed.** Its presentation continues to follow the
    authority documented by the plan capability rather than a TUI-owned mirror.
 

--- a/ROADMAP.zh.md
+++ b/ROADMAP.zh.md
@@ -38,7 +38,7 @@
 `ctx.sessionProjections` 是第二个被验证的架构模式。领域插件注册投影单元；Harness 拥有它们的日志驱动、缓存、快照与变更流；dshline 把快照与变更作为呈现输入消费。其内部共享观察器为原生适配器供数，而不是让每个特性重放同一个会话日志。
 
 1. **Todo——已实现。**`/todos` 与一条紧凑状态读数通过一个内部会话作用域观察器，消费 `@deepseek-ai/dsh-tool-todo` 提供的 `todos` 投影。整列表的 `todo/write` 状态、生命周期与持久化仍归 Harness 所有；dshline 既不解析调用、卡片或工具输出，也不拥有任何 Todo 状态机。
-2. **下一步，打磨 Goal。**把持久的 `goal` 投影用于日志派生的状态，在需要实时、进程局部的续跑权威时使用 `ctx.goals`。
+2. **Goal——已实现。**状态行的持久目标读数——objective、phase、轮次计数、轮次上限——来自 Harness 的 `goal` 投影，经由同一个观察器，取自 Todo 所用的同一份快照切面，因此 Goal 不增加第二次 dshline 直接快照。`ctx.goals` 只被咨询一个任何重放都无法重建的进程局部事实：续跑激活，并且只针对持久处于 active 的已投影目标。它是实时读取且从不缓存的，因为 `disarm()` 改变它时不产生任何持久事件；无法读取的激活报告 `goal idle`，而不是一个正在运行的目标。该调用之所以读取整个视图，是因为已采纳的这一代没有发布仅取激活的访问器——`GoalService.get()` 会在内部查询它自己的 `goal` 投影状态——而 dshline 只从中取用 `.activation`。
 3. **Plan 仍由 Harness 治理。**它的呈现继续遵循计划能力文档化的权威，而不是 TUI 自有的镜像。
 
 不承诺任何通用的公共 `ProjectionAdapter` 接口。

--- a/docs/architecture.i18n.yaml
+++ b/docs/architecture.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/architecture.md
-architecture.md: 0a523c00aa5d726897cec40cfc126e0b03b560c6
-architecture.zh.md: 56da2cd8c1324d917a4eef8f11364cacb0da5bb0
+architecture.md: daaea0ab857360eb1cef13ed9b0a753206640ca5
+architecture.zh.md: d33d845fca209228f3369217ab8b4a4840545b8b

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,12 +220,30 @@ the durable lifecycle, and the persistence checkpoint. `compactRegion` exists on
 the service and is deliberately not exposed: the human command is argument-free,
 and a range-selection UI would be a control contract upstream has not defined.
 
-Goal is another known projection domain, with one important extra authority:
-its durable `goal` projection represents log-derived goal state, while
-`ctx.goals` owns live, process-local continuation activation. A goal view that
-claims a resumed session will continue must therefore use the goal service for
-that live fact; a projection alone cannot supply it. Plan remains governed by
-its documented Harness authority.
+Goal is a known projection domain with two authorities, and dshline reads each
+from its owner. Everything durable — objective, phase, blocked reason,
+`roundsStarted`, `maxGoalRounds`, revision, timestamps — comes from the `goal`
+projection, out of the same session-scoped observer cut the status line already
+takes for Todo and context occupancy, so Goal adds no second direct dshline
+snapshot. `ctx.goals` answers exactly one question, and is asked only where the
+answer can change the reading: live, process-local continuation activation, for
+a projected goal whose durable phase is `active`. That read is live and never
+cached, because `disarm()` is process-local by design — it changes activation
+with no `goal/change` event, no revision, and no `goal/changed` notification, so
+no projection observer can reconstruct or own it. An activation that cannot be
+obtained is never taken for `armed`: a resumed session holding a durably active
+goal reports `goal idle` rather than claiming this process will continue it,
+which is the one thing neither authority could say on its own.
+
+The service call is a whole-view read because the adopted generation publishes
+no activation-only accessor, and `GoalService.get()` resolves its own durable
+half through `sessionProjections.stateOf(session, 'goal')` before combining it
+with process-local runtime state. That inner read belongs to the service, not to
+this frontend, and `.activation` is the only field taken from what it returns —
+so the authority split is exact even though it is not yet physically narrow. An
+upstream activation-only accessor would remove that service-side `stateOf()`
+read and make it both. Plan remains governed by its documented Harness
+authority.
 
 ### 3. Novel third-party capabilities
 

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -140,7 +140,9 @@ dshline Todo presentation
 `compactRegion` 存在于该服务上，并被特意不暴露：人类命令不接受参数，而一个范围选择
 界面会是上游尚未定义的控制约定。
 
-Goal 是另一个已知投影领域，有一个重要的额外权威：其持久的 `goal` 投影代表日志派生的目标状态，而 `ctx.goals` 拥有实时、进程局部的续跑激活。因此，声称恢复的会话将继续的目标视图必须使用目标服务来获取该实时事实；单独的投影无法提供它。Plan 仍由其文档化的 Harness 权威治理。
+Goal 是一个具有两个权威的已知投影领域，dshline 分别从各自的所有者读取。所有持久内容——objective、phase、blocked reason、`roundsStarted`、`maxGoalRounds`、revision、时间戳——都来自 `goal` 投影，取自状态行已经为 Todo 与上下文占用所取的同一份会话作用域观察器切面，因此 Goal 不增加第二次 dshline 直接快照。`ctx.goals` 只回答一个问题，并且只在答案能改变读数时才被询问：对于持久 phase 为 `active` 的已投影目标，读取实时、进程局部的续跑激活。该读取是实时的，且从不缓存，因为 `disarm()` 按设计是进程局部的——它改变激活时不产生 `goal/change` 事件、不推进 revision、也不发出 `goal/changed` 通知，因此任何投影观察器都无法重建或拥有它。无法获取的激活绝不被当作 `armed`：持有持久 active 目标的恢复会话报告 `goal idle`，而不是声称本进程会继续它——这正是任一权威单独都说不出的那件事。
+
+之所以整体读取该服务视图，是因为已采纳的这一代没有发布仅取激活的访问器，而 `GoalService.get()` 会先通过 `sessionProjections.stateOf(session, 'goal')` 解析它自己的持久部分，再与进程局部的运行时状态合并。那次内部读取属于该服务而不属于本前端，并且本前端只从其返回值中取用 `.activation`——因此权威划分是精确的，尽管在物理上还不够窄。上游若提供仅取激活的访问器，就能免去服务端的那次 `stateOf()` 读取，使两者兼得。Plan 仍由其文档化的 Harness 权威治理。
 
 ### 3. 新颖的第三方能力
 

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -23,10 +23,9 @@ import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { parseCommand } from '@deepseek-ai/dsh-commands'
 import type {} from '@deepseek-ai/dsh-user-questions'
 import type {} from '@deepseek-ai/dsh-cmdline'
-// Both carry `SessionEventMap` merges this module reads: `plan/mode` is folded
-// below, and the goal package also carries the `ctx.goals` service type. Neither
-// is a peer dependency, because neither has to be MOUNTED for this frontend to
-// run — a profile without them simply never reports either state.
+// `plan/mode` is folded below from the `SessionEventMap` merge this carries. Not
+// a peer dependency, because it does not have to be MOUNTED for this frontend to
+// run — a profile without it simply never reports plan mode.
 import type {} from '@deepseek-ai/dsh-plan-mode'
 // Optional projection infrastructure and Todo's `SessionProjectionMap` merge.
 // dsh-base mounts both, but custom profiles may omit either without stopping TUI.
@@ -35,7 +34,11 @@ import type {} from '@deepseek-ai/dsh-session-projection'
 // service only when the active profile mounts it.
 import type {} from '@deepseek-ai/dsh-session-title'
 import type {} from '@deepseek-ai/dsh-tool-todo'
-import type { GoalView } from '@deepseek-ai/dsh-goal'
+// The goal package publishes both of this frontend's goal authorities: the
+// `goal` key of `SessionProjectionMap` (durable, read from the shared snapshot)
+// and the `ctx.goals` service type (live activation, read below). Optional in
+// the same way — a profile without it reports no goal at all.
+import type { GoalActivation } from '@deepseek-ai/dsh-goal'
 // `fs` is read optionally for path completion: a profile that mounts no filesystem
 // offers none rather than failing, so this carries the type without a hard need.
 import type {} from '@deepseek-ai/dsh-fs'
@@ -67,7 +70,7 @@ import { StreamBuffer } from './stream.ts'
 import { effortLabel, pickReasoning, reasoningValues } from './reasoning.ts'
 import { THINKING_VALUES, pickThinking, thinkingAcknowledgement, validThinkingArgument } from './thinking.ts'
 import { createTimingView, TurnTimer } from './timing.ts'
-import { goalReading, planModeAfter } from './modes.ts'
+import { planModeAfter } from './modes.ts'
 import { commandEcho, commandLines, projectEvent } from './transcript.ts'
 import { promptSelect } from './select.ts'
 import { confirmPermissionSelection, permissionPicker } from './permission.ts'
@@ -82,6 +85,7 @@ import { createHarnessWork } from './work/index.ts'
 import { createWorkOverlay } from './work/overlay.ts'
 import { activeWorkCount, workSummary } from './work/model.ts'
 import { SessionProjectionObserver } from './projections/observer.ts'
+import { goalReading } from './goals/model.ts'
 import { todoReading, todoSummary } from './todos/model.ts'
 import { createTodoOverlay } from './todos/overlay.ts'
 import { SkillCatalog } from './skills/catalog.ts'
@@ -768,22 +772,40 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   }
 
   /**
-   * The current goal, or nothing when there is none to report.
-   * @returns the service's view, or undefined when it is absent or refuses.
+   * Live, process-local continuation activation for this agent's goal.
+   *
+   * The only thing this frontend asks the goal service for. Every durable field
+   * — objective, phase, blocked reason, round count, round cap, revision,
+   * timestamps — comes from the `goal` projection in the frame's shared
+   * snapshot instead, because Harness publishes those generically and the
+   * service is not their presentation authority. Activation is the one fact no
+   * replay can reconstruct: it is process-local, never persisted, and
+   * `disarm()` changes it with no `goal/change` event, no revision, and no
+   * `goal/changed` notification. So it is read live on the frame that needs it
+   * and never cached.
+   *
+   * `get()` is the whole read because alpha.5 publishes no activation-only
+   * accessor; it resolves its own durable half through
+   * `sessionProjections.stateOf(session, 'goal')` before combining it with the
+   * process-local runtime state. That inner read is the service's, not a second
+   * dshline snapshot, and `.activation` is the only field taken from what it
+   * returns.
+   * @returns the activation, or undefined when it cannot be obtained.
    */
-  const currentGoal = (): GoalView | undefined => {
+  const goalActivation = (): GoalActivation | undefined => {
     try {
-      return ctx.get('goals')?.get(agent)
+      return ctx.get('goals')?.get(agent)?.activation
     } catch {
-      // A goal that cannot be read is reported as no goal. The alternative is a
-      // status line that stops drawing, which loses the spinner and the context
-      // reading too.
+      // An activation that cannot be read is not `armed`. A refusal here — no
+      // live agent, a failed goal replay — leaves the durable projection to
+      // report the goal as idle rather than claiming this process will continue
+      // it, and never takes the whole status line down with it.
       return undefined
     }
   }
 
   const status = createStatusView(() => {
-    // ONE validated projection cut per frame, shared by every consumer below.
+    // One direct projection snapshot per frame, shared by every consumer below.
     // The registry validates each unit's view on the way out, so reading it
     // twice would pay for that twice on a line redrawn by every spinner beat.
     const projected = projections.snapshot()
@@ -812,12 +834,11 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
       todo: todoSummary(todoReading(projected)),
       plan: planActive,
       replay: replaying,
-      // Asked for at render time, unlike everything folded above, and for one
-      // reason: it is the authority, and it knows the one thing the log cannot say — whether
-      // THIS process still holds authority to take another round. Guarded because
-      // the service documents a throw, and a throw here would take the whole status
-      // line down rather than one segment of it.
-      goal: goalReading(currentGoal()),
+      // Two authorities, joined in the adapter and nowhere else: the durable
+      // goal comes out of the same cut as Todo and the context reading, adding
+      // no further dshline snapshot, and the service is consulted — lazily,
+      // only for an active projected goal — for process-local activation alone.
+      goal: goalReading(projected, goalActivation),
     }
   })
   const streamView = { render: (columns: number): string[] => stream.live(columns) }

--- a/packages/dshline/src/goals/model.ts
+++ b/packages/dshline/src/goals/model.ts
@@ -1,0 +1,136 @@
+/**
+ * Presentation-facing reading of the Harness goal domain's two authorities.
+ *
+ * The goal is owned in halves, and this adapter is where they are joined for
+ * the terminal — nowhere else:
+ *
+ * ```text
+ * Harness `goal` projection   durable, log-derived: identity, revision,
+ *   (ctx.sessionProjections)  objective, phase, blocked reason, round count,
+ *                             round cap, timestamps
+ *
+ * ctx.goals                   live, process-local: activation alone, the one
+ *                             fact no replay can reconstruct
+ * ```
+ *
+ * Activation is deliberately never persisted, so a resumed session can hold a
+ * durably `active` goal while this process is `disarmed` and will continue
+ * nothing. That is the distinction the whole reading exists to make, and it is
+ * why the durable half comes from the projection: reading those fields off
+ * `ctx.goals.get(agent)` would make the service the presentation authority for
+ * state Harness already publishes generically.
+ *
+ * Activation is asked for lazily, at render time, and never cached. Upstream's
+ * `disarm()` is process-local by design: it changes activation without a
+ * `goal/change` event, without a revision, and without a `goal/changed`
+ * notification, so a projection observer cannot own it and a remembered copy
+ * would go stale silently.
+ * @module dshline/goals/model
+ */
+
+import type { GoalActivation } from '@deepseek-ai/dsh-goal'
+import type { ProjectionSnapshot } from '@deepseek-ai/dsh-session-projection'
+import { displayWidth, escapeControls, truncateToWidth } from '@dshline/renderer'
+
+/**
+ * Columns an objective may occupy in the status line.
+ *
+ * Cut here rather than in the status line, which drops whole segments and never
+ * shortens one. An objective is prose a model wrote, so unlike a round count it
+ * has no length worth respecting and no smaller true form to fall back to — a
+ * shortened one is still an objective, where `goal 12/25` is a different fact
+ * from `goal 12/256`. Wide enough for a recognizable phrase, narrow enough that
+ * an eighty-column terminal still has room for the context reading.
+ */
+const OBJECTIVE_COLUMNS = 28
+
+/** What a goal is, how far in it is, and whether anything will continue it. */
+export interface GoalReading {
+  /** The full text for the status line: the state, and what the goal is. */
+  label: string
+  /** The state alone, for a terminal that cannot hold the objective. */
+  short: string
+  /** Whether this session will continue the goal by itself. */
+  running: boolean
+}
+
+/**
+ * Live process-local activation, asked for only when it can change the reading.
+ *
+ * A thunk rather than a value so this adapter decides whether the service is
+ * consulted at all. `undefined` means the answer could not be obtained — no goal
+ * service, no live agent, or a refusal — and is never read as `armed`.
+ */
+export type GoalActivationSource = () => GoalActivation | undefined
+
+/**
+ * How the status line reports a goal, or nothing when there is none.
+ *
+ * The objective leads the reading, because the first question about a goal is
+ * what it is — and a goal is not always something the reader set. The harness's
+ * `create_goal` tool is model-callable and documents that the model may infer the
+ * intent without being asked, so a session can acquire automatic continuation
+ * authority that was never typed. The round count is what says so; the objective
+ * is what makes that legible.
+ *
+ * The count appears only once a round has been taken. Before then it is
+ * `roundsStarted` against a deployment's cap — `0/256` — which reads as a meter
+ * stuck at zero when it is really a safety limit that has not been approached.
+ * `armed` says the same thing in the words that are true.
+ *
+ * A phase that is not `active` replaces the count: the round number of a paused
+ * goal is history, not progress. `idle` marks the case the count alone would
+ * misrepresent — a goal that is durably active while this process holds no
+ * authority to continue it, which is what every reopened session starts as. It
+ * reads as a goal that is set and going nowhere, which is what it is.
+ *
+ * Only an `active` projected goal consults `activation`: a paused, blocked, or
+ * complete goal reads the same either way, and a session with no projected goal
+ * has nothing to ask about.
+ * @param snapshot - the status frame's shared projection cut, or undefined without the registry.
+ * @param activation - live process-local activation, called at most once.
+ * @returns the reading, or undefined when nothing is worth reporting.
+ */
+export function goalReading(
+  snapshot: ProjectionSnapshot | undefined,
+  activation: GoalActivationSource,
+): GoalReading | undefined {
+  // `undefined` is the typed absence of an unregistered process-wide unit;
+  // `null` is the goal domain's distinct no-current-goal value. Neither is a
+  // goal, and a missing registry is not one either.
+  const current = snapshot?.values.goal
+  if (current === undefined || current === null) return undefined
+  const { goal, roundsStarted } = current
+  // An unobtainable activation is not `armed`. Inferring one from
+  // `phase === 'active'` is exactly the claim this split exists to refuse.
+  const running = goal.phase === 'active' && activation() === 'armed'
+  const state = goal.phase !== 'active'
+    ? goal.phase
+    : !running
+      ? 'idle'
+      : roundsStarted > 0 ? `${String(roundsStarted)}/${String(goal.maxGoalRounds)}` : 'armed'
+  const short = `goal ${state}`
+  // An objective is untrusted text: the model writes it, and it reaches the
+  // terminal. Escaped before it is measured, so the cut and the width agree.
+  const objective = elide(escapeControls(goal.objective), OBJECTIVE_COLUMNS)
+  return {
+    label: objective === '' ? short : `${short} \u00b7 ${objective}`,
+    short,
+    running,
+  }
+}
+
+/**
+ * Fit text to a column budget, marking a cut with an ellipsis.
+ *
+ * `truncateToWidth` alone cuts silently, and a silently cut objective reads as a
+ * complete one — "migrate every call site off" is a plausible whole sentence and
+ * a wrong summary of what the goal actually says.
+ * @param text - the already-escaped text.
+ * @param columns - the budget, ellipsis included.
+ * @returns the text, or a cut form ending in an ellipsis.
+ */
+function elide(text: string, columns: number): string {
+  if (displayWidth(text) <= columns) return text.trimEnd()
+  return `${truncateToWidth(text, columns - 1).trimEnd()}\u2026`
+}

--- a/packages/dshline/src/modes.ts
+++ b/packages/dshline/src/modes.ts
@@ -1,47 +1,24 @@
 /**
  * Session state that changes what a turn will do, rather than what it says.
  *
- * Plan mode and a running goal are both invisible in a transcript: the command
- * that set one prints a line and scrolls away, and everything after that looks
- * like an ordinary session while the agent behaves differently. That is exactly
- * what a status line is for.
+ * Plan mode is invisible in a transcript: the command that set it prints a line
+ * and scrolls away, and everything after that looks like an ordinary session
+ * while the agent behaves differently. That is exactly what a status line is
+ * for.
  *
- * The two are read by different means, each the one its owner documents. Plan
- * mode is folded from the log — `PlanModeController` says outright that UIs
- * observe committed flips through `session/event` and that there is no live
- * mirror — which also means a reopened session recovers it from the replay. A
- * goal is asked of its service instead, because the log carries the durable
- * phase but not whether THIS process will continue it: activation is
- * process-local and never persisted, so a resumed session holding an active goal
- * is not a session that is about to run one.
+ * It is read the way its owner documents. `PlanModeController` says outright
+ * that UIs observe committed flips through `session/event` and that there is no
+ * live mirror — which also means a reopened session recovers it from the replay.
+ * So plan mode is folded here, from the log, and nothing else is.
+ *
+ * A goal is not folded here. Harness publishes its durable state through the
+ * generic `goal` session projection and only its process-local activation
+ * through `ctx.goals`; joining those two authorities belongs to the projection
+ * adapter in `dshline/goals/model`, beside Todo's.
  * @module dshline/modes
  */
 
-import type { GoalView } from '@deepseek-ai/dsh-goal'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
-import { displayWidth, escapeControls, truncateToWidth } from '@dshline/renderer'
-
-/**
- * Columns an objective may occupy in the status line.
- *
- * Cut here rather than in the status line, which drops whole segments and never
- * shortens one. An objective is prose a model wrote, so unlike a round count it
- * has no length worth respecting and no smaller true form to fall back to — a
- * shortened one is still an objective, where `goal 12/25` is a different fact
- * from `goal 12/256`. Wide enough for a recognizable phrase, narrow enough that
- * an eighty-column terminal still has room for the context reading.
- */
-const OBJECTIVE_COLUMNS = 28
-
-/** What a goal is, how far in it is, and whether anything will continue it. */
-export interface GoalReading {
-  /** The full text for the status line: the state, and what the goal is. */
-  label: string
-  /** The state alone, for a terminal that cannot hold the objective. */
-  short: string
-  /** Whether this session will continue the goal by itself. */
-  running: boolean
-}
 
 /**
  * Plan mode after one event.
@@ -55,60 +32,4 @@ export interface GoalReading {
  */
 export function planModeAfter(active: boolean, event: SessionEvent): boolean {
   return event.type === 'plan/mode' ? event.data.active : active
-}
-
-/**
- * How the status line reports a goal, or nothing when there is none.
- *
- * The OBJECTIVE leads the reading, because the first question about a goal is
- * what it is — and a goal is not always something the reader set. The harness's
- * `create_goal` tool is model-callable and documents that the model may infer the
- * intent without being asked, so a session can acquire automatic continuation
- * authority that was never typed. The round count is what says so; the objective
- * is what makes that legible.
- *
- * The count appears only once a round has been taken. Before then it is
- * `roundsStarted` against a deployment's cap — `0/256` — which reads as a meter
- * stuck at zero when it is really a safety limit that has not been approached.
- * `armed` says the same thing in the words that are true.
- *
- * A phase that is not `active` replaces the count: the round number of a paused
- * goal is history, not progress. `idle` marks the case the count alone would
- * misrepresent — a goal that is durably active while this process holds no
- * authority to continue it, which is what every reopened session starts as. It
- * reads as a goal that is set and going nowhere, which is what it is.
- * @param goal - the service's view of the current goal, when there is one.
- * @returns the reading, or undefined when nothing is worth reporting.
- */
-export function goalReading(goal: GoalView | undefined): GoalReading | undefined {
-  if (goal === undefined) return undefined
-  const state = goal.phase !== 'active'
-    ? goal.phase
-    : goal.activation !== 'armed'
-      ? 'idle'
-      : goal.roundsStarted > 0 ? `${String(goal.roundsStarted)}/${String(goal.maxGoalRounds)}` : 'armed'
-  const short = `goal ${state}`
-  // An objective is untrusted text: the model writes it, and it reaches the
-  // terminal. Escaped before it is measured, so the cut and the width agree.
-  const objective = elide(escapeControls(goal.objective), OBJECTIVE_COLUMNS)
-  return {
-    label: objective === '' ? short : `${short} \u00b7 ${objective}`,
-    short,
-    running: goal.phase === 'active' && goal.activation === 'armed',
-  }
-}
-
-/**
- * Fit text to a column budget, marking a cut with an ellipsis.
- *
- * `truncateToWidth` alone cuts silently, and a silently cut objective reads as a
- * complete one — "migrate every call site off" is a plausible whole sentence and
- * a wrong summary of what the goal actually says.
- * @param text - the already-escaped text.
- * @param columns - the budget, ellipsis included.
- * @returns the text, or a cut form ending in an ellipsis.
- */
-function elide(text: string, columns: number): string {
-  if (displayWidth(text) <= columns) return text.trimEnd()
-  return `${truncateToWidth(text, columns - 1).trimEnd()}\u2026`
 }

--- a/packages/dshline/tests/goals.spec.ts
+++ b/packages/dshline/tests/goals.spec.ts
@@ -1,0 +1,338 @@
+/**
+ * Harness Goal adapter: the split between the durable `goal` projection and
+ * live, process-local activation.
+ *
+ * The tests that matter here are not about wording. They are about which
+ * authority each half of the reading comes from, because both authorities
+ * answer with a plausible-looking goal and only one of them is right for each
+ * half. A regression that quietly went back to reading durable fields off
+ * `ctx.goals.get(agent)` would render identically in every ordinary session and
+ * would be wrong in exactly the resumed one.
+ * @module
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import AgentRegistry from '@deepseek-ai/dsh-agent'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import GoalService, { GoalId } from '@deepseek-ai/dsh-goal'
+import type { GoalActivation, GoalPhase, GoalProjection, GoalView } from '@deepseek-ai/dsh-goal'
+import { createUserMessage } from '@deepseek-ai/dsh-llm'
+import SessionStore from '@deepseek-ai/dsh-session'
+import type { Session } from '@deepseek-ai/dsh-session'
+import SessionProjectionRegistry from '@deepseek-ai/dsh-session-projection'
+import type { ProjectionSnapshot } from '@deepseek-ai/dsh-session-projection'
+import { SessionProjectionObserver } from '../src/projections/observer.ts'
+import { goalReading } from '../src/goals/model.ts'
+
+/**
+ * One durable `goal` projection value, as the registry publishes it.
+ * @param over - the durable fields that matter to a test.
+ * @returns the projection value.
+ */
+function projection(over: {
+  objective?: string
+  phase?: GoalPhase
+  roundsStarted?: number
+  maxGoalRounds?: number
+} = {}): GoalProjection {
+  return {
+    goal: {
+      id: GoalId('goal-projected'),
+      revision: 4,
+      objective: over.objective ?? 'ship it',
+      phase: over.phase ?? 'active',
+      maxGoalRounds: over.maxGoalRounds ?? 256,
+    },
+    roundsStarted: over.roundsStarted ?? 3,
+    createdAt: 1_000,
+    updatedAt: 2_000,
+  }
+}
+
+/**
+ * One validated projection cut carrying a given `goal` value.
+ * @param goal - the projection value, `null` for no current goal, or undefined to leave the key unregistered.
+ * @returns the cut.
+ */
+function cut(goal: GoalProjection | null | undefined): ProjectionSnapshot {
+  return { asOfSeq: 7, values: goal === undefined ? {} : { goal } } as ProjectionSnapshot
+}
+
+/** A counting activation source, so a test can prove it was never consulted. */
+function activationSource(activation: GoalActivation | undefined): {
+  read: () => GoalActivation | undefined
+  calls: () => number
+} {
+  let calls = 0
+  return { read: () => { calls += 1; return activation }, calls: () => calls }
+}
+
+/**
+ * One source file with its comments removed.
+ *
+ * The assertion is about what the code does, and every prose explanation of the
+ * split necessarily names the paths the code must not take.
+ * @param url - the module's file URL.
+ * @returns the source with block and line comments stripped.
+ */
+function code(url: URL): string {
+  return readFileSync(fileURLToPath(url), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//gu, '')
+    .replace(/^\s*\/\/.*$/gmu, '')
+}
+
+describe('the Goal projection adapter', () => {
+  it('reports nothing without a projected goal, however the projection is missing', () => {
+    // Three different absences, one presentation: no registry at all, a
+    // registry that never registered the goal unit, and the goal domain's own
+    // "no current goal". None of them is a goal, and none may become one by
+    // asking the service what it thinks.
+    const never = activationSource('armed')
+    expect(goalReading(undefined, never.read)).toBeUndefined()
+    expect(goalReading(cut(undefined), never.read)).toBeUndefined()
+    expect(goalReading(cut(null), never.read)).toBeUndefined()
+    expect(never.calls()).toBe(0)
+  })
+
+  it('counts the rounds from the projection while live activation is armed', () => {
+    expect(goalReading(cut(projection()), () => 'armed'))
+      .toEqual({ label: 'goal 3/256 · ship it', short: 'goal 3/256', running: true })
+  })
+
+  it('says armed rather than nought of a cap no round has approached', () => {
+    // `goal 0/256` reads as a progress meter stuck at zero. It is not progress
+    // at all: 256 is the deployment's round cap, and nothing has been spent.
+    expect(goalReading(cut(projection({ roundsStarted: 0 })), () => 'armed'))
+      .toEqual({ label: 'goal armed · ship it', short: 'goal armed', running: true })
+  })
+
+  it('marks a durably active goal that this process will not continue', () => {
+    // The resumed-session shape, and the whole reason for the split: the log
+    // says active, the process says disarmed, and only the second one predicts
+    // what will happen next.
+    expect(goalReading(cut(projection()), () => 'disarmed'))
+      .toEqual({ label: 'goal idle · ship it', short: 'goal idle', running: false })
+  })
+
+  it('treats an unobtainable activation as idle rather than inferring armed', () => {
+    // No goal service, no live agent, a refused read. The durable phase is
+    // still `active`, and inferring `armed` from it is the exact claim this
+    // adapter must never make.
+    expect(goalReading(cut(projection()), () => undefined))
+      .toEqual({ label: 'goal idle · ship it', short: 'goal idle', running: false })
+  })
+
+  it('takes a stopped phase from the projection without consulting the service at all', () => {
+    // A paused, blocked, or complete goal reads the same whatever activation
+    // says, so asking is a pointless service call on a line redrawn by every
+    // spinner beat — and a call the service documents as able to throw.
+    for (const phase of ['paused', 'blocked', 'complete'] as const) {
+      const source = activationSource('armed')
+      expect(goalReading(cut(projection({ phase })), source.read), phase)
+        .toEqual({ label: `goal ${phase} · ship it`, short: `goal ${phase}`, running: false })
+      expect(source.calls(), phase).toBe(0)
+    }
+  })
+
+  it('never calls a goal running unless the projection is active and activation is armed', () => {
+    const running = (phase: GoalPhase, activation: GoalActivation): boolean =>
+      goalReading(cut(projection({ phase })), () => activation)?.running === true
+    expect(running('paused', 'armed')).toBe(false)
+    expect(running('complete', 'armed')).toBe(false)
+    expect(running('active', 'disarmed')).toBe(false)
+    expect(running('active', 'armed')).toBe(true)
+  })
+
+  it('bounds a long objective itself, so the status line never has to cut one', () => {
+    const long = goalReading(
+      cut(projection({ objective: 'migrate every call site off the deprecated adapter' })),
+      () => 'armed',
+    )
+    expect(long?.label).toBe('goal 3/256 · migrate every call site off…')
+    expect(long?.short).toBe('goal 3/256')
+  })
+
+  it('shows an escape sequence in an objective instead of obeying it', () => {
+    // A model writes the objective and it reaches the terminal on every frame.
+    expect(goalReading(cut(projection({ objective: 'ship\u001b[2Jit' })), () => 'armed')?.label)
+      .toContain('^[[2J')
+  })
+})
+
+describe('the Goal authority split', () => {
+  it('renders durable state from the projection and takes only activation from the service', () => {
+    // The distinguishing test. Both authorities answer, and they disagree about
+    // every durable field. A `GoalView` is exactly what `ctx.goals.get(agent)`
+    // returns, so an implementation that went back to reading durable state
+    // from the service would render the service's objective, phase, and counts
+    // here — and this test is the only thing that would notice.
+    const service: GoalView = {
+      id: GoalId('goal-from-service'),
+      revision: 99,
+      objective: 'a stale objective the service still remembers',
+      phase: 'complete',
+      maxGoalRounds: 25,
+      roundsStarted: 24,
+      createdAt: 5,
+      updatedAt: 6,
+      activation: 'armed',
+    }
+    const durable = projection({
+      objective: 'ship the release', phase: 'active', roundsStarted: 12, maxGoalRounds: 256,
+    })
+    const reading = goalReading(cut(durable), () => service.activation)
+    // Durable half: entirely the projection's.
+    expect(reading).toEqual({
+      label: 'goal 12/256 · ship the release',
+      short: 'goal 12/256',
+      running: true,
+    })
+    expect(reading?.label).not.toContain('stale objective')
+    expect(reading?.short).not.toContain('complete')
+    // The service's own round count, which shares no digits with `12/256`.
+    expect(reading?.short).not.toContain('24')
+
+    // Live half: entirely the service's. The same projection with a disarmed
+    // process is idle, and not one character of the durable text moves.
+    expect(goalReading(cut(durable), () => 'disarmed')).toEqual({
+      label: 'goal idle · ship the release',
+      short: 'goal idle',
+      running: false,
+    })
+  })
+
+  it('adds no dshline snapshot of its own and consumes only activation from the service', () => {
+    // Two status-frame invariants no unit test of the adapter can see. Goal
+    // shares the frame's one direct projection snapshot with Todo and the
+    // context reading rather than taking a second one, and `.activation` is the
+    // only field this frontend consumes from the goal service anywhere.
+    //
+    // Asserted against the source because neither is expressible in the type
+    // system: alpha.5 publishes no activation-only accessor, so `get()` hands
+    // back a whole `GoalView` and nothing but this stops a durable field being
+    // read off it. That call does resolve its own durable half through
+    // `sessionProjections.stateOf()` internally — a service-side read, not a
+    // dshline one, and not what this counts.
+    const source = code(new URL('../src/attachment.ts', import.meta.url))
+    const frame = source.slice(source.indexOf('const status = createStatusView('), source.indexOf('const streamView'))
+    expect(frame.match(/projections\.snapshot\(\)/gu)).toHaveLength(1)
+    expect(frame).toContain('goal: goalReading(projected, goalActivation)')
+    expect(source.match(/get\('goals'\)/gu)).toHaveLength(1)
+    expect(source).toContain('ctx.get(\'goals\')?.get(agent)?.activation')
+  })
+})
+
+/** Mount the real goal domain beside the real registry and agent store. */
+async function harness(): Promise<{ ctx: Context; agent: Agent; observer: SessionProjectionObserver }> {
+  const ctx = new Context()
+  await ctx.plugin(SessionStore)
+  await ctx.plugin(SessionProjectionRegistry)
+  await ctx.plugin(AgentRegistry)
+  await ctx.plugin(GoalService)
+  const session: Session = ctx.sessions.create()
+  // The goal service needs the registry's exact live agent and nothing else
+  // about one: no loop, no provider, no model.
+  const agent = { id: session.id, session, ctx } as unknown as Agent
+  ctx.agents.register(agent)
+  const observer = new SessionProjectionObserver({
+    registry: ctx.sessionProjections, session, invalidate: () => {},
+  })
+  return { ctx, agent, observer }
+}
+
+describe('the real Alpha.5 Goal service and session projection', () => {
+  it('reads the durable goal from the registry and activation from the service', async () => {
+    const { ctx, agent, observer } = await harness()
+    const created = ctx.goals.create(agent, { objective: 'ship the release', maxGoalRounds: 8 })
+    // One admitted continuation round, recorded the way the real goal round
+    // driver records it: a `user/message` attributed to the goal, folded into
+    // `roundsStarted` by the real projection unit.
+    agent.session.append('user/message', createUserMessage({
+      content: [{ type: 'text', text: 'continue' }],
+      source: { kind: 'goal', goalId: created.id, revision: created.revision, round: 1 },
+    }), { surfaceOp: 'append' })
+
+    const durable = observer.snapshot()?.values.goal
+    expect(durable?.goal.objective).toBe('ship the release')
+    expect(durable?.goal.phase).toBe('active')
+    expect(durable?.roundsStarted).toBe(1)
+    // Activation is deliberately absent from the durable projection value.
+    expect(durable).not.toHaveProperty('activation')
+
+    expect(goalReading(observer.snapshot(), () => ctx.goals.get(agent)?.activation))
+      .toEqual({ label: 'goal 1/8 · ship the release', short: 'goal 1/8', running: true })
+    observer.dispose()
+  })
+
+  it('reports idle after a real disarm, with the durable projection untouched', async () => {
+    // The acceptance case for the whole change. `disarm()` is process-local: it
+    // writes no `goal/change`, advances no revision, and notifies no listener.
+    // A projection observer therefore cannot see it, which is exactly why the
+    // service is still consulted for this one fact.
+    const { ctx, agent, observer } = await harness()
+    ctx.goals.create(agent, { objective: 'ship the release', maxGoalRounds: 8 })
+    const before = observer.snapshot()
+    expect(goalReading(before, () => ctx.goals.get(agent)?.activation)?.running).toBe(true)
+
+    ctx.goals.disarm(agent)
+
+    const after = observer.snapshot()
+    // Durable authority: unchanged, still active, same revision, same cut.
+    expect(after?.values.goal).toEqual(before?.values.goal)
+    expect(after?.values.goal?.goal.phase).toBe('active')
+    expect(after?.asOfSeq).toBe(before?.asOfSeq)
+    // Live authority: disarmed.
+    expect(ctx.goals.get(agent)?.activation).toBe('disarmed')
+    // dshline joins the two into the one reading neither could give alone.
+    expect(goalReading(after, () => ctx.goals.get(agent)?.activation))
+      .toEqual({ label: 'goal idle · ship the release', short: 'goal idle', running: false })
+    observer.dispose()
+  })
+
+  it('starts a reopened session idle and rearms only on a real resume', async () => {
+    // The `agent/session-start` edge the service installs is what makes every
+    // reopened session start disarmed; `resume()` is the authorized way back.
+    const { ctx, agent, observer } = await harness()
+    const created = ctx.goals.create(agent, { objective: 'ship the release', maxGoalRounds: 8 })
+    ctx.emit('agent/session-start', { agent, session: agent.session })
+    expect(observer.snapshot()?.values.goal?.goal.phase).toBe('active')
+    expect(goalReading(observer.snapshot(), () => ctx.goals.get(agent)?.activation))
+      .toEqual({ label: 'goal idle · ship the release', short: 'goal idle', running: false })
+
+    ctx.goals.resume(agent, { id: created.id, revision: created.revision })
+    expect(goalReading(observer.snapshot(), () => ctx.goals.get(agent)?.activation)?.running).toBe(true)
+    observer.dispose()
+  })
+
+  it('takes a real pause, block, and complete from the projection alone', async () => {
+    const { ctx, agent, observer } = await harness()
+    const created = ctx.goals.create(agent, { objective: 'ship the release', maxGoalRounds: 8 })
+    const paused = ctx.goals.pause(agent, { id: created.id, revision: created.revision })
+    const never = activationSource('armed')
+    expect(goalReading(observer.snapshot(), never.read)?.short).toBe('goal paused')
+
+    const resumed = ctx.goals.resume(agent, { id: paused.id, revision: paused.revision })
+    const blocked = ctx.goals.block(agent, { id: resumed.id, revision: resumed.revision }, {
+      code: 'needs-input', message: 'waiting on a decision',
+    })
+    expect(goalReading(observer.snapshot(), never.read)?.short).toBe('goal blocked')
+
+    ctx.goals.complete(agent, { id: blocked.id, revision: blocked.revision })
+    expect(goalReading(observer.snapshot(), never.read)?.short).toBe('goal complete')
+    // Not one of those three needed the live service.
+    expect(never.calls()).toBe(0)
+    observer.dispose()
+  })
+
+  it('drops the segment when a real clear leaves no current goal', async () => {
+    const { ctx, agent, observer } = await harness()
+    const created = ctx.goals.create(agent, { objective: 'ship the release' })
+    ctx.goals.clear(agent, { id: created.id, revision: created.revision })
+    expect(observer.snapshot()?.values.goal).toBeNull()
+    expect(goalReading(observer.snapshot(), () => ctx.goals.get(agent)?.activation)).toBeUndefined()
+    observer.dispose()
+  })
+})

--- a/packages/dshline/tests/modes.spec.ts
+++ b/packages/dshline/tests/modes.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import type { GoalView } from '@deepseek-ai/dsh-goal'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
-import { goalReading, planModeAfter } from '../src/modes.ts'
+import { planModeAfter } from '../src/modes.ts'
 
 /**
  * One log event, with only the fields the fold reads.
@@ -11,22 +10,6 @@ import { goalReading, planModeAfter } from '../src/modes.ts'
  */
 function event(type: string, data: unknown = {}): SessionEvent {
   return { type, data } as unknown as SessionEvent
-}
-
-/**
- * The goal service's view of one goal.
- * @param over - the fields that matter to this test.
- * @returns the view.
- */
-function view(over: Partial<GoalView>): GoalView {
-  return {
-    objective: 'ship it',
-    phase: 'active',
-    activation: 'armed',
-    roundsStarted: 3,
-    maxGoalRounds: 256,
-    ...over,
-  } as unknown as GoalView
 }
 
 describe('planModeAfter()', () => {
@@ -66,59 +49,5 @@ describe('planModeAfter()', () => {
 
   it('reads a log with no such event as inactive', () => {
     expect([event('turn/start'), event('turn/end')].reduce(planModeAfter, false)).toBe(false)
-  })
-})
-
-describe('goalReading()', () => {
-  it('reports nothing when there is no goal', () => {
-    expect(goalReading(undefined)).toBeUndefined()
-  })
-
-  it('counts the rounds while the goal is running, and says what it is', () => {
-    // "How far through" is the question about a run nobody watched start, and
-    // "what is it" is the question about a goal nobody set — which happens, since
-    // the harness's create_goal tool is model-callable.
-    expect(goalReading(view({}))).toEqual({ label: 'goal 3/256 · ship it', short: 'goal 3/256', running: true })
-  })
-
-  it('says armed rather than nought of a cap no round has approached', () => {
-    // `goal 0/256` reads as a progress meter stuck at zero. It is not progress at
-    // all: 256 is the deployment's round cap, and nothing has been spent against
-    // it. The count earns its place once there is a count to report.
-    expect(goalReading(view({ roundsStarted: 0 })))
-      .toEqual({ label: 'goal armed · ship it', short: 'goal armed', running: true })
-  })
-
-  it('marks a goal that is set but will not continue on its own', () => {
-    // Every reopened session starts here: activation is process-local and never
-    // persisted, so a resumed log holding an active goal is not a session about
-    // to run one. The round count alone would say otherwise.
-    expect(goalReading(view({ activation: 'disarmed' })))
-      .toEqual({ label: 'goal idle · ship it', short: 'goal idle', running: false })
-  })
-
-  it('replaces the count with the phase once the goal is not active', () => {
-    // The round number of a paused goal is history, not progress.
-    for (const phase of ['paused', 'blocked', 'complete'] as const) {
-      expect(goalReading(view({ phase })), phase)
-        .toEqual({ label: `goal ${phase} · ship it`, short: `goal ${phase}`, running: false })
-    }
-  })
-
-  it('bounds a long objective itself, so the status line never has to cut one', () => {
-    const long = goalReading(view({ objective: 'migrate every call site off the deprecated adapter' }))
-    expect(long?.label).toBe('goal 3/256 · migrate every call site off…')
-    expect(long?.short).toBe('goal 3/256')
-  })
-
-  it('shows an escape sequence in an objective instead of obeying it', () => {
-    // A model writes the objective and it reaches the terminal on every frame.
-    expect(goalReading(view({ objective: 'ship\u001b[2Jit' }))?.label).toContain('^[[2J')
-  })
-
-  it('never calls a goal running unless it is both active and armed', () => {
-    expect(goalReading(view({ phase: 'paused', activation: 'armed' }))?.running).toBe(false)
-    expect(goalReading(view({ phase: 'active', activation: 'disarmed' }))?.running).toBe(false)
-    expect(goalReading(view({ phase: 'active', activation: 'armed' }))?.running).toBe(true)
   })
 })

--- a/tools/capability-probes.mjs
+++ b/tools/capability-probes.mjs
@@ -46,8 +46,12 @@ export const CAPABILITY_PROBES = [
   },
   {
     name: 'sessionProjections',
-    files: ['packages/dshline/tests/todos.spec.ts', 'packages/dshline/tests/permission.spec.ts'],
-    note: 'Todo and permission projection acceptance tests',
+    files: [
+      'packages/dshline/tests/todos.spec.ts',
+      'packages/dshline/tests/goals.spec.ts',
+      'packages/dshline/tests/permission.spec.ts',
+    ],
+    note: 'Todo, Goal, and permission projection acceptance tests',
   },
   {
     name: 'workflows',


### PR DESCRIPTION
## What

Harness 0.1.2-alpha.5 gives Goal two authorities. dshline was reading both from one of them.

`ctx.goals.get(agent)` returns a complete `GoalView`, so the status line's objective, phase, round count, and round cap arrived through the service — even though Harness publishes every one of those fields on the standard `goal` session projection, which dshline already observes for Todo and context occupancy.

This splits the read along the seam upstream actually draws.

```text
Harness `goal` projection
        ↓ durable state
shared SessionProjectionObserver
        ↓ same snapshot cut as Todo/context
Goal presentation adapter

ctx.goals
        ↓ activation only
Goal presentation adapter
```

| | Owner | Fields |
|---|---|---|
| **Durable / log-derived** | `ctx.sessionProjections` `goal` unit | identity, revision, objective, phase, blocked reason, `maxGoalRounds`, `roundsStarted`, `createdAt`, `updatedAt` |
| **Live / process-local** | `ctx.goals` | `activation` — and nothing else |

## The durable half

Comes out of the **existing** `projections.snapshot()` call in the status frame. Goal adds no second direct dshline snapshot, no second observer, no local fold of `goal/change`, no dshline-owned goal state, no cache.

## The live half

Stays a service call because it has to. Activation is process-local and never persisted, and `disarm()` changes it with no `goal/change` event, no revision, and no `goal/changed` notification — a projection observer cannot reconstruct or own it.

So it is read at render time, never cached, and asked for only when it can change the reading: never for an absent projected goal, never for a paused, blocked, or complete one. The entire remaining use of the goal service is one expression:

```ts
ctx.get('goals')?.get(agent)?.activation
```

An activation that cannot be obtained is never taken for `armed`. A resumed session holding a durably active goal reports `goal idle` rather than claiming this process will continue it — which is exactly the state every reopened session starts in, since the service disarms on `agent/session-start`.

### One precision about the read count

The accurate claim is *one direct dshline projection snapshot per status frame*, not *one projection access in the process*.

`GoalService.get()` resolves its own durable half through `sessionProjections.stateOf(session, 'goal')` before combining it with process-local runtime state. That inner read belongs to the service, not to this frontend, and `.activation` is the only field dshline consumes from what it returns — so the authority split is exact even though it is not yet physically narrow. Comments, tests, architecture prose, and the changeset all say it that way.

## Shape

Goal becomes a small **concrete** projection-domain adapter beside Todo's, in `src/goals/model.ts`. It takes the projection cut and an activation thunk rather than a Cordis context, which is what lets it decide whether the service is consulted at all. `modes.ts` keeps only Plan's documented event fold.

No generic `ProjectionAdapter` abstraction — ROADMAP explicitly does not need one yet.

## UX

Unchanged. Same wording (`armed` / `N/MAX` / `idle` / `paused` / `blocked` / `complete`), same colour rule, same objective escaping, same 28-column elision, same indivisible high-priority segment, same degradation order.

## Tests

16 tests in `tests/goals.spec.ts`, written to fail if somebody later moves Goal back to service-owned presentation.

**The distinguishing case** feeds contradictory authorities: a real `GoalView` carrying a stale objective, `phase: 'complete'`, and 24/25, alongside a projection carrying the real objective, `active`, and 12/256. The rendered durable text must be entirely the projection's; activation alone must decide running.

Also covered: active+armed, active+disarmed, unobtainable activation; paused/blocked/complete taken from the projection with the activation source proven *never called*; three distinct absences (no registry / unregistered key / `null`) producing no false Goal; escaping and elision.

**Real-Harness acceptance** mounts the actual `GoalService`, `SessionProjectionRegistry`, `AgentRegistry`, and `SessionStore` — no fake of upstream Goal behavior. The valuable case: create an active goal, observe its durable projection, `disarm()` it for real, then prove the projection is byte-identical at the same `asOfSeq`, the live activation is `disarmed`, and dshline combines the two into `goal idle`. Plus a real goal-attributed `user/message` advancing `roundsStarted` through the real fold, a real session-start → `resume()` round trip, and real pause/block/complete/clear.

Each claim was checked by breaking it on purpose: dropping `activation()` from `running` fails 6 tests by name; a second service read fails the invariant test.

**One source-text test remains**, over `attachment.ts`: the status frame takes one direct snapshot, and `.activation` is the only field read off the goal service. Neither is expressible in the type system while `get()` returns a whole view. The earlier grep over the adapter's own source was dropped — the adapter's signature (`ProjectionSnapshot` + activation thunk, no context, no agent) and the contradictory-authority behavioral test already enforce that boundary, so it added no unique protection.

The `sessionProjections` capability probe now points at this suite alongside Todo's.

## Docs

`docs/architecture.md` and `ROADMAP.md` describe what exists rather than what was planned; the ROADMAP Goal item moves from *Next* to *implemented*, and both carry the `stateOf()` precision above. Chinese counterparts patched minimally against this diff and both `.i18n.yaml` pairings re-recorded — no whole-document retranslation.

## Upstream limitation

Alpha.5 exposes no activation-only accessor and no activation-change event, so the whole `GoalView` is the only way in and the single-field discipline is enforced by a source-level test rather than by the API. An upstream activation-only accessor would also remove the service-side `stateOf()` read and make the logical split physically narrow. Not proposed or implemented here.

`get()` also has two failure modes a status frame must survive — `GOAL_AGENT_NOT_LIVE`, and a plain `Error` when the projection is unregistered or its strict replay failed — both guarded. Nothing upstream was patched.

## Rebase

Rebased onto current `main` (`eb46c11`, PR #139). Only conflict was the `docs/architecture.i18n.yaml` hash record, resolved to main's values and then re-recorded from the settled content. #139's prerelease-residue cleanup — the deleted `src/commands.ts` arity probe, the direct `ctx.commands.execute` calls, the `themes/settings.ts` bridge removal, and the corrected `questions.ts` prose in both languages — is intact.

## Verification (from the rebased head)

```
pnpm typecheck               ✓
pnpm test                    ✓  2556 passed | 22 skipped (125 files)
pnpm build                   ✓
pnpm run verify-docs         ✓  9 bilingual pairs consistent
node tools/harness-target.mjs
                             ✓  0.1.2-alpha.5 @ db6bdc35, every dsh-* spec exact
node tools/capability-report.mjs
                             ✓  sessionProjections (Todo, Goal, and permission
                                projection acceptance tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
