### PR TITLE
feat(dshline): say when a model switch can cost the cache, and state /cache's scope

### DIFF
--- a/.changeset/cyan-crabs-cache-scope.md
+++ b/.changeset/cyan-crabs-cache-scope.md
@@ -10,8 +10,8 @@ totals cannot be read as the route named in the header section below. A
 provider/model change is a request boundary, not a reset boundary for this
 metric, and Harness's `tokenUsage` fold stays the single cumulative authority.
 
-`/model` now appends one informational note to its transcript line when the
-switch actually moves to a different provider or model: "cache reuse after a
+`/model` now emits one informational note on its own second transcript line when
+the switch actually moves to a different provider or model: "cache reuse after a
 provider/model change is provider-dependent; /cache remains session-cumulative".
 The note claims neither outcome — no promise that cache is lost, no promise that
 it carries over — and depends on the move alone: re-selecting the active route

--- a/.changeset/cyan-crabs-cache-scope.md
+++ b/.changeset/cyan-crabs-cache-scope.md
@@ -1,0 +1,20 @@
+---
+'@dshline/dshline': patch
+---
+
+`/cache` now says what its accounting is, and `/model` says what a real switch can cost.
+
+The `/cache` inspector gained one scope caption under its figures — "Session
+cumulative · includes requests across provider/model changes" — so the session
+totals cannot be read as the route named in the header section below. A
+provider/model change is a request boundary, not a reset boundary for this
+metric, and Harness's `tokenUsage` fold stays the single cumulative authority.
+
+`/model` now appends one informational note to its transcript line when the
+switch actually moves to a different provider or model: "cache reuse after a
+provider/model change is provider-dependent; /cache remains session-cumulative".
+The note claims neither outcome — no promise that cache is lost, no promise that
+it carries over — and depends on the move alone: re-selecting the active route
+says nothing, a pick that applied nothing says nothing, and there is no guard,
+confirmation, or automatic routing. It deliberately reads no usage projection,
+so no snapshot timing can affect whether it appears.

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/usage.md
-usage.md: f223d4048a909d26fde888ba64b16b9f93f8b92e
-usage.zh.md: 4bb9c15c331256b770bf6cd415a484aa542bdbc9
+usage.md: f3608ae2379acd513e203488964c32ec981195b6
+usage.zh.md: 1054b7f1e5ff426bb02c7c70b36dd879644d3b40

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/usage.md
-usage.md: f3608ae2379acd513e203488964c32ec981195b6
-usage.zh.md: 1054b7f1e5ff426bb02c7c70b36dd879644d3b40
+usage.md: 1860d45b415df72d2b3a7bdf9e5a8034ef7e29e8
+usage.zh.md: ee0be8361fdff40e186ffefe97d06f18ce0db98d

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1124,6 +1124,8 @@ provider serve from its cache?
 │  cache read      99.1%                                      │
 │  cached input    1.4M                                       │
 │  uncached input  13k                                        │
+│  Session cumulative · includes requests across             │
+│  provider/model changes                                    │
 │                                                             │
 │  Request header                                             │
 │  route           deepseek/deepseek-v4-flash                 │
@@ -1137,7 +1139,10 @@ provider serve from its cache?
 The top half is the same accounting `/usage` reports — Harness's own cumulative
 token buckets — narrowed to the cache question. There is no second count behind
 it. It is cumulative over the whole session and every route it used, which is
-why it is not filed under the route below it.
+why it is not filed under the route below it: a provider/model change is a
+request boundary, not a reset boundary, so the totals stay the totals even after
+the session moves to another model. The caption under the figures says that
+scope in one line.
 
 The bottom half is `Session.requestHeader()`, Harness's own fold of the request
 header. That header is the request state **outside** the conversation: the
@@ -1158,6 +1163,8 @@ provider fact nobody reported:
 │  This session has no provider-reported cache reads.         │
 │  dshline will show provider cache usage when the active     │
 │  Harness adapter exposes it.                                │
+│  Session cumulative · includes requests across             │
+│  provider/model changes                                    │
 │                                                             │
 │  Request header                                             │
 │  route           deepseek/deepseek-v4-flash                 │
@@ -1178,8 +1185,12 @@ unmounted meter is never mistaken for a quiet route.
 still the request header has been. Harness publishes no stability authority for
 it, and a logged header does not even mean the header moved — one is recorded on
 resume and again after a compaction with nothing about it changed. It also makes
-no claim that anything was saved, wasted, or missed, and it changes nothing:
-there is no warning on `/model`, no guard, and no automatic routing.
+no claim that anything was saved, wasted, or missed, and it changes nothing.
+The one consequence of a change is reported where the change is decided:
+`/model` adds one informational note when the switch actually moves to a
+different provider or model — cache reuse after the change is provider-dependent,
+and `/cache` stays session-cumulative. There is no guard, no confirmation, and
+no automatic routing.
 
 `/cache` is provider-neutral. A route whose adapter reports cache reads simply
 gets a richer top half; every route gets the same header half, because the
@@ -1352,6 +1363,22 @@ This is worth knowing before you use `/model` to try something for one question,
 ```
 · model set to deepseek-official / deepseek-v4-pro · also the default for new sessions
 ```
+
+A switch that actually moves to a different provider or model says what it can
+cost, in that same line, and only then:
+
+```
+· model set to opencode-go / deepseek-v4-flash · cache reuse after a provider/model change is provider-dependent; /cache remains session-cumulative · also the default for new sessions
+```
+
+The note is informational and claims neither outcome — cache reuse after a
+provider/model change is provider-dependent, and this frontend has no authority
+to promise which way any provider decides. It appears only when a real change is
+provable from two known selections: a different provider or model, where one was
+explicitly active. Re-selecting the model that is already active adds nothing,
+a first selection whose previous effective route is unknown proves nothing, and
+a pick that applied nothing adds nothing either. There is no guard, no
+confirmation, and no automatic routing.
 
 The two are independent, in that order: the running session switches first and is never rolled back, so if the settings file cannot be written you are told, and the turn you are about to run still uses the model you asked for.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1365,10 +1365,11 @@ This is worth knowing before you use `/model` to try something for one question,
 ```
 
 A switch that actually moves to a different provider or model says what it can
-cost, in that same line, and only then:
+cost, on its own second line, and only then:
 
 ```
-· model set to opencode-go / deepseek-v4-flash · cache reuse after a provider/model change is provider-dependent; /cache remains session-cumulative · also the default for new sessions
+· model set to opencode-go / deepseek-v4-flash · also the default for new sessions
+· cache reuse after a provider/model change is provider-dependent; /cache remains session-cumulative
 ```
 
 The note is informational and claims neither outcome — cache reuse after a

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -768,6 +768,8 @@ schema 由上面那套另外的估算统计，而把两种不同的估算加在�
 │  cache read      99.1%                                      │
 │  cached input    1.4M                                       │
 │  uncached input  13k                                        │
+│  Session cumulative · includes requests across             │
+│  provider/model changes                                    │
 │                                                             │
 │  Request header                                             │
 │  route           deepseek/deepseek-v4-flash                 │
@@ -780,7 +782,8 @@ schema 由上面那套另外的估算统计，而把两种不同的估算加在�
 
 上半部分就是 `/usage` 报告的那份计量——Harness 自己累计的 token 分桶——只是收窄到缓存
 这个问题上。它背后没有第二份统计。它是整个会话、跨其用过的每一条路由的累计值，所以它
-并不归在下方那条路由名下。
+并不归在下方那条路由名下：提供方/模型的变化是请求的边界，而不是重置的边界，即使会话移
+到另一个模型，总计仍保持总计。数字下方的说明文字用一行说清这个范围。
 
 下半部分是 `Session.requestHeader()`，即 Harness 自己对请求头的折叠。那个请求头是**对
 话之外**的请求状态：路由、渲染后的系统提示词，以及组装好的工具 schema。它是
@@ -798,6 +801,8 @@ schema 由上面那套另外的估算统计，而把两种不同的估算加在�
 │  This session has no provider-reported cache reads.         │
 │  dshline will show provider cache usage when the active     │
 │  Harness adapter exposes it.                                │
+│  Session cumulative · includes requests across             │
+│  provider/model changes                                    │
 │                                                             │
 │  Request header                                             │
 │  route           deepseek/deepseek-v4-flash                 │
@@ -816,7 +821,9 @@ schema 由上面那套另外的估算统计，而把两种不同的估算加在�
 **它不会告诉你什么。** 它不报告任何历史，也不对请求头有多稳定给出任何判断。Harness 没
 有为此发布稳定性权威，而且记录下一个请求头甚至并不意味着请求头发生了变动——恢复会话时
 会记录一个，压缩之后又会记录一个，而其中什么都没有改变。它同样不声称省下、浪费或错失
-了什么，也不改变任何东西：`/model` 上没有警告，没有护栏，也没有自动路由。
+了什么，也不改变任何东西。变更的唯一后果在做出变更的地方说明：当开关确实移到不同的提
+供方或模型时，`/model` 会加一行信息性说明——变更后的缓存复用取决于提供方，而 `/cache`
+仍是会话累计值。没有护栏，没有确认，也没有自动路由。
 
 `/cache` 与提供方无关。适配器报告缓存读取的路由只是获得更丰富的上半部分；每条路由都获
 得同样的请求头下半部分，因为请求头是 Harness 的记录，而不属于任何提供方。
@@ -971,6 +978,18 @@ dshline:
 ```
 · model set to deepseek-official / deepseek-v4-pro · also the default for new sessions
 ```
+
+真正切换到不同提供方或模型的开关，会在同一行里说明它可能付出的代价，而且只在这种情况下：
+
+```
+· model set to opencode-go / deepseek-v4-flash · cache reuse after a provider/model change is provider-dependent; /cache remains session-cumulative · also the default for new sessions
+```
+
+这句说明是信息性的，不承诺任何一种结果——提供方/模型变更后的缓存复用取决于提供方，本
+界面无权许诺任何提供方会怎么做。它只在能从两个已知的选择证明真实变更时出现：从一个明确
+激活的提供方或模型换成另一个。重新选择当前已激活的模型不会有任何附加说明；第一次选择时
+先前有效的路由未知，证明不了什么；未应用任何选择的挑选也不会有。没有护栏，没有确认，也
+没有自动路由。
 
 两者按那个顺序独立：运行中的会话先切换、绝不回滚，因此如果设置文件写不进去会告诉你，而即将运行的那一轮仍使用你要的模型。
 

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -979,10 +979,11 @@ dshline:
 · model set to deepseek-official / deepseek-v4-pro · also the default for new sessions
 ```
 
-真正切换到不同提供方或模型的开关，会在同一行里说明它可能付出的代价，而且只在这种情况下：
+真正切换到不同提供方或模型的开关，会在单独的第二行里说明它可能付出的代价，而且只在这种情况下：
 
 ```
-· model set to opencode-go / deepseek-v4-flash · cache reuse after a provider/model change is provider-dependent; /cache remains session-cumulative · also the default for new sessions
+· model set to opencode-go / deepseek-v4-flash · also the default for new sessions
+· cache reuse after a provider/model change is provider-dependent; /cache remains session-cumulative
 ```
 
 这句说明是信息性的，不承诺任何一种结果——提供方/模型变更后的缓存复用取决于提供方，本

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -86,7 +86,7 @@ import {
   usageInspection,
 } from './usage.ts'
 import { createUsageOverlay } from './usage-overlay.ts'
-import { cacheInspection, requestHeaderReading } from './cache/model.ts'
+import { cacheInspection, cacheTransitionNote, requestHeaderReading } from './cache/model.ts'
 import { createCacheOverlay } from './cache/overlay.ts'
 import { contextPreview, contextReading, ContextSurveyor, contextPressureTokens } from './context/model.ts'
 import { createContextOverlay } from './context/overlay.ts'
@@ -550,10 +550,21 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
       complete: async () => (await listModelOptions(ctx))
         .map(option => ({ value: option.model, note: option.provider })),
       execute: async rawInput => {
+        // The note is decided at this command seam, not inside the model
+        // picker: the selection before/after are the only facts it needs, and
+        // the picker stays cache-agnostic. No projection cut is captured:
+        // deciding "was there prior usage" would need a snapshot that is at
+        // once post-picker and pre-new-route while `/model` can run against an
+        // in-flight turn, and an informational note is not worth that race, so
+        // the note depends on the real provider/model move alone.
+        const before = selection.current
         const outcome = await pickModel(ctx, selection, rawInput)
         if (outcome !== undefined) {
           w.refreshModelInfo()
-          commit([paint(`· ${outcome}`, 'muted')])
+          const lines = [paint(`· ${outcome}`, 'muted')]
+          const note = cacheTransitionNote(before, selection.current)
+          if (note !== undefined) lines.push(paint(`· ${note}`, 'muted'))
+          commit(lines)
         }
         draw()
       },

--- a/packages/dshline/src/cache/model.ts
+++ b/packages/dshline/src/cache/model.ts
@@ -30,6 +30,7 @@
  */
 
 import type { EpochHeader, Session } from '@deepseek-ai/dsh-session'
+import type { ModelSelection } from '@deepseek-ai/dsh-agent'
 import type { ProjectionSnapshot } from '@deepseek-ai/dsh-session-projection'
 import type {} from '@deepseek-ai/dsh-token-meter/client'
 import type { UsageBuckets } from '../usage.ts'
@@ -125,6 +126,52 @@ export function cacheInspection(
     cacheReadShare: cacheReadShare(buckets),
     header,
   }
+}
+
+/**
+ * The informational note a real provider/model switch earns.
+ *
+ * Deliberately worded as an expectation about provider behaviour, never a
+ * promise about either outcome: dshline has no authority to say whether any
+ * particular provider reuses cache across a route change, and saying it would
+ * resend the prompt or keep the cache would claim a provider fact nobody
+ * reported. The second half is a statement about this frontend's own metric —
+ * `/cache` counts the whole session, so a route boundary is not a reset
+ * boundary — which is the claim this note exists to make.
+ */
+export const CACHE_TRANSITION_NOTE
+  = 'cache reuse after a provider/model change is provider-dependent; /cache remains session-cumulative'
+
+/**
+ * Whether a provider/model switch earns the transition note, and its text.
+ *
+ * The cache feature's answer to "is this a real provider/model move", decided
+ * on the two facts the command seam already has: the selection BEFORE and AFTER
+ * the pick. Deliberately no projection cut and no usage reading beside them:
+ * deciding "was there prior usage" would need a snapshot captured at exactly
+ * the transition, and the seam cannot take one that is both pre-new-route and
+ * post-picker while `/model` can run against an in-flight turn — so the note
+ * makes none of those claims and depends on nothing race-sensitive. The
+ * decision lives here, not in the model picker: model selection is about
+ * models, and the note is cache vocabulary, so the seam composes the two rather
+ * than the picker knowing about cache.
+ *
+ * A move is a REAL change of provider or model, and it takes two known
+ * selections to prove one: re-selecting what is already active says nothing,
+ * and so does either side being undefined — no explicit override before means
+ * the effective route is unknown, not that it differs, and no selection after
+ * means nothing was applied.
+ * @param before - the selection being replaced; undefined when no override existed.
+ * @param after - the selection the pick produced; undefined when nothing was applied.
+ * @returns the note to print, or undefined when the switch does not earn one.
+ */
+export function cacheTransitionNote(
+  before: ModelSelection | undefined,
+  after: ModelSelection | undefined,
+): string | undefined {
+  if (before === undefined || after === undefined) return undefined
+  if (before.provider === after.provider && before.model === after.model) return undefined
+  return CACHE_TRANSITION_NOTE
 }
 
 /**

--- a/packages/dshline/src/cache/overlay.ts
+++ b/packages/dshline/src/cache/overlay.ts
@@ -55,6 +55,18 @@ const LABEL_COLUMN = 16
 const WHEN_AVAILABLE
   = 'dshline will show provider cache usage when the active Harness adapter exposes it.'
 
+/**
+ * The accounting's scope, in one line.
+ *
+ * The figures above are Harness's session-wide `tokenUsage` fold — every route
+ * this session used, including ones the session has left. The header section
+ * below names ONE recorded request, so without the caption a reader can read
+ * the totals as the route beneath them. A provider/model change is a request
+ * boundary, not a reset boundary for this metric, and the caption says that
+ * without having to say why the numbers did not move.
+ */
+const SESSION_SCOPE_NOTE = 'Session cumulative · includes requests across provider/model changes'
+
 /** Inputs the cache inspector needs from its owner. */
 export interface CacheOverlaySpec {
   /** The current reading, read fresh on every paint. */
@@ -149,15 +161,19 @@ function accountingRows(inspection: CacheInspection, width: number): string[] {
   const rows = [paint('Cache accounting', 'section-heading')]
   const buckets = inspection.buckets
   if (!hasCacheReads(inspection) || buckets === undefined) {
-    return [...rows, ...note(unavailable(inspection), width), ...note(WHEN_AVAILABLE, width)]
+    rows.push(...note(unavailable(inspection), width), ...note(WHEN_AVAILABLE, width))
+  } else {
+    const share = formatCacheShare(inspection.cacheReadShare)
+    if (share !== undefined) rows.push(fact('cache read', share, width))
+    rows.push(
+      fact('cached input', formatTokens(buckets.cacheRead), width),
+      fact('uncached input', formatTokens(buckets.uncachedInput), width),
+    )
+    if (buckets.cacheWrite > 0) rows.push(fact('cache write', formatTokens(buckets.cacheWrite), width))
   }
-  const share = formatCacheShare(inspection.cacheReadShare)
-  if (share !== undefined) rows.push(fact('cache read', share, width))
-  rows.push(
-    fact('cached input', formatTokens(buckets.cacheRead), width),
-    fact('uncached input', formatTokens(buckets.uncachedInput), width),
-  )
-  if (buckets.cacheWrite > 0) rows.push(fact('cache write', formatTokens(buckets.cacheWrite), width))
+  // The caption belongs to the accounting half, not the header half: it states
+  // what the fold's scope is, and the route below it is a separate record.
+  rows.push(...note(SESSION_SCOPE_NOTE, width))
   return rows
 }
 

--- a/packages/dshline/tests/cache-inspector.spec.ts
+++ b/packages/dshline/tests/cache-inspector.spec.ts
@@ -22,8 +22,15 @@ import SessionProjectionRegistry from '@deepseek-ai/dsh-session-projection'
 import type { ProjectionSnapshot } from '@deepseek-ai/dsh-session-projection'
 import TokenMeter from '@deepseek-ai/dsh-token-meter'
 import type { ToolSchema } from '@deepseek-ai/dsh-llm'
+import type { ModelSelection } from '@deepseek-ai/dsh-agent'
 import { displayWidth, stripAnsi } from '@dshline/renderer'
-import { cacheInspection, hasCacheReads, requestHeaderReading } from '../src/cache/model.ts'
+import {
+  CACHE_TRANSITION_NOTE,
+  cacheInspection,
+  cacheTransitionNote,
+  hasCacheReads,
+  requestHeaderReading,
+} from '../src/cache/model.ts'
 import type { CacheInspection, RequestHeaderReading } from '../src/cache/model.ts'
 import { createCacheOverlay } from '../src/cache/overlay.ts'
 
@@ -212,6 +219,53 @@ describe('the cache inspection', () => {
     expect(hasCacheReads(inspection)).toBe(true)
   })
 
+  it('keeps one cumulative fold across a provider/model change', async () => {
+    // A provider/model switch is exactly the case the scope caption exists for:
+    // the session's totals must NOT reset at the boundary, because the buckets
+    // are a session bill, not any one route's gauge. The second route below
+    // starts without a cache read, the way a real switch behaves.
+    const ctx = new Context()
+    await ctx.plugin(SessionStore)
+    await ctx.plugin(SessionProjectionRegistry)
+    await ctx.plugin(TokenMeter)
+    const target: Session = ctx.sessions.create()
+    const send = (
+      turn: number,
+      id: string,
+      source: { provider: string; model: string },
+      usage: Record<string, number>,
+    ): void => {
+      target.append('turn/start', { turn })
+      target.append('step/start', { turn, step: 1 })
+      target.append('assistant/message', {
+        turn, step: 1,
+        message: {
+          id, role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }], source: { kind: 'model', ...source },
+        },
+        usage,
+      } as never, { surfaceOp: 'append' })
+      target.append('step/end', { turn, step: 1 })
+      target.append('turn/end', { turn, reason: { kind: 'completed' } })
+    }
+    send(1, 'a-1', { provider: 'openai-codex', model: 'gpt-5.6-terra' },
+      { inputTokens: 12_800, outputTokens: 40, cacheReadTokens: 1_400_000, cacheWriteTokens: 0 })
+    send(2, 'a-2', { provider: 'opencode-go', model: 'deepseek-v4-flash' },
+      { inputTokens: 45_508, outputTokens: 300 })
+
+    const inspection = cacheInspection(ctx.sessionProjections.snapshot(target), reading())
+    // Both routes' billing in one fold: the switch is a request boundary, not
+    // a reset boundary.
+    expect(inspection.buckets).toEqual({
+      uncachedInput: 58_308,
+      cacheRead: 1_400_000,
+      cacheWrite: 0,
+      input: 1_458_308,
+      output: 340,
+    })
+    expect(inspection.cacheReadShare).toBeCloseTo(1_400_000 / 1_458_308, 10)
+  })
+
   it('has no cache read without a registry, without the meter, or with a zero read bucket', () => {
     expect(hasCacheReads(cacheInspection(undefined, reading()))).toBe(false)
     expect(hasCacheReads(cacheInspection(cut(), reading()))).toBe(false)
@@ -312,6 +366,20 @@ describe('the cache report', () => {
     expect(drawn).toContain('31')
   })
 
+  it('says the accounting is session-cumulative across provider/model changes', () => {
+    // The header section below names ONE recorded route; the caption stops the
+    // totals above it from being read as that route's own cache.
+    const drawn = report(cacheInspection(CACHING_ROUTE, reading()))
+    expect(drawn).toContain('Session cumulative')
+    expect(drawn).toContain('includes requests across provider/model changes')
+  })
+
+  it('keeps the scope caption when accounting is unavailable', () => {
+    // The statement is about the session regardless of whether figures exist.
+    expect(prose(cacheInspection(undefined, reading())))
+      .toContain('Session cumulative · includes requests across provider/model changes')
+  })
+
   it('never claims a saving, a waste, or a cause', () => {
     for (const inspection of [
       cacheInspection(CACHING_ROUTE, reading()),
@@ -382,5 +450,43 @@ describe('the cache report', () => {
     })
     overlay.handleKey?.({ kind: 'text', text: 's' } as never)
     expect(closed).toBe(0)
+  })
+})
+
+describe('the model-switch cache note', () => {
+  /** A selection shaped like the ref's current value. */
+  function sel(provider: string, model: string): ModelSelection {
+    return { provider, model }
+  }
+
+  it('notes that cache reuse is provider-dependent when the route actually changes', () => {
+    expect(cacheTransitionNote(sel('openai-codex', 'gpt-5.6-terra'), sel('opencode-go', 'deepseek-v4-flash')))
+      .toBe(CACHE_TRANSITION_NOTE)
+  })
+
+  it('stays silent when the already-active provider/model is selected again', () => {
+    // Re-selecting what is current is not a move, so it earns no note.
+    const current = sel('opencode-go', 'deepseek-v4-flash')
+    expect(cacheTransitionNote(current, current)).toBeUndefined()
+  })
+
+  it('stays silent when either side of the transition is unknown', () => {
+    // `before` undefined means no explicit override existed — Harness may
+    // already be resolving an effective route underneath it, so nothing proves
+    // a change happened. `after` undefined means nothing was applied.
+    expect(cacheTransitionNote(undefined, sel('deepseek-official', 'deepseek-v4-flash')))
+      .toBeUndefined()
+    expect(cacheTransitionNote(sel('deepseek-official', 'deepseek-v4-flash'), undefined))
+      .toBeUndefined()
+    expect(cacheTransitionNote(undefined, undefined)).toBeUndefined()
+  })
+
+  it('states provider dependence and session-cumulative scope, and nothing more', () => {
+    // dshline has no authority to promise either outcome — "the cache is lost"
+    // or "the cache carries over" — only to say what its own metric is. The
+    // wording must therefore commit to neither.
+    expect(CACHE_TRANSITION_NOTE).toContain('provider-dependent')
+    expect(CACHE_TRANSITION_NOTE).toContain('session-cumulative')
+    expect(CACHE_TRANSITION_NOTE).not.toMatch(/will|guaranteed|lost|resend|uncached|carry over/iu)
   })
 })


### PR DESCRIPTION
**What this fixes.** `/cache` reported one blended session-wide percentage while the header section beneath it named a single route, so the totals read as the *current model's* cache even though they mix every provider/model the session has used. And `/model` switched models silently, with nothing explaining that cache reuse across a provider/model change is provider-dependent.

**What changes.**

- `/cache` gains one muted caption under its accounting — `Session cumulative · includes requests across provider/model changes` — so the header's route cannot be mistaken for the scope of the figures above it. Accounting is untouched: Harness's `tokenUsage` fold stays the single cumulative authority; a provider/model change is a request boundary, not a reset boundary for that metric (no reset, no per-route fork).
- `/model` appends one informational note when the selection *provably* changes provider or model (both sides known and different): `cache reuse after a provider/model change is provider-dependent; /cache remains session-cumulative`. It claims neither outcome — no guarantee that cache is lost, no guarantee that it carries over — and depends on no projection cut, so no snapshot timing (an in-flight turn under the old route, async settings persistence) can affect whether it appears. The note renders as its own second transcript line, as the docs now show.
  - Silent on: same-route re-selection, cancelled/unapplied picks, and a first explicit selection (`before === undefined` — the effective route is unknown, not different).

**Design choices.** Resetting the figures would lie about the bill (the buckets are cumulative session accounting shared with `/usage`). Warning that cache "will be lost" would claim a provider fact this frontend cannot observe — the note is a hedged provider-behaviour expectation. The decision lives in the cache feature (`cacheTransitionNote`) composed by the `/model` command seam; the generic model picker stays cache-agnostic, and `/cache` remains session-cumulative.

**Verified.** `pnpm typecheck`, `pnpm build`, `pnpm test` (2954 passed, 37 skipped), `pnpm run verify-docs` (9 pairs consistent). Undefined-side and same-route silence are pinned by tests.

**Out of scope:** the harness-sync CI fix (`5fcd8e5`) is intentionally **not** in this PR — it remains on local `main`, unpushed.
