### PR TITLE
fix(dshline): keep root live rows inside the terminal below the chrome floor

### DIFF
--- a/.changeset/narrow-root-fallback.md
+++ b/.changeset/narrow-root-fallback.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': patch
+---
+
+Fix the root composer and status line so they never ask the terminal to draw a row wider than itself below the chrome floor (terminals narrower than 12 columns). Previously the shared root frame's 12-column presentation floor, and the status line's 10-column budget floor, could both exceed a narrower real terminal; `Screen` re-wrapped the overlong logical row into extra physical ones after the live region had already been budgeted in logical rows, which invalidated the live-region height assumptions. Below the floor, the composer now draws its own rows directly against the terminal's width with no frame, keeping an editable buffer and a valid cursor; the status line now bounds its budget to the real width and gives up entirely when there is no room at all. Widths at or above 12 columns are unchanged.

--- a/packages/dshline/src/chrome.ts
+++ b/packages/dshline/src/chrome.ts
@@ -8,6 +8,21 @@ import { BOX_CHROME_COLUMNS, displayWidth, frame, paint } from '@dshline/rendere
 /** Widest the chrome will draw, so a maximized terminal keeps readable lines. */
 const MAX_COLUMNS = 100
 
+/**
+ * Narrowest terminal that still gets the normal framed chrome.
+ *
+ * Below this, {@link chromeWidth} would ask for a frame wider than the
+ * terminal itself — safe for `frame()`, which leaves the width choice to its
+ * caller, but not for a live-region view: `Screen` re-wraps an overlong
+ * logical row into several physical ones, which invalidates the live-region
+ * height budgeting done above it. Presentation that draws the root live
+ * region (the composer, the status line) must fall back to something bounded
+ * by the terminal itself below this floor, rather than asking for this width.
+ * The one shared definition, so the floor is not a literal repeated at every
+ * call site that needs to know it.
+ */
+export const CHROME_MIN_COLUMNS = BOX_CHROME_COLUMNS + 8
+
 /** One rendering of the dshline visual root. */
 export interface RootFrameOptions {
   /** The terminal's current width; the frame width is derived from it. */
@@ -27,7 +42,7 @@ export interface RootFrameOptions {
  * @returns the width every framed element uses.
  */
 export function chromeWidth(columns: number): number {
-  return Math.max(BOX_CHROME_COLUMNS + 8, Math.min(columns - 1, MAX_COLUMNS))
+  return Math.max(CHROME_MIN_COLUMNS, Math.min(columns - 1, MAX_COLUMNS))
 }
 
 /**

--- a/packages/dshline/src/views.ts
+++ b/packages/dshline/src/views.ts
@@ -24,7 +24,7 @@ import {
 } from '@dshline/renderer'
 import type { CardDetail } from './cards.ts'
 import type { ActivityWord } from './activity.ts'
-import { chromeWidth, rootFrame } from './chrome.ts'
+import { CHROME_MIN_COLUMNS, chromeWidth, rootFrame } from './chrome.ts'
 import type { BusyEnter } from './delivery.ts'
 import { DEFAULT_BUSY_ENTER } from './delivery.ts'
 import type { TuiSlotView } from './slots.ts'
@@ -240,10 +240,62 @@ export function createComposerView(
   /** Row of the frame's first content line, which the separator's presence moves. */
   const contentRowOffset = (rows: number | undefined): number => keepsSeparator(rows) ? 2 : 1
 
+  /**
+   * Gutter for the pathological-width fallback, truncated to fit the terminal
+   * itself rather than the frame's inner width.
+   *
+   * Below {@link CHROME_MIN_COLUMNS} there is no frame, so the gutter has
+   * nothing to share the row with but the terminal's own width. Truncating it
+   * here — the same width `layoutComposer` chunks against — is what keeps
+   * every row `chunkLine` produces inside `columns` even when the prompt
+   * itself cannot fit whole.
+   * @param columns - the terminal's current width.
+   * @returns the gutter function for `layoutComposer`.
+   */
+  const narrowGutter = (columns: number) => (line: number): string =>
+    truncateToWidth(line === 0 ? PROMPT : CONTINUATION, Math.max(0, columns))
+
+  /**
+   * The composer laid out directly against the terminal's width, with no
+   * frame around it. See {@link layout} for the framed equivalent.
+   * @param columns - the terminal's current width.
+   * @returns the rows and the cursor's row and column within them.
+   */
+  const narrowLayout = (columns: number): { rows: readonly string[]; row: number; column: number } => {
+    const found = layoutComposer(composer, Math.max(1, columns), narrowGutter(columns))
+    return { rows: found.rows, row: found.cursorRow, column: found.cursorColumn }
+  }
+
+  /** Rows outside the composer's own content in the fallback: no borders, just the optional separator. */
+  const NARROW_FIXED_ROWS = 1
+
+  /** Content rows the fallback may spend, the same accounting as {@link contentBudget} without the borders. */
+  const narrowContentBudget = (rows: number | undefined): number =>
+    rows === undefined ? COMPOSER_ROWS : rows - Math.max(0, rowsBelow()) - NARROW_FIXED_ROWS
+
+  /** Whether the fallback keeps the blank separator, by the same rule as {@link keepsSeparator}. */
+  const narrowKeepsSeparator = (rows: number | undefined): boolean =>
+    rows === undefined || NARROW_FIXED_ROWS + 1 <= rows - Math.max(0, rowsBelow())
+
+  /** Row of the fallback's first content line, which the separator's presence moves. */
+  const narrowContentRowOffset = (rows: number | undefined): number => narrowKeepsSeparator(rows) ? 1 : 0
+
   return {
     // A blank line above separates the frame from whatever the transcript just
     // committed, so a reply and the input box do not read as one block.
     render: (columns, terminalRows = 24) => {
+      // Below the shared chrome floor, `rootFrame` would ask for a frame wider
+      // than the terminal: `Screen` re-wraps that AFTER this view has already
+      // budgeted the live region, which is exactly what invalidates it. There
+      // is no width left for chrome at all here, so the fallback draws the
+      // composer's own rows directly against `columns`, with no frame and no
+      // hint — editable text and a valid cursor are the only things a terminal
+      // this narrow is guaranteed to have room for.
+      if (columns < CHROME_MIN_COLUMNS) {
+        const { rows, row } = narrowLayout(columns)
+        const shown = window(rows, row, narrowContentBudget(terminalRows))
+        return narrowKeepsSeparator(terminalRows) ? ['', ...shown.rows] : [...shown.rows]
+      }
       if (composer.isEmpty) {
         // One row, chosen to fit — never `chunkToWidth`, which would wrap it and
         // make this the only view in the live region that can outgrow its budget.
@@ -271,6 +323,11 @@ export function createComposerView(
       return keepsSeparator(terminalRows) ? ['', ...framed] : [...framed]
     },
     cursor: (columns, rows): LiveCursor => {
+      if (columns < CHROME_MIN_COLUMNS) {
+        const { rows: every, row, column } = narrowLayout(columns)
+        const shown = window(every, row, narrowContentBudget(rows))
+        return { row: narrowContentRowOffset(rows) + row - shown.offset, column }
+      }
       if (composer.isEmpty) return { row: contentRowOffset(rows), column: 2 + displayWidth(PROMPT) }
       const { rows: every, row, column } = layout(columns)
       const shown = window(every, row, contentBudget(rows))
@@ -435,8 +492,16 @@ export function pressureBar(
 export function createStatusView(state: () => StatusState): TuiSlotView {
   return {
     render(columns) {
+      // The old `Math.max(10, ...)` floor gave this line a presentation-only
+      // minimum independent of the terminal, so a terminal narrower than 12
+      // columns got a budget wider than itself and the two-column indent
+      // pushed the drawn row past the real width. `columns - 2` alone is safe
+      // at every width down to zero: it is never larger than `columns`, and it
+      // matches the old floor exactly once `columns - 2` reaches 10 on its
+      // own, so nothing above that width changes.
+      const budget = Math.max(0, columns - 2)
+      if (budget <= 0) return []
       const current = state()
-      const budget = Math.max(10, columns - 2)
       const separator = paint(' · ', 'chrome')
 
       // Facts first, in the order they matter. These are never dropped: a status

--- a/packages/dshline/tests/narrow-root.spec.ts
+++ b/packages/dshline/tests/narrow-root.spec.ts
@@ -74,15 +74,20 @@ async function drawnRoot(composer: Composer, columns: number): Promise<{
 }
 
 describe('the root live region below the chrome floor', () => {
-  it('never emits a logical row wider than the terminal', () => {
-    for (const columns of [1, 2, 3, 5, 8, 9, 10, 11]) {
-      const slots = new TuiSlots(new Context())
-      slots.register('composer', createComposerView(typed('hello world'), '/work/repo'))
-      slots.register('status', createStatusView(() => BUSY))
-      const { lines } = slots.compose(columns, ROWS)
-      for (const line of lines) {
-        expect(displayWidth(line), `${String(columns)} columns: ${JSON.stringify(line)}`)
-          .toBeLessThanOrEqual(columns)
+  it('never emits a logical row wider than the terminal, at every width below the floor', () => {
+    // The fundamental invariant: cheap enough (no terminal, no emulator) to
+    // prove exhaustively rather than sample. Both an empty and a populated
+    // composer, since the two take different code paths through the view.
+    for (let columns = 1; columns < CHROME_MIN_COLUMNS; columns += 1) {
+      for (const composer of [new Composer(), typed('hello world')]) {
+        const slots = new TuiSlots(new Context())
+        slots.register('composer', createComposerView(composer, '/work/repo'))
+        slots.register('status', createStatusView(() => BUSY))
+        const { lines } = slots.compose(columns, ROWS)
+        for (const line of lines) {
+          expect(displayWidth(line), `${String(columns)} columns: ${JSON.stringify(line)}`)
+            .toBeLessThanOrEqual(columns)
+        }
       }
     }
   })

--- a/packages/dshline/tests/narrow-root.spec.ts
+++ b/packages/dshline/tests/narrow-root.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * The root live region below the shared chrome floor.
+ *
+ * `chromeWidth` never draws a frame narrower than `CHROME_MIN_COLUMNS`, so at a
+ * terminal below that floor a framed row is wider than the terminal itself.
+ * `Screen` re-wraps that AFTER the live region has already been budgeted in
+ * logical rows, which is exactly what invalidates the budget. These tests prove
+ * the presentation fallback keeps every logical row inside the real terminal at
+ * pathological widths, while leaving ordinary widths untouched.
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import { Composer, displayWidth, Screen, stripAnsi } from '@dshline/renderer'
+import { describe, expect, it } from 'vitest'
+import { createEmulator } from '../../../tests/emulator.ts'
+import { CHROME_MIN_COLUMNS } from '../src/chrome.ts'
+import { TuiSlots } from '../src/slots.ts'
+import type { StatusState } from '../src/views.ts'
+import { createComposerView, createStatusView } from '../src/views.ts'
+
+const ROWS = 24
+
+/** A busy, richly-populated status, which is the widest thing this view ever draws. */
+const BUSY: StatusState = {
+  busy: true,
+  tick: 0,
+  elapsedMs: 4_000,
+  activityWord: 'thinking',
+  activity: undefined,
+  model: 'deepseek-v4-flash',
+  effort: undefined,
+  usage: undefined,
+  tokens: undefined,
+  contextWindow: undefined,
+  detail: 'compact',
+  work: undefined,
+  pending: undefined,
+  todo: undefined,
+  plan: false,
+  replay: undefined,
+  goal: undefined,
+}
+
+/**
+ * A composer holding `text`, cursor at the end, as typing it would leave it.
+ * @param text - the content to type.
+ * @returns the composer.
+ */
+function typed(text: string): Composer {
+  const composer = new Composer()
+  composer.handle({ kind: 'paste', text })
+  return composer
+}
+
+/**
+ * Compose the root live region — composer and status together, the runner's
+ * own registration order — and draw it through a real `Screen` and terminal.
+ * @param composer - the composer to draw.
+ * @param columns - the terminal width.
+ * @returns the visible rows and where the terminal actually left the cursor.
+ */
+async function drawnRoot(composer: Composer, columns: number): Promise<{
+  rows: string[]
+  cursor: { column: number; row: number }
+}> {
+  const slots = new TuiSlots(new Context())
+  slots.register('composer', createComposerView(composer, '/work/repo'))
+  slots.register('status', createStatusView(() => BUSY))
+  const composed = slots.compose(columns, ROWS)
+  const emulator = createEmulator(columns, ROWS)
+  const screen = new Screen(emulator.target)
+  screen.setLive(composed.lines, composed.cursor)
+  return { rows: (await emulator.screen()).map(row => row.trimEnd()), cursor: await emulator.cursor() }
+}
+
+describe('the root live region below the chrome floor', () => {
+  it('never emits a logical row wider than the terminal', () => {
+    for (const columns of [1, 2, 3, 5, 8, 9, 10, 11]) {
+      const slots = new TuiSlots(new Context())
+      slots.register('composer', createComposerView(typed('hello world'), '/work/repo'))
+      slots.register('status', createStatusView(() => BUSY))
+      const { lines } = slots.compose(columns, ROWS)
+      for (const line of lines) {
+        expect(displayWidth(line), `${String(columns)} columns: ${JSON.stringify(line)}`)
+          .toBeLessThanOrEqual(columns)
+      }
+    }
+  })
+
+  it('stays editable with the cursor immediately after typed text, below six columns', async () => {
+    // No exact-fill roll-over at this width and length: `› ab` is four display
+    // columns inside a five-column budget, so the cursor stays on the same row
+    // as the text rather than moving to the fresh row a filled one gets.
+    const { rows, cursor } = await drawnRoot(typed('ab'), 5)
+    const row = rows[cursor.row] ?? ''
+    expect(row).toContain('ab')
+    expect(cursor.column).toBeLessThanOrEqual(5)
+    expect(row.slice(0, cursor.column).endsWith('ab')).toBe(true)
+  })
+
+  it('stays editable with the cursor immediately after typed text, in the eight-to-eleven range', async () => {
+    for (const columns of [8, 9, 11]) {
+      const { rows, cursor } = await drawnRoot(typed('hello'), columns)
+      const row = rows[cursor.row] ?? ''
+      expect(cursor.column).toBeLessThanOrEqual(columns)
+      expect(row.slice(0, cursor.column).endsWith('hello')).toBe(true)
+    }
+  })
+
+  it('keeps a valid cursor at the narrowest possible terminal, one column wide', async () => {
+    // `› ` cannot fit at all here, and neither can the exact-fill prompt glyph
+    // alongside a typed character, so this is the case that forces the
+    // roll-to-a-fresh-row behaviour every row in this view has to honour.
+    const { rows, cursor } = await drawnRoot(typed('x'), 1)
+    expect(displayWidth(rows[cursor.row] ?? ''), 'row under the cursor').toBeLessThanOrEqual(1)
+    // The character just typed is the row above the fresh cursor row.
+    const above = rows[cursor.row - 1] ?? ''
+    expect(above).toContain('x')
+    expect(cursor.column).toBe(0)
+  })
+
+  it('keeps the empty composer editable with a valid cursor down to one column', async () => {
+    for (const columns of [1, 3, 5, 8, 11]) {
+      const { rows, cursor } = await drawnRoot(new Composer(), columns)
+      expect(cursor.row).toBeGreaterThanOrEqual(0)
+      expect(cursor.column).toBeLessThanOrEqual(columns)
+      for (const row of rows) expect(displayWidth(row)).toBeLessThanOrEqual(columns)
+    }
+  })
+
+  it("the status view cannot independently exceed the terminal's width, and may surrender entirely", () => {
+    for (const columns of [1, 2, 3, 5, 8, 11]) {
+      const lines = createStatusView(() => BUSY).render(columns)
+      for (const line of lines) expect(displayWidth(line)).toBeLessThanOrEqual(columns)
+    }
+    // At the narrowest widths there is no room even for the indent, so the
+    // status line gives up entirely rather than drawing a fragment.
+    expect(createStatusView(() => BUSY).render(1)).toEqual([])
+    expect(createStatusView(() => BUSY).render(2)).toEqual([])
+  })
+})
+
+describe('the root live region at and above the chrome floor', () => {
+  it(`keeps the normal framed chrome at width ${String(CHROME_MIN_COLUMNS)} and ordinary widths`, () => {
+    // At the floor itself the label is already tight enough to truncate — that
+    // is unchanged pre-existing behaviour, not this fix — so only the frame's
+    // presence is asserted there; the full label is asserted where it fits.
+    for (const columns of [CHROME_MIN_COLUMNS, 20, 40, 80]) {
+      const lines = createComposerView(new Composer(), '/work/repo').render(columns)
+      expect(lines.some(line => stripAnsi(line).includes('╭')), `${String(columns)} columns`).toBe(true)
+    }
+    for (const columns of [20, 40, 80]) {
+      const lines = createComposerView(new Composer(), '/work/repo').render(columns)
+      expect(stripAnsi(lines.join('\n')), `${String(columns)} columns`).toContain('dshline')
+    }
+  })
+
+  it(`keeps the status line's ordinary budget unchanged at width ${String(CHROME_MIN_COLUMNS)} and above`, () => {
+    // The old floor was `Math.max(10, columns - 2)`; at these widths
+    // `columns - 2` already reaches 10 or more, so the fix changes nothing here.
+    // At the floor itself the word is already tight enough to truncate — that
+    // is unchanged pre-existing behaviour — so the full word is asserted only
+    // where it comfortably fits.
+    for (const columns of [CHROME_MIN_COLUMNS, 20, 40, 80]) {
+      const line = createStatusView(() => BUSY).render(columns)[0] ?? ''
+      expect(displayWidth(line)).toBeLessThanOrEqual(columns)
+    }
+    for (const columns of [20, 40, 80]) {
+      const line = createStatusView(() => BUSY).render(columns)[0] ?? ''
+      expect(stripAnsi(line)).toContain('thinking')
+    }
+  })
+})

--- a/tools/consumer-smoke.mjs
+++ b/tools/consumer-smoke.mjs
@@ -58,6 +58,21 @@ const PLUGIN_PACKAGE_NAME = '@dshline/dshline'
 const RENDERER_PACKAGE_NAME = '@dshline/renderer'
 const PROFILE_NAME = 'dshline'
 
+/**
+ * The pseudo-terminal's geometry, an ordinary terminal size rather than
+ * whatever `script(1)` leaves unconfigured.
+ *
+ * This check proves a normal packaged startup, not narrow-terminal
+ * presentation — that is `packages/dshline/tests/narrow-root.spec.ts`'s job,
+ * against the real code paths rather than a captured transcript. Left
+ * unconfigured, a pty with no controlling terminal to inherit from (which is
+ * every CI runner) can come up at an unusably small size, and a startup that
+ * genuinely never reaches `ready` at that size can still read as evidence
+ * this check passed.
+ */
+const PTY_COLUMNS = 80
+const PTY_ROWS = 24
+
 /** How long the boot may take to show its banner before this is a failure. */
 export const BOOT_TIMEOUT_MS = 60_000
 
@@ -384,7 +399,16 @@ function shellWord(argument) {
  * @returns the spawned, fully piped child.
  */
 function ptySpawn(argv, { cwd, env, transcript }) {
-  const inner = argv.map(part => shellWord(part)).join(' ')
+  // `stty` sets the pty's winsize the moment it is this shell's controlling
+  // terminal, which `script(1)` has just made it — before the real command
+  // ever reads it. `shift 2` drops the size arguments so `"$@"` is exactly
+  // `argv` again, so the numbers travel as ordinary arguments rather than
+  // being spliced into the script text.
+  const sized = [
+    'bash', '-c', 'stty cols "$1" rows "$2" && shift 2 && exec "$@"',
+    'bash', String(PTY_COLUMNS), String(PTY_ROWS), ...argv,
+  ]
+  const inner = sized.map(part => shellWord(part)).join(' ')
   const line = process.platform === 'linux'
     ? `exec script -qec ${shellWord(inner)} ${shellWord(transcript)}`
     : `exec script -q ${shellWord(transcript)} ${inner} < <(cat)`


### PR DESCRIPTION
## Summary

- `chromeWidth()` floors the shared root frame at 12 columns and the status line floored its own budget at 10, both independent of the real terminal width. Below 12 columns this asked `rootFrame()` for a frame wider than the terminal; `Screen` correctly re-wraps that, but only after the live region had already been budgeted in logical rows — invalidating the budget.
- Below the shared chrome floor (`CHROME_MIN_COLUMNS`, extracted as the one shared definition), the composer now draws its own rows directly against the terminal's width with no frame — editable text and a valid cursor, no hint. The status line bounds its budget to the real width and surrenders entirely when there is no room.
- Widths at or above 12 columns are byte-for-byte unchanged; overlays are untouched.
- Consumer smoke now establishes a deterministic 80×24 PTY before boot, so ordinary packaged-startup coverage no longer depends on whatever zero/unconfigured size `script(1)` inherits in CI. The old smoke could run under a 0×0/unconfigured PTY; the old width bug happened to still emit garbled text containing `ready` there, so it passed by accident. With the real fix, status correctly disappears at pathological widths, which exposed the smoke's own invalid terminal setup rather than a regression — the smoke now proves ordinary packaged startup at 80×24, and `narrow-root.spec.ts` remains the authority for pathological-width behavior.

## Test plan

- [x] `packages/dshline/tests/narrow-root.spec.ts` (new): the fundamental width invariant is checked exhaustively for every positive width below the chrome floor (1–11); composer/cursor stays valid at width 1, 5, and 8/9/11 through a real `TuiSlots.compose` + `Screen` + `@xterm/headless` emulator; status bounds itself or surrenders; width 12+ keeps the framed UI.
- [x] Deliberately broke each fix (disabled the composer fallback branch; restored the old `Math.max(10, …)` status floor) and confirmed the tests fail for the intended reason, then restored.
- [x] Deliberately ran `script(1)` with and without the PTY sizing fix: unsized comes up `0x0` in a non-interactive environment (reproducing the CI failure); with the fix, `24 80`.
- [x] `node tools/consumer-smoke.mjs --launcher-version <adopted>` and `--bootstrap` both pass locally end to end at the deterministic size.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 2660 passed, 0 failed, 22 pre-existing skips, across all 129 test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
