### PR TITLE
fix(dshline): make Connect authorization progress visible

### DIFF
--- a/.changeset/connect-authorization-lifecycle.md
+++ b/.changeset/connect-authorization-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': patch
+---
+
+Make dormant provider activation discoverable and keep Connect visibly waiting while an authorization attempt is still in progress.

--- a/packages/dshline/src/connect/authorize.ts
+++ b/packages/dshline/src/connect/authorize.ts
@@ -25,9 +25,11 @@
  */
 
 import type { Context } from '@deepseek-ai/cordis'
-import { escapeControls, paint } from '@dshline/renderer'
+import { BOX_CHROME_COLUMNS, escapeControls, paint, truncateToWidth } from '@dshline/renderer'
+import { chromeWidth, fitFooterHelp, footerBudget, rootFrame } from '../chrome.ts'
 import { promptSelect } from '../select.ts'
 import { promptText } from '../prompt.ts'
+import type { TuiOverlay } from '../slots.ts'
 import type {
   AuthorizationNoticeRead,
   AuthorizationPromptRead,
@@ -87,6 +89,52 @@ export function noticeLines(notice: AuthorizationNoticeRead, label: string): str
   return lines
 }
 
+/** Leading blank, four body rows, and two frame borders. */
+const WAITING_MIN_ROWS = 7
+
+/**
+ * The attempt-owned surface shown while authorization needs no human answer.
+ *
+ * A prompt pushed by {@link render} sits above this overlay and dismisses back
+ * to it, so an OAuth callback wait never exposes the Connect browser as though
+ * its action had completed.
+ * @param label - the flow's user-facing name.
+ * @param withdraw - cancels the attempt when the reader leaves this surface.
+ * @param invalidate - asks the window to redraw.
+ * @returns the waiting overlay.
+ */
+function waitingOverlay(label: string, withdraw: () => void, invalidate: () => void): TuiOverlay {
+  return {
+    render(columns, terminalRows = 24) {
+      const title = `Sign in · ${label}`
+      const width = chromeWidth(columns)
+      const inner = width - BOX_CHROME_COLUMNS
+      if (terminalRows < WAITING_MIN_ROWS || width >= columns) {
+        return [paint(truncateToWidth('◌ Waiting for authorization… · esc cancel', Math.max(1, columns)), 'muted')]
+          .slice(0, terminalRows)
+      }
+      return [
+        '',
+        ...rootFrame({
+          columns,
+          context: paint('Sign in', 'overlay-title'),
+          body: [
+            paint(truncateToWidth(escapeControls(title), inner), 'overlay-title'),
+            '',
+            paint(truncateToWidth('◌ Waiting for authorization…', inner), 'busy'),
+            paint(truncateToWidth('The authorization flow is still in progress.', inner), 'muted'),
+          ],
+          footer: fitFooterHelp('esc cancel', footerBudget(columns)),
+        }),
+      ]
+    },
+    handleKey(key) {
+      if (key.kind === 'key' && (key.name === 'escape' || key.name === 'ctrl-c')) withdraw()
+      invalidate()
+    },
+  }
+}
+
 /**
  * Run one authorization flow and report how it ended.
  *
@@ -140,6 +188,14 @@ export async function runAuthorization(spec: AuthorizeSpec): Promise<ConnectActi
     // attempt as `cancelled`; the message is only ever seen in a debug log.
     throw new Error('the authorization prompt was dismissed')
   }
+  // An OAuth callback can take minutes without requesting terminal input. Keep
+  // an attempt-owned overlay below any transient Harness prompt for that whole
+  // interval, rather than revealing the Connect browser beneath it.
+  const dismissWaiting = ctx.tuiSlots.pushOverlay(waitingOverlay(
+    label,
+    () => { controller.abort() },
+    () => { ctx.tuiSlots.invalidate() },
+  ))
   try {
     const outcome = await authorization.begin({
       key,
@@ -159,13 +215,14 @@ export async function runAuthorization(spec: AuthorizeSpec): Promise<ConnectActi
     })
     if (retiredByOwner()) return retired(label)
     if (outcome.status === 'authorized') {
-      return { kind: 'done', message: `${label}: signed in` }
+      return { kind: 'done', message: `${label}: signed in · provider routes are activated separately` }
     }
     return { kind: 'failed', message: dismissed ? `${label}: sign-in dismissed` : `${label}: sign-in cancelled` }
   } catch (error) {
     if (retiredByOwner()) return retired(label)
     return { kind: 'failed', message: `${label}: sign-in failed — ${messageOf(error)}` }
   } finally {
+    dismissWaiting()
     unwatch()
   }
 }

--- a/packages/dshline/src/connect/model.ts
+++ b/packages/dshline/src/connect/model.ts
@@ -216,6 +216,15 @@ function normalize(value: string): string {
 }
 
 /**
+ * The user-facing state of one configurable route.
+ * @param state - the internal registry state.
+ * @returns the state wording a Connect surface presents.
+ */
+function providerStateLabel(state: ConnectRouteState): string {
+  return state === 'dormant' ? 'not active' : state
+}
+
+/**
  * Whether one row answers a typed query.
  *
  * Matched against what the row SHOWS, which is the whole contract of a filter:
@@ -228,7 +237,7 @@ export function matchesRow(row: ConnectRow, query: string): boolean {
   const needle = normalize(query)
   if (needle === '') return true
   const words = row.kind === 'provider'
-    ? [row.provider, row.displayName, row.settingsNs, row.state]
+    ? [row.provider, row.displayName, row.settingsNs, providerStateLabel(row.state)]
     : row.kind === 'sign-in'
       ? [row.key, row.label, ...row.methods.map(method => method.label)]
       : [row.label]
@@ -271,10 +280,19 @@ export function providerReadiness(row: ConnectProviderRow): ConnectReadiness {
  * Whole facts, joined with a separator the row's renderer may drop from the
  * left. Each is something a surface asked Harness rather than concluded.
  * @param row - the provider row.
+ * @param capabilities - mounted seams, when the caller can determine whether activation is offered.
  * @returns the facts, most important first.
  */
-export function providerFacts(row: ConnectProviderRow): string[] {
-  const facts: string[] = [row.state]
+export function providerFacts(row: ConnectProviderRow, capabilities?: ConnectCapabilities): string[] {
+  const facts: string[] = [providerStateLabel(row.state)]
+  // A dormant route is actionable only when the same offer the picker uses says
+  // it is. Naming activation without that check would promise a settings write
+  // to a profile that cannot make one.
+  if (row.state === 'dormant'
+    && capabilities !== undefined
+    && rowActions(row, capabilities).some(action => action.id === 'activate')) {
+    facts.push('activate to add models')
+  }
   if (row.state === 'active' && row.models !== undefined) {
     facts.push(`${String(row.models)} model${row.models === 1 ? '' : 's'}`)
   }

--- a/packages/dshline/src/connect/overlay.ts
+++ b/packages/dshline/src/connect/overlay.ts
@@ -29,7 +29,7 @@ import {
 import { chromeWidth, fitFooterHelp, footerBudget, rootFrame } from '../chrome.ts'
 import { RowViewport } from '../scroll.ts'
 import type { TuiOverlay } from '../slots.ts'
-import type { ConnectCreateRow, ConnectProviderRow, ConnectRow, ConnectSignInRow, ConnectState } from './model.ts'
+import type { ConnectCapabilities, ConnectCreateRow, ConnectProviderRow, ConnectRow, ConnectSignInRow, ConnectState } from './model.ts'
 import {
   filterRows,
   providerDetail,
@@ -323,6 +323,7 @@ function render(
   if (state.kind === 'loading') return single('Reading provider configuration…', inner)
   if (state.kind === 'failed') return single(`Harness could not be read: ${state.message}`, inner)
   const rows: string[] = []
+  const capabilities = state.kind === 'ready' ? state.capabilities : undefined
   let selectedRow = 0
   let index = 0
   sections.forEach((section, position) => {
@@ -335,7 +336,7 @@ function render(
     for (const row of section.rows) {
       const active = index === selected
       if (active) selectedRow = rows.length
-      rows.push(entryRow(row, active, inner))
+      rows.push(entryRow(row, active, inner, capabilities))
       if (active) rows.push(detailRow(row, inner))
       index += 1
     }
@@ -360,9 +361,14 @@ function single(text: string, inner: number): Rendered {
  * @param inner - the frame's inner width.
  * @returns the row.
  */
-function entryRow(row: ConnectRow, active: boolean, inner: number): string {
+function entryRow(
+  row: ConnectRow,
+  active: boolean,
+  inner: number,
+  capabilities: ConnectCapabilities | undefined,
+): string {
   const mark = readinessMark(row)
-  const right = rightColumn(row, inner)
+  const right = rightColumn(row, inner, capabilities)
   const rightWidth = Math.min(displayWidth(right), Math.max(0, inner - 10))
   const label = truncateToWidth(
     escapeControls(rowName(row)),
@@ -417,19 +423,22 @@ function rowName(row: ConnectRow): string {
 }
 
 /**
- * The right-hand facts, dropped from the left when the name needs the room.
+ * The right-hand facts, retained in priority order when the name needs room.
  * @param row - the row.
  * @param inner - the frame's inner width.
+ * @param capabilities - mounted seams used to determine truthful provider facts.
  * @returns the right-aligned text.
  */
-function rightColumn(row: ConnectRow, inner: number): string {
+function rightColumn(row: ConnectRow, inner: number, capabilities: ConnectCapabilities | undefined): string {
   if (row.kind === 'create') return ''
   // Escaped before anything is measured or coloured: these facts carry a
   // credential reference out of the settings document and a source layer name
   // the credential provider chose, neither of which this frontend authored.
-  const facts = (row.kind === 'provider' ? providerFacts(row) : signInFacts(row)).map(escapeControls)
-  for (let from = 0; from < facts.length; from += 1) {
-    const candidate = facts.slice(from).join(' · ')
+  const facts = (row.kind === 'provider' ? providerFacts(row, capabilities) : signInFacts(row)).map(escapeControls)
+  // Facts arrive most important first. Keeping a prefix makes "not active"
+  // survive before ancillary key provenance when the terminal grows tight.
+  for (let count = facts.length; count > 0; count -= 1) {
+    const candidate = facts.slice(0, count).join(' · ')
     if (inner - 5 - displayWidth(candidate) >= MIN_NAME_COLUMNS) return candidate
   }
   return ''

--- a/packages/dshline/tests/connect-authorize.spec.ts
+++ b/packages/dshline/tests/connect-authorize.spec.ts
@@ -28,6 +28,10 @@ interface Slots {
   readonly mounted: () => boolean
   /** How many overlays were pushed in total, mounted or not. */
   readonly pushes: () => number
+  /** The topmost overlay's rendered lines. */
+  readonly lines: (columns: number, rows: number) => readonly string[]
+  /** The topmost overlay's visible text. */
+  readonly text: () => string
 }
 
 /**
@@ -58,6 +62,8 @@ function slots(): Slots {
     },
     mounted: () => stack.length > 0,
     pushes: () => pushes,
+    lines: (columns, rows) => stack.at(-1)?.render(columns, rows) ?? [],
+    text: () => stripAnsi((stack.at(-1)?.render(80, 24) ?? []).join('\n')),
   }
 }
 
@@ -166,7 +172,7 @@ describe('running one flow', () => {
     view.answer({ kind: 'text', text: 'sk-1' }, { kind: 'key', name: 'enter' })
     await settle()
     view.answer({ kind: 'key', name: 'enter' })
-    expect(await running).toEqual({ kind: 'done', message: 'ChatGPT: signed in' })
+    expect(await running).toEqual({ kind: 'done', message: 'ChatGPT: signed in · provider routes are activated separately' })
     expect(asked).toEqual(['text', 'secret', 'select'])
     expect(committed[0]).toContain('Continue in your browser')
     expect(committed[1]).toContain('https://auth.example')
@@ -185,6 +191,90 @@ describe('running one flow', () => {
       commit: () => {},
     })
     expect(began).toEqual([{ key: 'llm-pi-ai/openai', method: 'api-key' }])
+  })
+
+  it('keeps an attempt-owned waiting overlay visible without a Harness prompt', async () => {
+    const view = slots()
+    let aborted = false
+    const { authorization } = seam(async (_interaction, signal) => {
+      await new Promise<void>(resolve => {
+        signal.addEventListener('abort', () => {
+          aborted = true
+          resolve()
+        }, { once: true })
+      })
+      throw new Error('withdrawn')
+    })
+    const running = runAuthorization({
+      ctx: view.ctx,
+      authorization,
+      key: 'llm-pi-ai/openai',
+      label: 'ChatGPT',
+      commit: () => {},
+    })
+    await settle()
+    expect(view.text()).toContain('Waiting for authorization…')
+    expect(view.text()).toContain('The authorization flow is still in progress.')
+    // The waiting surface owns Esc while no prompt does, so this withdraws the
+    // actual attempt rather than exposing an inert Connect browser.
+    view.answer({ kind: 'key', name: 'escape' })
+    expect(await running).toEqual({ kind: 'failed', message: 'ChatGPT: sign-in cancelled' })
+    expect(aborted).toBe(true)
+    expect(view.mounted()).toBe(false)
+  })
+
+  it('bounds the waiting surface at its physical-height boundary', async () => {
+    const view = slots()
+    let finish: (() => void) | undefined
+    const { authorization } = seam(async () => {
+      await new Promise<void>(resolve => { finish = resolve })
+      return 'authorized'
+    })
+    const running = runAuthorization({
+      ctx: view.ctx,
+      authorization,
+      key: 'llm-pi-ai/openai',
+      label: 'ChatGPT',
+      commit: () => {},
+    })
+    await settle()
+    // The framed surface is seven physical rows: a leading blank, four body
+    // rows, and the frame's two borders. Six must select the compact fallback.
+    expect(view.lines(80, 6)).toHaveLength(1)
+    expect(view.lines(80, 7)).toHaveLength(7)
+    for (const columns of [1, 20, 80]) {
+      for (const rows of [0, 1, 5, 6, 7, 8]) {
+        expect(view.lines(columns, rows).length).toBeLessThanOrEqual(rows)
+      }
+    }
+    finish?.()
+    await running
+  })
+
+  it('returns to waiting after a prompt until the unfinished flow settles', async () => {
+    const view = slots()
+    let finish: (() => void) | undefined
+    const { authorization } = seam(async interaction => {
+      const answer = await interaction.prompt({ kind: 'text', message: 'Paste the code' })
+      expect(answer).toBe('abcd')
+      await new Promise<void>(resolve => { finish = resolve })
+      return 'authorized'
+    })
+    const running = runAuthorization({
+      ctx: view.ctx,
+      authorization,
+      key: 'llm-pi-ai/openai',
+      label: 'ChatGPT',
+      commit: () => {},
+    })
+    await settle()
+    expect(view.text()).toContain('Paste the code')
+    view.answer({ kind: 'text', text: 'abcd' }, { kind: 'key', name: 'enter' })
+    await settle()
+    expect(view.text()).toContain('Waiting for authorization…')
+    finish?.()
+    expect(await running).toEqual({ kind: 'done', message: 'ChatGPT: signed in · provider routes are activated separately' })
+    expect(view.mounted()).toBe(false)
   })
 
   it('withdraws the whole attempt when the reader dismisses a prompt', async () => {
@@ -229,7 +319,7 @@ describe('running one flow', () => {
       label: 'ChatGPT',
       commit: () => {},
     })
-    expect(await running).toEqual({ kind: 'done', message: 'ChatGPT: signed in' })
+    expect(await running).toEqual({ kind: 'done', message: 'ChatGPT: signed in · provider routes are activated separately' })
     expect(view.mounted()).toBe(false)
   })
 
@@ -322,9 +412,10 @@ describe('when the browser that started a sign-in closes', () => {
       commit: () => {},
     })
     expect(refused).toBe(true)
-    // Never pushed at all, not pushed and torn down: an overlay that flickers
-    // onto the live region has already drawn over what the reader moved on to.
-    expect(view.pushes()).toBe(0)
+    // The waiting surface was mounted before the flow withdrew, but the late
+    // prompt itself was refused rather than pushed over the next browser view.
+    expect(view.pushes()).toBe(1)
+    expect(view.mounted()).toBe(false)
   })
 
   it('commits no later notice', async () => {

--- a/packages/dshline/tests/connect-model.spec.ts
+++ b/packages/dshline/tests/connect-model.spec.ts
@@ -99,7 +99,21 @@ describe('what a row reports', () => {
     expect(providerFacts(provider())).toEqual(['active', '12 models', 'key from file'])
     expect(providerFacts(provider({ models: undefined }))).toEqual(['active', 'key from file'])
     expect(providerFacts(provider({ state: 'dormant', models: undefined })))
-      .toEqual(['dormant', 'key from file'])
+      .toEqual(['not active', 'key from file'])
+  })
+
+  it('teaches activation only when the existing action is available', () => {
+    const dormant = provider({
+      state: 'dormant',
+      models: undefined,
+      userOwned: false,
+      credential: { field: 'apiKeyEnv', ref: undefined, info: undefined },
+    })
+    expect(providerFacts(dormant, ALL)).toEqual(['not active', 'activate to add models', 'no key reference'])
+    const noSettings: ConnectCapabilities = { settings: false, credentials: true, authorization: true }
+    expect(providerFacts(dormant, noSettings)).toEqual(['not active', 'no key reference'])
+    expect(providerFacts({ ...dormant, revision: undefined }, ALL)).toEqual(['not active', 'no key reference'])
+    expect(providerFacts({ ...dormant, settingsPath: [] }, ALL)).toEqual(['not active', 'no key reference'])
   })
 
   it('names the reference when it is unset, so the reader knows what to set', () => {
@@ -279,7 +293,8 @@ describe('filtering', () => {
   it('matches what the row shows, in either section', () => {
     expect(matchesRow(provider(), 'openai')).toBe(true)
     expect(matchesRow(provider(), 'pi-ai')).toBe(true)
-    expect(matchesRow(provider(), 'dormant')).toBe(false)
+    expect(matchesRow(provider({ state: 'dormant' }), 'not active')).toBe(true)
+    expect(matchesRow(provider({ state: 'dormant' }), 'dormant')).toBe(false)
     expect(matchesRow(signIn(), 'chatgpt')).toBe(true)
     expect(matchesRow(signIn(), 'anthropic')).toBe(false)
   })

--- a/packages/dshline/tests/connect-overlay.spec.ts
+++ b/packages/dshline/tests/connect-overlay.spec.ts
@@ -147,6 +147,32 @@ describe('what the browser shows', () => {
     expect(shown).toContain('key from file')
   })
 
+  it('makes an activatable dormant route’s next step visible', () => {
+    const dormant = provider({
+      state: 'dormant',
+      models: undefined,
+      userOwned: false,
+      credential: { field: 'apiKeyEnv', ref: undefined, info: undefined },
+    })
+    const view = mount(ready([dormant]))
+    expect(view.text()).toContain('not active · activate to add models')
+    // The instruction gives way before the provider identity does.
+    expect(view.text(55, ROWS)).toContain('OpenAI')
+  })
+
+  it('does not promise activation for a dormant route the picker cannot activate', () => {
+    const dormant = provider({
+      state: 'dormant',
+      models: undefined,
+      revision: undefined,
+      userOwned: false,
+      credential: { field: 'apiKeyEnv', ref: undefined, info: undefined },
+    })
+    const shown = mount(ready([dormant])).text()
+    expect(shown).toContain('not active')
+    expect(shown).not.toContain('activate to add models')
+  })
+
   it('shows the settings address of the selected row only', () => {
     const shown = mount(ready([provider(), provider({ provider: 'anthropic', displayName: 'Anthropic' })])).text()
     expect(shown.match(/llm-pi-ai · providers\./gu)).toHaveLength(1)


### PR DESCRIPTION
## Summary
- keep an attempt-owned waiting overlay visible while Harness authorization awaits a callback without a prompt
- restore that waiting state after prompts resolve; Esc/Ctrl-C withdraw the attempt
- present dormant routes as `not active` and expose `activate to add models` only when the existing activation action is available
- clarify successful sign-in without inferring any flow-to-route relationship

## Validation
- `pnpm vitest run packages/dshline/tests/connect-*.spec.ts`
- `pnpm build && pnpm test`
- Deliberately changed the waiting copy and confirmed the two waiting-overlay tests failed before restoring it.