### PR TITLE
fix(dshline): let the composer use wide terminal input space

### DIFF
--- a/.changeset/wide-composer-frame.md
+++ b/.changeset/wide-composer-frame.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': patch
+---
+
+Let the composer frame use the terminal's available width while keeping the capped readable policy for overlays and other document-style surfaces.

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -1602,9 +1602,10 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     // navigation, and stays there until they edit or submit. At the draft, the
     // composer's own `↑`/`↓` move through the wrapped buffer first, so a long
     // prompt is navigated vertically before `↑` reaches for history.
+    const columns = terminal.columns()
     const geometry = {
-      width: composerInner(terminal.columns()),
-      gutter: composerGutter,
+      width: composerInner(columns),
+      gutter: (line: number): string => composerGutter(line, columns),
     }
     const routed = routeInputKey(key, composer, completion, history, geometry)
     if (routed === 'completion') {

--- a/packages/dshline/src/chrome.ts
+++ b/packages/dshline/src/chrome.ts
@@ -5,7 +5,7 @@
 
 import { BOX_CHROME_COLUMNS, displayWidth, frame, paint } from '@dshline/renderer'
 
-/** Widest the chrome will draw, so a maximized terminal keeps readable lines. */
+/** Widest the default readable chrome draws; the composer has its own terminal-following policy. */
 const MAX_COLUMNS = 100
 
 /**
@@ -25,8 +25,13 @@ export const CHROME_MIN_COLUMNS = BOX_CHROME_COLUMNS + 8
 
 /** One rendering of the dshline visual root. */
 export interface RootFrameOptions {
-  /** The terminal's current width; the frame width is derived from it. */
+  /** The terminal's current width; the default frame width is derived from it. */
   readonly columns: number
+  /**
+   * Optional total width for a consumer with a different policy; it must fit the
+   * terminal, and body/footer content must use its corresponding inner width.
+   */
+  readonly width?: number
   /** Right-hand label: already escaped and styled by the caller. It may be truncated. */
   readonly context: string
   /** Body rows: already fitted to the frame's inner width and safe. */
@@ -36,23 +41,36 @@ export interface RootFrameOptions {
 }
 
 /**
- * Chrome width for a terminal of `columns`, leaving a column of breathing room.
- * Every framed element shares it so their edges line up.
+ * Default readable frame width for a terminal of `columns`, leaving a column of
+ * breathing room. Overlays and document-style surfaces use this capped policy.
  * @param columns - the terminal's width.
- * @returns the width every framed element uses.
+ * @returns the default readable frame width.
  */
 export function chromeWidth(columns: number): number {
   return Math.max(CHROME_MIN_COLUMNS, Math.min(columns - 1, MAX_COLUMNS))
 }
 
 /**
+ * Terminal-following width for the composer's frame, leaving breathing space.
+ * Unlike {@link chromeWidth}, the primary input surface intentionally has no
+ * readability cap: its inner width is also used by cursor movement.
+ * @param columns - the terminal's width.
+ * @returns the composer's total frame width.
+ */
+export function composerFrameWidth(columns: number): number {
+  return Math.max(CHROME_MIN_COLUMNS, columns - 1)
+}
+
+/**
  * Draw dshline's shared visual root around already-prepared content.
- * @param options - terminal width, right context, body rows, and optional footer help.
+ * @param options - terminal width, optional total frame width, right context, body
+ *   rows, and optional footer help. A supplied width must fit the terminal and
+ *   the caller must fit body and footer content to that width.
  * @returns the framed rows, including the integrated top and bottom borders.
  */
 export function rootFrame(options: RootFrameOptions): string[] {
   return frame(options.body, {
-    width: chromeWidth(options.columns),
+    width: options.width ?? chromeWidth(options.columns),
     title: paint('dshline', 'banner'),
     rightTitle: options.context,
     // Help inside the bottom border stays muted, as the old external help rows

--- a/packages/dshline/src/views.ts
+++ b/packages/dshline/src/views.ts
@@ -24,7 +24,7 @@ import {
 } from '@dshline/renderer'
 import type { CardDetail } from './cards.ts'
 import type { ActivityWord } from './activity.ts'
-import { CHROME_MIN_COLUMNS, chromeWidth, rootFrame } from './chrome.ts'
+import { CHROME_MIN_COLUMNS, chromeWidth, composerFrameWidth, rootFrame } from './chrome.ts'
 import type { BusyEnter } from './delivery.ts'
 import { DEFAULT_BUSY_ENTER } from './delivery.ts'
 import type { TuiSlotView } from './slots.ts'
@@ -195,7 +195,7 @@ export function createComposerView(
    * @returns the rows and the cursor's row and column within them.
    */
   const layout = (columns: number): { rows: readonly string[]; row: number; column: number } => {
-    const found = layoutComposer(composer, composerInner(columns), composerGutter)
+    const found = layoutComposer(composer, composerInner(columns), line => composerGutter(line, columns))
     return { rows: found.rows, row: found.cursorRow, column: found.cursorColumn }
   }
 
@@ -252,28 +252,13 @@ export function createComposerView(
   const contentRowOffset = (rows: number | undefined): number => keepsSeparator(rows) ? 2 : 1
 
   /**
-   * Gutter for the pathological-width fallback, truncated to fit the terminal
-   * itself rather than the frame's inner width.
-   *
-   * Below {@link CHROME_MIN_COLUMNS} there is no frame, so the gutter has
-   * nothing to share the row with but the terminal's own width. Truncating it
-   * here — the same width `layoutComposer` chunks against — is what keeps
-   * every row `chunkLine` produces inside `columns` even when the prompt
-   * itself cannot fit whole.
-   * @param columns - the terminal's current width.
-   * @returns the gutter function for `layoutComposer`.
-   */
-  const narrowGutter = (columns: number) => (line: number): string =>
-    truncateToWidth(line === 0 ? PROMPT : CONTINUATION, Math.max(0, columns))
-
-  /**
    * The composer laid out directly against the terminal's width, with no
    * frame around it. See {@link layout} for the framed equivalent.
    * @param columns - the terminal's current width.
    * @returns the rows and the cursor's row and column within them.
    */
   const narrowLayout = (columns: number): { rows: readonly string[]; row: number; column: number } => {
-    const found = layoutComposer(composer, Math.max(1, columns), narrowGutter(columns))
+    const found = layoutComposer(composer, composerInner(columns), line => composerGutter(line, columns))
     return { rows: found.rows, row: found.cursorRow, column: found.cursorColumn }
   }
 
@@ -312,6 +297,7 @@ export function createComposerView(
         // make this the only view in the live region that can outgrow its budget.
         const prompt = rootFrame({
           columns,
+          width: composerFrameWidth(columns),
           context: paint(escapedLabel, 'composer-title'),
           body: [composerHintRow(hint(), composerInner(columns))],
         })
@@ -323,6 +309,7 @@ export function createComposerView(
       const shown = window(rows, row, contentBudget(terminalRows))
       const hidden = rows.length - shown.rows.length
       const framed = rootFrame({
+        width: composerFrameWidth(columns),
         columns,
         context: hidden > 0
           ? `${paint(escapedLabel, 'composer-title')} ${paint(`+${String(hidden)} rows`, 'muted')}`
@@ -388,7 +375,8 @@ export interface ComposerHint {
  * that silently does the other thing. `docs/usage.md` teaches it instead, which
  * is the same call this interface already made about `shift-enter`.
  * @param hint - whether a turn is running, and what enter means while one is.
- * @param inner - the composer's content width, from {@link composerInner}.
+ * @param inner - the framed composer's content width, from {@link composerInner}.
+ *   The narrow unframed fallback does not call this helper.
  * @returns one row, prompt included, painted and ready for the frame.
  */
 export function composerHintRow(hint: ComposerHint, inner: number): string {
@@ -418,34 +406,40 @@ export function composerHintRow(hint: ComposerHint, inner: number): string {
     // `cursor()` places the caret just past it at every rung.
     return `${PROMPT}${segments.map(segment => paint(segment, 'muted')).join(separator)}`
   }
-  // Unreachable in practice — the empty rung is two columns and the inner width
-  // floors at eight — but a ladder whose last rung could be skipped would return
-  // undefined, and the prompt is the one thing that must survive every width.
+  // Unreachable in the framed branch — the empty rung is two columns and its
+  // inner width floors at eight — but a ladder whose last rung could be skipped
+  // would return undefined, and the prompt is the one thing that must survive.
   return PROMPT
 }
 
 /**
  * Display columns of the composer's content area, including its gutter.
  *
- * The inner cell budget of the framed box, shared by the view that draws the
- * cursor and the router that moves it, so both calculate the same visual rows.
+ * The width is shared by the view that draws the cursor and the router that moves
+ * it. Below the frame floor it becomes the physical terminal width, because the
+ * unframed fallback has no border cells to subtract.
  * @param columns - the terminal's current width.
  * @returns the content width the composer draws and moves within.
  */
 export function composerInner(columns: number): number {
-  return chromeWidth(columns) - BOX_CHROME_COLUMNS
+  return columns < CHROME_MIN_COLUMNS
+    ? Math.max(1, columns)
+    : composerFrameWidth(columns) - BOX_CHROME_COLUMNS
 }
 
 /**
  * The gutter preceding each logical line of the composer.
  *
  * Line zero carries the prompt; continuation lines an indent of the same width,
- * so the wrapped text lines up under the prompt.
+ * so the wrapped text lines up under the prompt. The optional terminal width is
+ * used by the unframed narrow fallback, where the gutter itself may not fit.
  * @param line - zero-based logical line index.
+ * @param columns - the terminal's current width, when the gutter must be bounded.
  * @returns the line's leading gutter.
  */
-export function composerGutter(line: number): string {
-  return line === 0 ? PROMPT : CONTINUATION
+export function composerGutter(line: number, columns?: number): string {
+  const gutter = line === 0 ? PROMPT : CONTINUATION
+  return columns === undefined ? gutter : truncateToWidth(gutter, Math.max(0, columns))
 }
 
 /**

--- a/packages/dshline/tests/narrow-root.spec.ts
+++ b/packages/dshline/tests/narrow-root.spec.ts
@@ -13,10 +13,13 @@ import { Context } from '@deepseek-ai/cordis'
 import { Composer, displayWidth, Screen, stripAnsi } from '@dshline/renderer'
 import { describe, expect, it } from 'vitest'
 import { createEmulator } from '../../../tests/emulator.ts'
+import { createCompletion } from '../src/completion.ts'
 import { CHROME_MIN_COLUMNS } from '../src/chrome.ts'
+import { InputHistory } from '../src/history.ts'
+import { routeInputKey } from '../src/input.ts'
 import { TuiSlots } from '../src/slots.ts'
 import type { StatusState } from '../src/views.ts'
-import { createComposerView, createStatusView } from '../src/views.ts'
+import { composerGutter, composerInner, createComposerView, createStatusView } from '../src/views.ts'
 
 const ROWS = 24
 
@@ -132,6 +135,28 @@ describe('the root live region below the chrome floor', () => {
       expect(cursor.column).toBeLessThanOrEqual(columns)
       for (const row of rows) expect(displayWidth(row)).toBeLessThanOrEqual(columns)
     }
+  })
+
+  it('uses the unframed width and gutter for narrow vertical movement', async () => {
+    const columns = 5
+    const composer = typed('abcdefghij')
+    const completion = createCompletion(composer, {
+      commands: () => [],
+      commandArguments: async () => [],
+      paths: async () => [],
+    }, () => {})
+    const history = new InputHistory()
+
+    expect(routeInputKey(
+      { kind: 'key', name: 'up' },
+      composer,
+      completion,
+      history,
+      { width: composerInner(columns), gutter: line => composerGutter(line, columns) },
+    )).toBe('vertical')
+    const { rows, cursor } = await drawnRoot(composer, columns)
+    expect(rows[cursor.row]).toContain('defgh')
+    expect((rows[cursor.row] ?? '').slice(0, cursor.column)).toBe('de')
   })
 
   it("the status view cannot independently exceed the terminal's width, and may surrender entirely", () => {

--- a/packages/dshline/tests/views.spec.ts
+++ b/packages/dshline/tests/views.spec.ts
@@ -195,7 +195,7 @@ describe("the empty composer's hint", () => {
    * @returns the visible row, prompt included.
    */
   const hint = (hint: ComposerHint, columns = 120): string =>
-    stripAnsi(composerHintRow(hint, composerInner(columns)))
+    stripAnsi(composerHintRow(hint, Math.max(8, composerInner(columns))))
 
   const idle: ComposerHint = { busy: false, busyEnter: 'queue' }
 
@@ -291,14 +291,17 @@ describe("the empty composer's hint", () => {
     // region past the screen where rows can no longer be erased.
     for (const state of [idle, { busy: true, busyEnter: 'steer' } as const]) {
       for (let columns = 1; columns <= 130; columns += 1) {
+        // The narrow live-region fallback does not render a hint or frame; keep
+        // this standalone hint test's framed minimum independent of its width.
+        const inner = Math.max(8, composerInner(columns))
         expect(
-          composerHintRow(state, composerInner(columns)).split('\n'),
+          composerHintRow(state, inner).split('\n'),
           `${String(columns)} columns`,
         ).toHaveLength(1)
         expect(
-          displayWidth(composerHintRow(state, composerInner(columns))),
+          displayWidth(composerHintRow(state, inner)),
           `${String(columns)} columns`,
-        ).toBeLessThanOrEqual(composerInner(columns))
+        ).toBeLessThanOrEqual(inner)
       }
     }
   })

--- a/packages/dshline/tests/visual-root-frames.spec.ts
+++ b/packages/dshline/tests/visual-root-frames.spec.ts
@@ -5,8 +5,11 @@ import { Composer, displayWidth, Screen, stripAnsi } from '@dshline/renderer'
 import { describe, expect, it } from 'vitest'
 import { createEmulator } from '../../../tests/emulator.ts'
 import { chromeWidth, fitFooterHelp, rootFrame } from '../src/chrome.ts'
+import { createCompletion } from '../src/completion.ts'
+import { InputHistory } from '../src/history.ts'
+import { routeInputKey } from '../src/input.ts'
 import { TuiSlots } from '../src/slots.ts'
-import { createComposerView } from '../src/views.ts'
+import { composerGutter, composerInner, createComposerView } from '../src/views.ts'
 
 /** Terminal widths that exercise the floor, ordinary widths, and the cap. */
 const ROOT_WIDTHS = [20, 24, 30, 40, 80, 120] as const
@@ -129,6 +132,47 @@ describe('the composer inside the shared root', () => {
     expect(frame.cursor.row).toBeGreaterThan(2)
     expect((await frame.emulator.cell(frame.cursor.column - 1, frame.cursor.row))?.chars).toBe('x')
     expect((await frame.emulator.cell(frame.cursor.column, frame.cursor.row))?.chars).toBe(' ')
+  })
+
+  it.each([
+    [80, 79],
+    [100, 99],
+    [101, 100],
+    [102, 101],
+    [120, 119],
+    [160, 159],
+  ] as const)('uses terminal-following composer width at %i columns', async (columns, expected) => {
+    const wideText = typed(`界${'🙂界'.repeat(80)}`)
+    for (const composer of [new Composer(), typed('hello'), wideText]) {
+      const frame = await drawn(composer, columns)
+      const top = frame.rows.find(row => stripAnsi(row).includes('dshline')) ?? ''
+      expect(displayWidth(top), `${String(columns)} columns`).toBe(expected)
+      expect(frame.rows.every(row => displayWidth(row) <= columns), `${String(columns)} columns`).toBe(true)
+    }
+  })
+
+  it('keeps a wide cursor on typed text and moves it through wrapped multiline rows', async () => {
+    const columns = 120
+    const composer = typed(`${'a'.repeat(140)}\n${'b'.repeat(140)}\nccc`)
+    const completion = createCompletion(composer, {
+      commands: () => [],
+      commandArguments: async () => [],
+      paths: async () => [],
+    }, () => {})
+    const history = new InputHistory()
+    const before = await drawn(composer, columns)
+    expect((await before.emulator.cell(before.cursor.column - 1, before.cursor.row))?.chars).toBe('c')
+
+    expect(routeInputKey(
+      { kind: 'key', name: 'up' },
+      composer,
+      completion,
+      history,
+      { width: composerInner(columns), gutter: line => composerGutter(line, columns) },
+    )).toBe('vertical')
+    const after = await drawn(composer, columns)
+    expect(after.rows[after.cursor.row]).toContain('b')
+    expect((await after.emulator.cell(after.cursor.column, after.cursor.row))?.chars).toBe('b')
   })
 
   it('lets an overlay replace composer rows and cursor together', () => {


### PR DESCRIPTION
## Summary

On terminals wider than the shared `MAX_COLUMNS = 100` readable-chrome cap, the composer inherited `chromeWidth()` through `rootFrame()` and `composerInner()`. That left the editable input at roughly 100 columns while the status line used the real terminal width.

This keeps the capped policy for overlays, completion, timing, and the startup banner, while giving only the primary composer a terminal-following frame width (`columns - 1`, preserving breathing room). It still uses the shared `rootFrame()` renderer. The composer view and attachment input routing share the same width and bounded gutter, including the narrow unframed fallback.

## Coverage

- ordinary widths remain unchanged;
- cap boundary covers 100/101/102 columns;
- 120- and 160-column composers grow beyond the former cap;
- empty, populated, long Unicode, cursor, and wrapped multiline movement are checked through xterm/headless;
- narrow fallback remains physically bounded and vertical movement agrees with its rendered rows;
- composer rows never exceed physical terminal width;
- deliberately restoring the old cap fails `uses terminal-following composer width at 102/120/160 columns`.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm test` — 2917 passed, 37 skipped
- `pnpm run verify-docs` — 9 bilingual pairs consistent (2 existing documents await Chinese counterparts)
- `pnpm security`
- `git diff --check`

No Harness or renderer API changes; no documentation files changed.
