### PR TITLE
docs(dshline): say how dshline behaves behind a network proxy, and prove the part it owns

### DIFF
--- a/.changeset/proxy-inheritance.md
+++ b/.changeset/proxy-inheritance.md
@@ -1,0 +1,25 @@
+---
+'@dshline/dshline': patch
+---
+
+Document how dshline behaves behind a network proxy, and pin the part of it
+this frontend actually owns.
+
+Outbound traffic is Harness's: DSH reads the standard proxy variables at launch
+and routes model calls, web search, page fetches, and HTTP MCP through them, so
+`dshline` configures nothing of its own and `docs/install.md` now says so and
+links upstream's own guide — including the two things people lose an afternoon
+to, that an operating-system "system proxy" switch is invisible to
+command-line tools, and that a SOCKS URL is reported and skipped rather than
+used.
+
+The part that is this frontend's is `/profiles`, which installs and removes
+bundles by running `dsh plugin` and therefore pnpm. Those children run under
+Harness's environment scrub plus `childEnvironment()`'s own restore, and a
+regression test now spawns a real child through the real subprocess seam to
+prove `HTTPS_PROXY`, `NO_PROXY`, pnpm's `npm_config_*` spellings, and
+`NODE_EXTRA_CA_CERTS` all arrive — so a `/profiles` install keeps working on a
+corporate network with a TLS-intercepting proxy. The existing test that Harness's
+own API key does NOT reach those children still stands beside it.
+
+No behaviour change: this was already true, and is now proven and written down.

--- a/docs/install.i18n.yaml
+++ b/docs/install.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/install.md
-install.md: 0f40fb519d47b73052494dd89a099287f411195c
-install.zh.md: 82bca70f6c0692bb9671d766f31758df6be3f28f
+install.md: bc715182befe1c3cb6bf7f0a70a087b9130b85d6
+install.zh.md: 0a07992df19a79aaeb4a156ccbdd34c8a1d53cb9

--- a/docs/install.md
+++ b/docs/install.md
@@ -187,6 +187,19 @@ That is the frontend refusing to start without a real terminal, which happens wh
 
 Run `node tools/keyprobe.mjs` from a checkout of this repository and press the key. It prints the bytes your terminal sends and the key this project decodes them into; an empty result is a bug worth reporting.
 
+### Nothing reaches the network, and you are behind a proxy
+
+Outbound traffic is Harness's, not this frontend's. DSH routes model calls, web search, page fetches, and HTTP MCP through the standard proxy environment variables and reads them at launch, so `dshline` needs nothing configured of its own. The whole story is [Run DSH behind a network proxy](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/guide/network-proxy.md) upstream; the short version is:
+
+```sh
+export HTTPS_PROXY=http://127.0.0.1:7890
+export HTTP_PROXY=http://127.0.0.1:7890
+```
+
+Export them from your shell profile, or put them in `$DSH_HOME/.env` (`~/.dsh/.env` by default). A "system proxy" switch in an application such as Clash writes only the operating system's settings, which command-line tools never read — exporting the variables is a separate step, which is why your browser can be proxied while your terminal is not. SOCKS URLs are not supported: one is reported at startup and skipped, so point the variables at your proxy's HTTP port instead.
+
+One part of this *is* the frontend's. `/profiles` installs and removes bundles by running `dsh plugin`, which runs pnpm against a registry, and those child processes inherit your proxy settings — `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY`, and pnpm's own `npm_config_*` spellings — together with `NODE_EXTRA_CA_CERTS`, so a TLS-intercepting corporate proxy works there too once Node is pointed at your CA bundle. Harness's own API key is deliberately *not* forwarded to them.
+
 ## Uninstalling
 
 This removes both the package and the profile's reference to it:

--- a/docs/install.zh.md
+++ b/docs/install.zh.md
@@ -191,6 +191,19 @@ no terminal here to ask on.
 
 在本仓库检出的目录下运行 `node tools/keyprobe.mjs` 并按下该按键。它会打印你的终端发送的字节以及本项目解码出的按键；结果为空是一个值得报告的缺陷。
 
+### 什么都连不上网络，而你在代理之后
+
+出站流量属于 Harness，而不是这个前端。DSH 通过标准的代理环境变量路由模型调用、网页搜索、页面抓取以及基于 HTTP 的 MCP，并在启动时读取它们，因此 `dshline` 自己不需要配置任何东西。完整说明见上游的 [Run DSH behind a network proxy](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/guide/network-proxy.md)；简版是：
+
+```sh
+export HTTPS_PROXY=http://127.0.0.1:7890
+export HTTP_PROXY=http://127.0.0.1:7890
+```
+
+在你的 shell 配置里导出它们，或者把它们放进 `$DSH_HOME/.env`（默认是 `~/.dsh/.env`）。像 Clash 这类应用中的「系统代理」开关只会写入操作系统的设置，而命令行工具从不读取它——导出这些变量是一个独立的步骤，这也正是为什么你的浏览器被代理了而终端没有。不支持 SOCKS URL：遇到时会在启动时报告并跳过，因此请把这些变量指向你的代理的 HTTP 端口。
+
+其中有一部分**确实**属于这个前端。`/profiles` 通过运行 `dsh plugin` 来安装和移除 bundle，而后者会对着一个 registry 运行 pnpm；这些子进程会继承你的代理设置——`HTTP_PROXY`、`HTTPS_PROXY`、`NO_PROXY`、`ALL_PROXY`，以及 pnpm 自己的 `npm_config_*` 拼写——并且连同 `NODE_EXTRA_CA_CERTS` 一起，因此只要把 Node 指向你的 CA 证书包，一个做 TLS 拦截的企业代理在那里同样能工作。Harness 自己的 API 密钥则被刻意**不**转发给它们。
+
 ## 卸载
 
 这会同时移除包和配置文件对它的引用：

--- a/packages/dshline/tests/profiles-actions.spec.ts
+++ b/packages/dshline/tests/profiles-actions.spec.ts
@@ -369,6 +369,36 @@ describe('the environment the launcher child runs with', () => {
     )
     expect(result.output).toBe('absent absent')
   }, 10_000)
+
+  it('carries the whole proxy and corporate-CA story through to the child', async () => {
+    // A profile operation is a package install, and on a corporate network the
+    // only thing that says where its traffic goes is the environment. Harness's
+    // own scrub is documented as keeping proxy variables, and `NODE_EXTRA_CA_CERTS`
+    // survives it because it is not credential-SHAPED — but neither fact is
+    // dshline's to assume, and `childEnvironment()` sits between the scrub and
+    // the child. Proven end to end against the real seam rather than asserted
+    // from the two modules separately, because the failure this rules out is a
+    // `/profiles` install that hangs on a network nobody can reach.
+    vi.stubEnv('HTTPS_PROXY', 'http://127.0.0.1:7890')
+    vi.stubEnv('NO_PROXY', 'registry.internal')
+    // `npm_config_*` reaches the child through the package-manager restore
+    // above rather than the scrub, so a proxy configured pnpm's way travels too.
+    vi.stubEnv('npm_config_https_proxy', 'http://127.0.0.1:7890')
+    vi.stubEnv('NODE_EXTRA_CA_CERTS', '/etc/ssl/corporate-ca.pem')
+    const result = await spawnCaptured(
+      processContext.subprocess,
+      nodeProgram(
+        "process.stdout.write([process.env.HTTPS_PROXY, process.env.NO_PROXY, "
+        + "process.env.npm_config_https_proxy, process.env.NODE_EXTRA_CA_CERTS]"
+        + ".map(value => value ?? 'absent').join(' '))",
+      ),
+      [],
+      { timeoutMs: 5_000 },
+    )
+    expect(result.output).toBe(
+      'http://127.0.0.1:7890 registry.internal http://127.0.0.1:7890 /etc/ssl/corporate-ca.pem',
+    )
+  }, 10_000)
 })
 
 describe('a failure says what went wrong, not just that it did', () => {


### PR DESCRIPTION
## Summary

This closes out the second item from the post-adoption review, with the answer the investigation actually produced: **proxy inheritance already works, and it is not something Harness `0.1.2-rc.1` delivered.** So there is no adoption here — there is a doc that was missing and a regression test that was missing.

## What was verified

Upstream owns outbound traffic entirely: `packages/util/http-proxy`, an outbound-proxy-policy architecture note dated 2026-08-27, and a user guide at `docs/user/guide/network-proxy.md`. DSH reads the standard proxy variables at launch and routes model calls, web search, page fetches, and HTTP MCP through them. `dshline` configures nothing of its own, and none of this is new in rc.1 — that adoption is a pure version stamp (252 files, none of them source; every published `dsh-*` lib byte-identical to alpha.5).

`docs/install.md` said nothing about any of it, which is the gap worth closing: a user behind a corporate proxy has no reason to go looking in the Harness repo. The new troubleshooting entry links upstream's guide and carries the two facts people lose an afternoon to — that an operating-system "system proxy" switch is invisible to command-line tools (so a proxied browser and an unproxied terminal are normal), and that a SOCKS URL is reported and skipped rather than used.

## The part that is actually ours

`/profiles` installs and removes bundles by running `dsh plugin`, which runs pnpm against a registry. Those children run under Harness's `scrubbedParentEnv()` *plus* `childEnvironment()`'s own restore (`profiles/actions.ts:106`, `/^(?:NPM_|PNPM_|COREPACK_|NODE_AUTH_TOKEN)/iu`). Whether a proxy survives that composition is not something either module answers alone, and nothing tested it.

The new test spawns a real child through the real subprocess seam — the same way the two tests already in that block do — and proves `HTTPS_PROXY`, `NO_PROXY`, pnpm's own `npm_config_https_proxy`, and `NODE_EXTRA_CA_CERTS` all arrive. That last one is what makes a TLS-intercepting corporate proxy work at all. The existing test that `DEEPSEEK_API_KEY` and `GITHUB_TOKEN` do **not** reach those children sits directly beside it, so the pair reads as one statement: routing travels, secrets do not.

## Not in scope

No behaviour change. Nothing was broken; this makes an existing guarantee provable and findable. Changeset is `patch` for that reason.

## Testing

- [x] `pnpm run typecheck`
- [x] `pnpm test` — 2731 passed / 22 skipped, +1 new
- [x] `node tools/verify-translation-pairing.mjs` — 9 pairs consistent, `docs/install` re-recorded
- [x] The test is not vacuous: the child's environment really is restricted, which the neighbouring `DEEPSEEK_API_KEY` / `GITHUB_TOKEN` test in the same block already proves — a child inheriting `process.env` wholesale would pass both of these for the wrong reason, and it does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)

