### PR TITLE
fix(dshline): make header edit/remove act on the selected row's index

### DIFF
--- a/packages/dshline/src/connect/route-editor.ts
+++ b/packages/dshline/src/connect/route-editor.ts
@@ -46,7 +46,6 @@ import {
   entriesFromRawHeaders,
   headerNameProblem,
   headerValueProblem,
-  removeHeader,
   sameHeaderSet,
   toRawHeaders,
   upsertHeader,
@@ -719,7 +718,8 @@ async function editHeaders(
       current = upsertHeader(current, name, value)
       continue
     }
-    const target = current[Number(choice.slice(ROW_PREFIX.length))]
+    const targetIndex = Number(choice.slice(ROW_PREFIX.length))
+    const target = current[targetIndex]
     if (!choice.startsWith(ROW_PREFIX) || target === undefined) continue
     const next = await promptSelect(ctx, {
       title: target.name,
@@ -731,12 +731,21 @@ async function editHeaders(
       ],
     })
     if (next === 'remove') {
-      current = removeHeader(current, target.name)
+      // By index, not by name: two rows can share a case-folded name (a
+      // hand-edited `settings.yaml` carrying both `X-Test` and `x-test`), and
+      // `removeHeader` would drop every row that folds to it instead of only
+      // the one the reader selected.
+      current = current.filter((_entry, index) => index !== targetIndex)
       continue
     }
     if (next === 'edit') {
       const value = await promptHeaderValue(ctx, view, target.name, target.value)
-      if (value !== undefined) current = upsertHeader(current, target.name, value)
+      // By index too, for the same reason: `upsertHeader` would update the
+      // first row matching this name, which is a different row when the draft
+      // holds two case spellings of it.
+      if (value !== undefined) {
+        current = current.map((entry, index) => index === targetIndex ? { name: entry.name, value } : entry)
+      }
     }
   }
 }

--- a/packages/dshline/tests/connect-route-editor.spec.ts
+++ b/packages/dshline/tests/connect-route-editor.spec.ts
@@ -905,6 +905,81 @@ describe('curating a route’s request headers', () => {
     expect(await outcome).toBeUndefined()
     expect(fixture.mutateCalls).toEqual([])
   })
+
+  describe('a stored map hand-edited to carry two case spellings of one name', () => {
+    // `X-Test` and `x-test` are one HTTP header, but a hand-edited
+    // `settings.yaml` can still store both as distinct object keys, and
+    // `entriesFromRawHeaders` renders each as its own row (see the `__done`
+    // regression above: rows are keyed by position precisely so a case this
+    // odd is still reachable). The row's own index must be what edit and
+    // remove act on — a case-insensitive name lookup would find the WRONG row,
+    // or both.
+    function duplicateSpellingFixture(): ReturnType<typeof seamsFor> {
+      return seamsFor({
+        descriptor: headerDescriptorFor({
+          baseURL: 'http://x/v1',
+          api: 'openai-completions',
+          headers: { 'X-Test': 'one', 'x-test': 'two' },
+          models: [{ id: 'a' }],
+        }),
+      })
+    }
+
+    it('edits the second row without touching the first', async () => {
+      const { ctx, type, press } = slots()
+      const fixture = duplicateSpellingFixture()
+      const outcome = runRouteEditor(ctx, fixture.seams, declaredRow())
+      await press(...HEADERS_ROW)
+      // Submenu: add(0), X-Test(1), x-test(2), Done(3). Open the second row.
+      await press(DOWN, DOWN, ENTER)
+      await press(ENTER) // 'Edit value', at the cursor
+      await press(CTRL_U) // clear the prefilled 'two'
+      await type('TWO-NEW')
+      await press(ENTER)
+      await press(UP, ENTER) // Done
+      await press(UP, UP, ENTER) // save
+      const result = await outcome
+      expect(result?.kind).toBe('done')
+      // `X-Test` is unchanged; only the row the reader actually opened moved.
+      // A name-based `upsertHeader('x-test', …)` would instead have matched
+      // `X-Test` first and left this exact bug in place.
+      expect(fixture.mutateCalls).toEqual([{
+        ns: 'llm-pi-ai',
+        ops: [{
+          op: 'set',
+          path: ['providers', 'local-llama', 'headers'],
+          value: { 'X-Test': 'one', 'x-test': 'TWO-NEW' },
+        }],
+        revision: 9,
+      }])
+    })
+
+    it('removes one row and leaves the other in the written map', async () => {
+      const { ctx, press } = slots()
+      const fixture = duplicateSpellingFixture()
+      const outcome = runRouteEditor(ctx, fixture.seams, declaredRow())
+      await press(...HEADERS_ROW)
+      // Submenu: add(0), X-Test(1), x-test(2), Done(3). Open the second row.
+      await press(DOWN, DOWN, ENTER)
+      await press(DOWN, ENTER) // 'Remove header'
+      // Submenu now: add(0), X-Test(1), Done(2).
+      await press(UP, ENTER) // Done
+      await press(UP, UP, ENTER) // save
+      const result = await outcome
+      expect(result?.kind).toBe('done')
+      // A name-based `removeHeader('x-test', …)` folds both keys to the same
+      // name and would have dropped `X-Test` too.
+      expect(fixture.mutateCalls).toEqual([{
+        ns: 'llm-pi-ai',
+        ops: [{
+          op: 'set',
+          path: ['providers', 'local-llama', 'headers'],
+          value: { 'X-Test': 'one' },
+        }],
+        revision: 9,
+      }])
+    })
+  })
 })
 
 describe('declaring a route that needs request headers', () => {


### PR DESCRIPTION
## What

PR #150 keyed the request-header menu's rows by index rather than by
name, so a legal HTTP header name such as `__add` or `__done` cannot
collide with a menu sentinel. That part is correct.

But once a row was selected, edit and remove still delegated to
`upsertHeader(current, target.name, value)` / `removeHeader(current,
target.name)` — both case-insensitive by name. A hand-edited
`settings.yaml` carrying two case spellings of one name (`X-Test` and
`x-test`) renders as two distinct rows, but selecting the second row
was not actually isolated: editing it could update the *first*
matching spelling, and removing either row could remove both.

## Fix

`editHeaders()` now edits and removes the exact draft entry at the
selected index, with no second name-based lookup. Ordinary header
identity rules are unchanged elsewhere: adding a header still refuses
a second case spelling of an existing name, and `upsertHeader()` /
`removeHeader()` remain for that add path (and other callers).

## Tests

Added a regression under "a stored map hand-edited to carry two case
spellings of one name", proving:
- editing the second row (`x-test`) changes only that row, leaving
  `X-Test` untouched;
- removing that row removes only it, leaving `X-Test` in the written
  map.

Both drive the real overlay flow (`runRouteEditor` + the terminal key
handler), pinning the actual index-selection path, and both were
confirmed to fail for the right reason against the pre-fix code
(editing hit the first spelling; removing dropped both / unset the
field entirely). The existing `__done`/`__add` sentinel-name regression
from #150 still passes.

## Validation

- `pnpm exec vitest run` on the two touched spec files: 43/43 passed
- `pnpm run test` (full suite): 2757 passed, 22 skipped, 0 failed
- `pnpm run build` (`tsc -b`): clean
- `pnpm run typecheck` (same `tsc -b`): clean

Scope: two files only (`route-editor.ts`, its spec). No header-schema,
credential/redaction, Connect-redesign, discovery, docs, or Harness
adoption changes.