### PR TITLE
perf(dshline): defer Connect and Sessions browser graphs past ordinary startup

### DIFF
--- a/.changeset/defer-connect-sessions-startup.md
+++ b/.changeset/defer-connect-sessions-startup.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': patch
+---
+
+Defer the Connect and Sessions browser module graphs until they are first opened, reducing dshline's ordinary startup module-evaluation work without changing command or session behavior.

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -63,8 +63,6 @@ import { LocalCommandRegistry } from './local-commands.ts'
 import { runThemes, themeValues } from './themes/index.ts'
 import type { LocalCommandChoice } from './local-commands.ts'
 import { SessionScope } from './session-scope.ts'
-import { listConnectTargets, openConnect } from './connect/index.ts'
-import { browseSessions } from './sessions/index.ts'
 import { planNew } from './sessions/plan.ts'
 import type { AttachOutcome, AttachTarget } from './sessions/reopen.ts'
 import { shouldClearDisplay } from './sessions/reopen.ts'
@@ -603,13 +601,22 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     {
       name: 'connect',
       description: 'Configure and authenticate Harness providers',
-      complete: () => listConnectTargets(ctx),
+      // Imported on demand, like `/plugins`, `/profiles`, and `/skills` below:
+      // the browser's module graph (catalog, authorization presentation,
+      // actions, overlay, schema interpretation, route editor) is one
+      // command's UI, and startup cost a profile that never opens `/connect`
+      // should not pay.
+      complete: async () => {
+        const { listConnectTargets } = await import('./connect/index.ts')
+        return listConnectTargets(ctx)
+      },
       execute: async rawInput => {
         // Configuration is a window-level concern, not a session one, but it is
         // opened from here for the same reason every other picker is: the
         // attachment owns the keyboard while a session is up. Nothing it does
         // touches this session — a route it activates is read by the NEXT step's
         // model selection, which is what `/model` then offers.
+        const { openConnect } = await import('./connect/index.ts')
         await openConnect({ ctx, commit, query: rawInput.trim() })
         draw()
       },
@@ -704,6 +711,14 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
         // inspector; the committed transcript under it is never rewritten.
         // Reopening is the one thing it can do that outlives it, and the plan
         // that authorizes it reads the conditions at the moment enter is pressed.
+        //
+        // Imported on demand, like `/plugins`, `/profiles`, and `/connect`
+        // above: the browser's module graph (catalog, overlay, panels,
+        // lineage) is one command's UI, and `busy`/`activeWork` below are
+        // passed as live functions, so the plan below still decides against
+        // the conditions AT THE MOMENT the reader chooses a session, not at
+        // import time.
+        const { browseSessions } = await import('./sessions/index.ts')
         const chosen = await browseSessions({
           ctx,
           currentSessionId: agent.session.id,

--- a/packages/dshline/src/window.ts
+++ b/packages/dshline/src/window.ts
@@ -40,7 +40,6 @@ import type { CardDetail } from './cards.ts'
 import { pluginsSeams, sessionFacts } from './plugins/harness.ts'
 import type { AgentPresetsSeam } from './plugins/harness.ts'
 import { RedrawScheduler } from './redraw.ts'
-import { browseSessions } from './sessions/index.ts'
 import type { AttachTarget } from './sessions/reopen.ts'
 import type { TuiStartupOptions } from './startup.ts'
 import type { PeakWindow, PricingTable, UsageMode } from './usage.ts'
@@ -566,6 +565,10 @@ async function legacyPreset(
  */
 export async function chooseTarget(w: Window): Promise<AttachTarget> {
   const { ctx } = w
+  // Resolved BEFORE dispatch changes below: routing ordinary keys toward
+  // `activeOverlay` before the module that creates it is ready would open a
+  // window where delegated keystrokes are dropped. `ctrl-d` remains window-owned.
+  const { browseSessions } = await import('./sessions/index.ts')
   w.setDispatch(key => { ctx.tuiSlots.activeOverlay?.handleKey(key) })
   try {
     const chosen = await browseSessions({


### PR DESCRIPTION
## Summary

- `/connect` and `/sessions` are two substantial eagerly imported browser graphs that ordinary chat does not use. `connect/index.ts` pulls the whole provider-configuration browser (catalog, authorization, actions, overlay, schema, route editor — ~7.9k lines); `sessions/index.ts` pulls the whole session browser (catalog, overlay, panels, lineage — ~3.5k lines). `sessions/plan.ts` and `sessions/reopen.ts`, which do participate in ordinary attachment lifecycle (`/new`, resume, safety checks), stay resident and untouched.
- Both are now dynamically imported at their existing call sites instead of statically imported: `attachment.ts`'s `/connect` `complete`/`execute` and `/sessions` `execute`, and `window.ts`'s `chooseTarget` (launch-time bare `--resume`). `chooseTarget` resolves the import *before* installing browser-owned key dispatch, so there is no interval where a keystroke could be dropped or misrouted while the module loads.

## Measurement

Fresh Node v24.19.0 processes, module-eval timed via `performance.now()` around `import()`, never reused across reps. Sequential before/after blocks drifted ~4ms from thermal/background load over the session — caught by redoing the baseline and discarded. Fixed with **interleaved paired sampling**: alternate A/B process spawns and take per-pair diffs, which cancels slow drift. n=60 pairs per comparison (1 cold-cache outlier row dropped).

Combined real boot order (`window.js` → `attachment.js`, matching the actual launch sequence):

| Comparison | A median | B median | diff median | diff p95 | A>B rate |
|---|---|---|---|---|---|
| main vs Connect-lazy | 24.88ms | 22.99ms | 1.99ms | 4.71ms | 93.3% |
| Connect-lazy vs +Sessions-lazy | 22.71ms | 20.80ms | 1.86ms | 3.85ms | 100% |
| main vs Connect+Sessions | 24.45ms | 20.84ms | 3.66ms | 6.41ms | 100% |

Both cuts are real and repeatable (~100% consistent pairwise direction), not noise — about a 15% cut to dshline's own module-eval on top of PR #110's earlier work. Harness-core boot (per #110, ~570ms) is untouched.

First-use cost, measured once the resident graph is already warm: `/connect` ≈2.1ms median (p95 2.6ms), `/sessions` ≈1.6ms median (p95 2.1ms) — cheap, since shared deps (renderer, `select.ts`, `prompt.ts`) are already loaded by the resident graph.

`/model` was deliberately left eager — per the task's own scoping, only worth revisiting with a separate measurement showing a meaningful gain, which nothing here demonstrates. Work/Context overlay lazification was not evaluated since Sessions already cleared the bar on its own.

## Test plan

- [x] `pnpm build` (tsc -b) — clean
- [x] `pnpm test` — 2660 passed, 22 skipped, no failures
- [x] `node tools/harness-target.mjs` — coherent
- [x] `.changeset/defer-connect-sessions-startup.md` added (`@dshline/dshline`: patch)
- [x] Manual PTY smoke against the real linked dev profile (tmux): fresh boot banner; `/connect` completes and opens the browser; `/sessions` opens the browser; launch-time bare `--resume` shows the browser and `ctrl-d` quits cleanly from it; `--resume <session-id>` skips the browser entirely and resumes directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
