### PR TITLE
fix(dshline): cancel attachment work before exit

### DIFF
--- a/.changeset/quiet-otters-exit.md
+++ b/.changeset/quiet-otters-exit.md
@@ -3,5 +3,3 @@
 ---
 
 Make `/exit`, `/quit`, and the equivalent quit gestures cancel active attachment work before requesting shutdown. Exit no longer waits for replay input gating, and image admission and command execution receive attachment-lifetime cancellation.
-
-Improve `/sessions` clarity by labeling delegated child sessions in the list and showing `current` instead of `untitled` for the open session when it has no title.

--- a/.changeset/quiet-otters-exit.md
+++ b/.changeset/quiet-otters-exit.md
@@ -1,0 +1,7 @@
+---
+'@dshline/dshline': patch
+---
+
+Make `/exit`, `/quit`, and the equivalent quit gestures cancel active attachment work before requesting shutdown. Exit no longer waits for replay input gating, and image admission and command execution receive attachment-lifetime cancellation.
+
+Improve `/sessions` clarity by labeling delegated child sessions in the list and showing `current` instead of `untitled` for the open session when it has no title.

--- a/docs/architecture.i18n.yaml
+++ b/docs/architecture.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/architecture.md
-architecture.md: 39b840e4ce286983904e4debea5e064c825e5d26
-architecture.zh.md: 14cbb6e8dfe5cdb53bb97c0723a90880e0240eeb
+architecture.md: c953317ce1d9e663643d72b35ef9fc7ff1a95e2b
+architecture.zh.md: 23eb454f5a5bc20fdfcbf053c301c2dcaa94c1b6

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -437,7 +437,11 @@ registrations, the log listener, the spinner, and the Work and projection
 adapters all describe one session, so they belong to a `SessionScope` that comes
 down before its agent handle does. Key routing moved the other way, up to the
 window, which is also why `ctrl-d` now quits from the launch browser without that
-browser owning a keyboard of its own.
+browser owning a keyboard of its own. The window remains the global quit owner; an
+attached session supplies only a cancellation-aware prelude that cancels its own
+async work and tears down presentation before interrupting the Agent through its
+public cancel seam. It then requests `ctx.appExit`; Harness still owns AgentHandle
+teardown, tree disposal, persistence, and final process shutdown.
 
 Reopening uses the supported lifecycle and nothing else: the owned
 `AgentHandle.dispose()` retires the current agent — the handle is this

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -229,7 +229,7 @@ window        terminal, key routing, model route, reader preferences
 attachment    one Agent, its log projection, its capability adapters, its views
 ```
 
-当一次启动在进程生命周期内恰好驱动一个会话时，插件 fiber 与会话是同一个生命周期，`ctx.effect` 是适合拥有一切的地方。原位重新打开会话打破了这个同一性：槽位注册、日志监听器、旋转指示器以及 Work 与投影适配器都描述同一个会话，因此它们属于一个在其 agent 句柄之前拆除的 `SessionScope`。按键路由向另一个方向移动，上移到窗口，这也是为什么 `ctrl-d` 现在从启动浏览器退出，而那个浏览器不拥有自己的键盘。
+当一次启动在进程生命周期内恰好驱动一个会话时，插件 fiber 与会话是同一个生命周期，`ctx.effect` 是适合拥有一切的地方。原位重新打开会话打破了这个同一性：槽位注册、日志监听器、旋转指示器以及 Work 与投影适配器都描述同一个会话，因此它们属于一个在其 agent 句柄之前拆除的 `SessionScope`。按键路由向另一个方向移动，上移到窗口，这也是为什么 `ctrl-d` 现在从启动浏览器退出，而那个浏览器不拥有自己的键盘。窗口仍然是全局退出的所有者；附着的会话只提供一个感知取消的前置步骤：取消它自己的异步工作、拆除呈现，然后通过公开的取消 seam 中断 Agent。随后它请求 `ctx.appExit`；AgentHandle 的拆除、树的销毁、持久化与最终进程退出仍由 Harness 负责。
 
 重新打开只使用受支持的生命周期，别无其他：拥有的 `AgentHandle.dispose()` 使当前 agent 退役——句柄是本前端的能力，因为本前端创建了该 agent——而 `ctx.agents.resume` 打开下一个。会话记录追加进已有内容下的原生滚动缓冲区；没有任何已提交内容被重写。被拒绝的恢复既不终止进程，也不替换会话：到那时前一个 agent 已退役，因此窗口提交 Harness 的原因，并通过同一个浏览器再次询问。关掉它正是读者刻意选择新会话的方式。
 

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -207,11 +207,15 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   const scope = new SessionScope()
   const attachmentAbort = new AbortController()
   let imageAdmission: AbortController | undefined
-  scope.own(() => {
+  const cancelAttachmentWork = (): void => {
     attachmentAbort.abort(new Error('Session attachment stopped because the session closed.'))
     imageAdmission?.abort(new Error('Image attachment stopped because the session closed.'))
     imageAdmission = undefined
-  })
+  }
+  // Session switching and process exit share the same cancellation prelude. The
+  // scope registration remains the ordinary-switch owner; the explicit call in
+  // the exit path makes the ordering visible before presentation teardown.
+  scope.own(cancelAttachmentWork)
   // Created before anything can ask for it: a transition requested while the
   // transcript is still replaying must not resolve into a promise that does not
   // exist yet.
@@ -222,17 +226,18 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   const requestExit = (): void => {
     if (exitRequested) return
     exitRequested = true
-    // The launcher's exit request waits for tree disposal. Tear down this
-    // attachment's presentation first, then cancel any active model request so
-    // the same AbortSignal reaches the provider before AgentHandle.dispose()
-    // waits for loop convergence. The launcher still owns final shutdown.
+    // The launcher's exit request waits for tree disposal. Cancel attachment
+    // work first, tear down presentation second, then interrupt any active model
+    // request so the same AbortSignal reaches the provider before
+    // AgentHandle.dispose() waits for loop convergence. The launcher still owns
+    // final shutdown.
+    cancelAttachmentWork()
     try {
       scope.dispose()
-    } catch (error: unknown) {
-      // Exit is not the moment to strand the terminal over a cleanup failure.
-      // The normal session-switch path still reports these failures to the
-      // transcript; shutdown proceeds after the best-effort cleanup here.
-      process.stderr.write(`dshline: session cleanup failed: ${error instanceof Error ? error.message : String(error)}\r\n`)
+    } catch {
+      // SessionScope contains disposer failures after running every disposer.
+      // There is no safe terminal-independent diagnostic surface here; do not
+      // replace Harness shutdown with a raw write into the TUI's terminal.
     }
     if (agent.status === 'running') agent.cancel({ kind: 'user' })
     exit?.(0)

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -205,8 +205,10 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   const { ctx, terminal, exit, startup, pricing, peakHours, selection, prefs, draw, commit, clear } = w
   const { target, attached } = outcome
   const scope = new SessionScope()
+  const attachmentAbort = new AbortController()
   let imageAdmission: AbortController | undefined
   scope.own(() => {
+    attachmentAbort.abort(new Error('Session attachment stopped because the session closed.'))
     imageAdmission?.abort(new Error('Image attachment stopped because the session closed.'))
     imageAdmission = undefined
   })
@@ -216,6 +218,27 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   let requestNext: (target: AttachTarget) => void = () => {}
   const switched = new Promise<AttachTarget>(resolve => { requestNext = resolve })
   const { agent, dispose: disposeAgent } = attached.handle
+  let exitRequested = false
+  const requestExit = (): void => {
+    if (exitRequested) return
+    exitRequested = true
+    // The launcher's exit request waits for tree disposal. Tear down this
+    // attachment's presentation first, then cancel any active model request so
+    // the same AbortSignal reaches the provider before AgentHandle.dispose()
+    // waits for loop convergence. The launcher still owns final shutdown.
+    try {
+      scope.dispose()
+    } catch (error: unknown) {
+      // Exit is not the moment to strand the terminal over a cleanup failure.
+      // The normal session-switch path still reports these failures to the
+      // transcript; shutdown proceeds after the best-effort cleanup here.
+      process.stderr.write(`dshline: session cleanup failed: ${error instanceof Error ? error.message : String(error)}\r\n`)
+    }
+    if (agent.status === 'running') agent.cancel({ kind: 'user' })
+    exit?.(0)
+  }
+  w.setExit(requestExit)
+  scope.own(() => { w.setExit(undefined) })
 
   // Held until after the banner, so the transcript reads in the order it
   // happened rather than opening with a footnote. The window asked which session
@@ -966,12 +989,12 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     {
       name: 'exit',
       description: 'Leave the session, as ctrl-d does',
-      execute: () => { exit?.(0) },
+      execute: () => { requestExit() },
     },
     {
       name: 'quit',
       description: 'Leave the session, as ctrl-d does',
-      execute: () => { exit?.(0) },
+      execute: () => { requestExit() },
     },
   ])
 
@@ -1405,7 +1428,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
             workspace,
             attachments.imageLimits.maxImageBytes,
             attachments.imageLimits.maxMessageImageBytes,
-            AbortSignal.any([admission.signal, AbortSignal.timeout(IMAGE_ADMISSION_TIMEOUT_MS)]),
+            AbortSignal.any([attachmentAbort.signal, admission.signal, AbortSignal.timeout(IMAGE_ADMISSION_TIMEOUT_MS)]),
           )
         } catch (error: unknown) {
           if (scope.closed) return
@@ -1426,8 +1449,15 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
         commandLine,
         commandImages,
         admission === undefined
-          ? AbortSignal.timeout(isCompactionCommand ? COMPACTION_COMMAND_TIMEOUT_MS : COMMAND_TIMEOUT_MS)
-          : AbortSignal.any([admission.signal, AbortSignal.timeout(COMMAND_TIMEOUT_MS)]),
+          ? AbortSignal.any([
+            attachmentAbort.signal,
+            AbortSignal.timeout(isCompactionCommand ? COMPACTION_COMMAND_TIMEOUT_MS : COMMAND_TIMEOUT_MS),
+          ])
+          : AbortSignal.any([
+            attachmentAbort.signal,
+            admission.signal,
+            AbortSignal.timeout(COMMAND_TIMEOUT_MS),
+          ]),
       )
     } catch (error: unknown) {
       if (scope.closed) return
@@ -1531,7 +1561,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
       const admission = new AbortController()
       imageAdmission = admission
       const batch = imageDrafts.items
-      const admissionSignal = AbortSignal.any([admission.signal, AbortSignal.timeout(IMAGE_ADMISSION_TIMEOUT_MS)])
+      const admissionSignal = AbortSignal.any([attachmentAbort.signal, admission.signal, AbortSignal.timeout(IMAGE_ADMISSION_TIMEOUT_MS)])
       let inputs
       try {
         inputs = await readImageDrafts(
@@ -1683,6 +1713,15 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
       // had in flight must not land afterwards.
       completion.invalidate()
       if (replaying !== undefined) {
+        // Leaving is window-global and must not wait for a slow transcript read:
+        // unlike a prompt, `/exit` cannot be interleaved with the replay flood.
+        // `ctrl-d` already takes this path at the window boundary; exempt the
+        // equivalent local commands here as well.
+        const replayCommand = parseCommand(action.text.trim())
+        if (replayCommand?.name === 'exit' || replayCommand?.name === 'quit') {
+          void localCommands.execute(replayCommand.name, replayCommand.rawInput).catch(report)
+          return
+        }
         // The composer has already cleared its buffer. Put the draft back so the
         // enter that could not be honoured costs nothing, and park the reason in
         // the transcript AFTER the replay flood (this window is the one in which
@@ -1753,7 +1792,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
           }
           return
         }
-        exit?.(0)
+        requestExit()
         return
       }
       case 'ctrl-r':

--- a/packages/dshline/src/window.ts
+++ b/packages/dshline/src/window.ts
@@ -224,6 +224,29 @@ function terminalColorDepth(): ColorDepth {
 }
 
 /**
+ * Route one decoded key through the window's global quit boundary.
+ *
+ * Kept as the small policy seam under the one terminal subscription: `ctrl-d`
+ * never belongs to an overlay or attachment, while every other key may be
+ * delegated to the current attachment.
+ * @param key - the decoded terminal key.
+ * @param requestExit - the window exit request, possibly attachment-aware.
+ * @param dispatch - the current attachment's key handler, when one exists.
+ * @returns nothing; the chosen handler receives the key synchronously.
+ */
+export function routeWindowKey(
+  key: Key,
+  requestExit: () => void,
+  dispatch: ((key: Key) => void) | undefined,
+): void {
+  if (key.kind === 'key' && key.name === 'ctrl-d') {
+    requestExit()
+    return
+  }
+  dispatch?.(key)
+}
+
+/**
  * Take the terminal and wait for the Loader, before any agent exists.
  *
  * The Loader mounts siblings concurrently, so this waits for the whole tree
@@ -356,11 +379,7 @@ export async function createWindow(ctx: Context, options: WindowOptions): Promis
     else exitHandler()
   }
   ctx.effect(() => terminal.onKey(key => {
-    if (key.kind === 'key' && key.name === 'ctrl-d') {
-      requestExit()
-      return
-    }
-    dispatch?.(key)
+    routeWindowKey(key, requestExit, dispatch)
   }), 'dshline: input')
   ctx.effect(() => ctx.on('tui/render', draw), 'dshline: redraw on slot change')
   ctx.effect(() => terminal.onResize(() => {

--- a/packages/dshline/src/window.ts
+++ b/packages/dshline/src/window.ts
@@ -196,6 +196,8 @@ export interface Window {
   readonly refreshModelInfo: () => void
   /** Route decoded keys to the attached session, or to nothing between two. */
   readonly setDispatch: (handler: ((key: Key) => void) | undefined) => void
+  /** Install the attached session's cancellation-aware exit handler. */
+  readonly setExit: (handler: (() => void) | undefined) => void
 }
 
 /**
@@ -346,9 +348,16 @@ export async function createWindow(ctx: Context, options: WindowOptions): Promis
   // thing everywhere, and the places it used to be re-implemented — the launch
   // picker's own key loop — are exactly the places it went missing.
   let dispatch: ((key: Key) => void) | undefined
+  let exitHandler: (() => void) | undefined
+  const requestExit = (): void => {
+    // An attached agent supplies a cancellation-aware handler. During the gaps
+    // before and between attachments, the launcher remains the only authority.
+    if (exitHandler === undefined) exit?.(0)
+    else exitHandler()
+  }
   ctx.effect(() => terminal.onKey(key => {
     if (key.kind === 'key' && key.name === 'ctrl-d') {
-      exit?.(0)
+      requestExit()
       return
     }
     dispatch?.(key)
@@ -425,6 +434,7 @@ export async function createWindow(ctx: Context, options: WindowOptions): Promis
     clear,
     refreshModelInfo,
     setDispatch: handler => { dispatch = handler },
+    setExit: handler => { exitHandler = handler },
   }
 }
 

--- a/packages/dshline/tests/context-attachment.spec.ts
+++ b/packages/dshline/tests/context-attachment.spec.ts
@@ -147,6 +147,7 @@ async function fixture(options: {
     clear: () => {},
     refreshModelInfo: () => {},
     setDispatch: (handler?: (key: Key) => void) => { dispatch = handler },
+    setExit: () => {},
   } as unknown as Window
 
   const agent = {

--- a/packages/dshline/tests/delivery-routing.spec.ts
+++ b/packages/dshline/tests/delivery-routing.spec.ts
@@ -83,6 +83,7 @@ async function fixture(options: { busyEnter?: BusyEnter } = {}) {
     clear: () => {},
     refreshModelInfo: () => {},
     setDispatch: handler => { dispatch = handler },
+    setExit: () => {},
   } as unknown as Window
 
   const session = Session.create(SessionId('routing-test'))

--- a/packages/dshline/tests/exit-lifecycle.spec.ts
+++ b/packages/dshline/tests/exit-lifecycle.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * The attachment-specific shutdown prelude, exercised through real input paths.
+ *
+ * The window still owns the global key boundary; this fixture only captures the
+ * handler the attachment installs there. A real attachment then proves that
+ * local quit commands, idle ctrl-c, Agent cancellation, and lifetime signals all
+ * converge on the same ordered prelude before the launcher's app-exit seam.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { Context as RealContext } from '@deepseek-ai/cordis'
+import { type Key } from '@dshline/renderer'
+import { attachSession } from '../src/attachment.ts'
+import { TuiSlots } from '../src/slots.ts'
+import { pricingFrom } from '../src/usage.ts'
+import type { AttachOutcome } from '../src/sessions/reopen.ts'
+import type { Window } from '../src/window.ts'
+
+/** Configuration for one attachment shutdown fixture. */
+interface FixtureOptions {
+  /** Lifecycle state visible to the attachment. */
+  readonly status?: 'idle' | 'running'
+  /** Mount a pending `/compact` command to capture its lifetime signal. */
+  readonly pendingCommand?: boolean
+  /** Make the window's exit-handler cleanup throw when it is cleared. */
+  readonly cleanupFailure?: boolean
+}
+
+/** One assembled attachment and the controls needed by these tests. */
+interface Fixture {
+  readonly dispatch: () => ((key: Key) => void) | undefined
+  readonly requestExit: () => void
+  readonly exit: ReturnType<typeof vi.fn>
+  readonly events: string[]
+  readonly agent: { readonly status: 'idle' | 'running'; readonly cancel: ReturnType<typeof vi.fn> }
+  readonly commandSignal: () => AbortSignal | undefined
+}
+
+/** Let the attachment's submitted command reach its Harness double. */
+async function flush(): Promise<void> {
+  await new Promise<void>(resolve => { setImmediate(resolve) })
+}
+
+/** Type and submit one line through the real attachment composer. */
+function submit(dispatch: ((key: Key) => void) | undefined, line: string): void {
+  expect(dispatch).toBeDefined()
+  for (const text of [...line]) dispatch?.({ kind: 'text', text })
+  dispatch?.({ kind: 'key', name: 'enter' })
+}
+
+/** Build one fresh attached session with captured exit and command seams. */
+async function fixture(options: FixtureOptions = {}): Promise<Fixture> {
+  const ctx = new RealContext()
+  await ctx.plugin(TuiSlots)
+  ctx.provide('tools', { get: () => undefined })
+  ctx.provide('userQuestions', {} as never)
+
+  let commandSignal: AbortSignal | undefined
+  const commands = {
+    list: () => options.pendingCommand
+      ? [{ name: 'compact', description: 'Compact older conversation history' }]
+      : [],
+    execute: vi.fn(async (
+      _agent: unknown,
+      _line: string,
+      _images: readonly unknown[],
+      signal: AbortSignal,
+    ) => {
+      commandSignal = signal
+      if (options.pendingCommand) await new Promise<never>(() => {})
+      return { commandId: 'exit-test', result: { kind: 'success' as const } }
+    }),
+  }
+  ctx.provide('commands', commands as never)
+
+  const events: string[] = []
+  const exit = vi.fn(() => { events.push('appExit') })
+  let exitHandler: (() => void) | undefined
+  const setExit = (handler: (() => void) | undefined): void => {
+    if (handler === undefined && options.cleanupFailure) throw new Error('cleanup failed')
+    exitHandler = handler
+  }
+  let dispatch: ((key: Key) => void) | undefined
+  const window = {
+    ctx,
+    terminal: { columns: () => 80, rows: () => 24 },
+    exit,
+    startup: { cwd: '/workspace', task: undefined, resume: undefined },
+    pricing: pricingFrom(undefined),
+    peakHours: [],
+    version: 'test',
+    selection: { current: undefined },
+    modelInfo: { contextWindow: undefined, reasoning: undefined },
+    prefs: {
+      usageMode: 'cost',
+      timing: false,
+      cardDetail: 'compact',
+      reasoningVisible: true,
+      busyEnter: 'queue',
+    },
+    colorDepth: 0,
+    palette: () => ({}),
+    setPalette: () => {},
+    themeSettings: {},
+    pendingTask: undefined,
+    draw: () => {},
+    paintNow: () => {},
+    commit: () => {},
+    clear: () => {},
+    refreshModelInfo: () => {},
+    setDispatch: (handler: ((key: Key) => void) | undefined) => { dispatch = handler },
+    setExit,
+  } as unknown as Window
+  const agent = {
+    session: { id: 'exit-test', header: { cwd: '/workspace' }, events: [] },
+    status: options.status ?? 'idle',
+    inbox: { nextStep: [], nextTurn: [] },
+    followup: vi.fn(),
+    steer: vi.fn(),
+    cancel: vi.fn(() => { events.push('cancel') }),
+  }
+  const outcome = {
+    target: { kind: 'new', cwd: '/workspace' },
+    attached: { handle: { agent, dispose: async () => {} }, reopened: false },
+  } as unknown as AttachOutcome
+
+  void attachSession(window, outcome)
+  expect(exitHandler).toBeDefined()
+  return {
+    dispatch: () => dispatch,
+    requestExit: () => { exitHandler?.() },
+    exit,
+    events,
+    agent,
+    commandSignal: () => commandSignal,
+  }
+}
+
+describe('attachment exit lifecycle', () => {
+  it('routes the local exit and quit commands through one exit behavior', async () => {
+    for (const command of ['/exit', '/quit']) {
+      const f = await fixture()
+      submit(f.dispatch(), command)
+      expect(f.exit).toHaveBeenCalledOnce()
+      expect(f.events).toEqual(['appExit'])
+    }
+  })
+
+  it('uses the same exit path for idle ctrl-c', async () => {
+    const f = await fixture()
+    f.dispatch()?.({ kind: 'key', name: 'ctrl-c' })
+    expect(f.exit).toHaveBeenCalledOnce()
+    expect(f.events).toEqual(['appExit'])
+  })
+
+  it('cancels a running Agent before requesting app exit', async () => {
+    const f = await fixture({ status: 'running' })
+    submit(f.dispatch(), '/exit')
+    expect(f.events).toEqual(['cancel', 'appExit'])
+    expect(f.agent.cancel).toHaveBeenCalledWith({ kind: 'user' })
+  })
+
+  it('aborts a pending registered command through the attachment lifetime', async () => {
+    const f = await fixture({ pendingCommand: true })
+    submit(f.dispatch(), '/compact')
+    await flush()
+    const signal = f.commandSignal()
+    expect(signal).toBeDefined()
+    expect(signal?.aborted).toBe(false)
+
+    f.requestExit()
+    expect(signal?.aborted).toBe(true)
+    expect(f.exit).toHaveBeenCalledOnce()
+  })
+
+  it('contains cleanup failure and still requests Harness shutdown', async () => {
+    const f = await fixture({ cleanupFailure: true })
+    f.requestExit()
+    expect(f.exit).toHaveBeenCalledOnce()
+  })
+
+  it('does not repeat cancellation or shutdown for repeated exit gestures', async () => {
+    const f = await fixture({ status: 'running' })
+    f.requestExit()
+    f.requestExit()
+    expect(f.agent.cancel).toHaveBeenCalledOnce()
+    expect(f.exit).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/dshline/tests/image-attachment-flow.spec.ts
+++ b/packages/dshline/tests/image-attachment-flow.spec.ts
@@ -118,6 +118,7 @@ async function fixture(options: {
     clear: () => {},
     refreshModelInfo: () => {},
     setDispatch: (handler?: (key: Key) => void) => { dispatch = handler },
+    setExit: () => {},
   } as unknown as Window
   const agent = {
     session: { id: 's-image', header: { cwd: '/workspace' }, events: [] },

--- a/packages/dshline/tests/image-attachment-flow.spec.ts
+++ b/packages/dshline/tests/image-attachment-flow.spec.ts
@@ -34,6 +34,8 @@ async function fixture(options: {
   reads: ReturnType<typeof vi.fn>
   saves: ReturnType<typeof vi.fn>
   commands: { execute: ReturnType<typeof vi.fn> }
+  exit: ReturnType<typeof vi.fn>
+  requestExit: () => void
   commits: string[][]
   draws: ReturnType<typeof vi.fn>
   frame: () => string
@@ -88,6 +90,8 @@ async function fixture(options: {
   }
 
   const commits: string[][] = []
+  const exit = vi.fn()
+  let exitHandler: (() => void) | undefined
   let dispatch: ((key: Key) => void) | undefined
   let latest: string[] = []
   const compose = (): void => { latest = ctx.tuiSlots.compose(80, 24).lines }
@@ -95,7 +99,7 @@ async function fixture(options: {
   const window = {
     ctx,
     terminal: { columns: () => 80, rows: () => 24 },
-    exit: undefined,
+    exit,
     startup: { cwd: '/workspace', task: undefined, resume: undefined },
     pricing: pricingFrom(undefined),
     peakHours: [],
@@ -118,7 +122,7 @@ async function fixture(options: {
     clear: () => {},
     refreshModelInfo: () => {},
     setDispatch: (handler?: (key: Key) => void) => { dispatch = handler },
-    setExit: () => {},
+    setExit: handler => { exitHandler = handler },
   } as unknown as Window
   const agent = {
     session: { id: 's-image', header: { cwd: '/workspace' }, events: [] },
@@ -139,6 +143,8 @@ async function fixture(options: {
     reads,
     saves,
     commands,
+    exit,
+    requestExit: () => { exitHandler?.() },
     commits,
     draws,
     frame: () => stripAnsi(latest.join('\n')),
@@ -304,6 +310,24 @@ describe('image attachment submission', () => {
     expect(f.agent.followup).not.toHaveBeenCalled()
     expect(f.saves).not.toHaveBeenCalled()
     expect(f.commits.flat().map(stripAnsi).join('\n')).toContain('image attachment cancelled')
+  })
+
+  it('aborts an in-flight image read before requesting app exit', async () => {
+    const read = (signal: AbortSignal | undefined): Promise<Uint8Array> => new Promise((resolve, reject) => {
+      void resolve
+      signal?.addEventListener('abort', () => { reject(signal.reason) }, { once: true })
+    })
+    const f = await fixture({ read })
+    submit(f.dispatch(), '/image slow.png')
+    await flush()
+    submit(f.dispatch(), 'inspect this')
+    await flush()
+
+    const signal = f.reads.mock.calls[0]?.[1] as AbortSignal | undefined
+    expect(signal?.aborted).toBe(false)
+    f.requestExit()
+    expect(signal?.aborted).toBe(true)
+    expect(f.exit).toHaveBeenCalledOnce()
   })
 
   it('freezes the draft batch and refuses draft mutations while a read is pending', async () => {

--- a/packages/dshline/tests/permission.spec.ts
+++ b/packages/dshline/tests/permission.spec.ts
@@ -112,6 +112,7 @@ async function fixture(options: {
     clear: () => {},
     refreshModelInfo: () => {},
     setDispatch: (handler: ((key: Key) => void) | undefined) => { dispatch = handler },
+    setExit: () => {},
   } as unknown as Window
   const session = {
     id: 'permission-test',

--- a/packages/dshline/tests/replay-gate.spec.ts
+++ b/packages/dshline/tests/replay-gate.spec.ts
@@ -253,17 +253,19 @@ describe('the replay input gate', () => {
     expect(message.content?.[0]?.text).toBe('hi!')
   })
 
-  it('lets /exit bypass the replay gate while the log read is still pending', async () => {
-    const { dispatch, exit, agent, resolveRead } = await fixture()
-    typeText(dispatch(), '/exit')
-    press(dispatch(), { kind: 'key', name: 'enter' })
+  it('lets /exit and /quit bypass the replay gate while the log read is pending', async () => {
+    for (const command of ['/exit', '/quit']) {
+      const { dispatch, exit, agent, resolveRead } = await fixture()
+      typeText(dispatch(), command)
+      press(dispatch(), { kind: 'key', name: 'enter' })
 
-    // The command is global: it must request shutdown without waiting for the
-    // deferred read or the synchronous replay projection to finish.
-    expect(exit).toHaveBeenCalledTimes(1)
-    expect(agent.followup).not.toHaveBeenCalled()
-    expect(agent.steer).not.toHaveBeenCalled()
-    resolveRead()
+      // The command is global: it must request shutdown without waiting for the
+      // deferred read or the synchronous replay projection to finish.
+      expect(exit).toHaveBeenCalledTimes(1)
+      expect(agent.followup).not.toHaveBeenCalled()
+      expect(agent.steer).not.toHaveBeenCalled()
+      resolveRead()
+    }
   })
 
   it('suppresses persisted reasoning while replaying but keeps the answer', async () => {

--- a/packages/dshline/tests/replay-gate.spec.ts
+++ b/packages/dshline/tests/replay-gate.spec.ts
@@ -82,6 +82,7 @@ async function fixture(options: {
   dispatch: () => ((key: Key) => void) | undefined
   agent: { followup: ReturnType<typeof vi.fn>; steer: ReturnType<typeof vi.fn> }
   commands: { execute: ReturnType<typeof vi.fn> }
+  exit: ReturnType<typeof vi.fn>
   resolveRead: (events?: SessionEvent[]) => void
   commits: string[][]
   frames: Array<{ lines: string[] }>
@@ -97,6 +98,7 @@ async function fixture(options: {
 
   const commits: string[][] = []
   const frames: Array<{ lines: string[] }> = []
+  const exit = vi.fn()
   let dispatch: ((key: Key) => void) | undefined
   const compose = (): void => {
     frames.push(ctx.tuiSlots.compose(80, 24))
@@ -104,7 +106,7 @@ async function fixture(options: {
   const window = {
     ctx,
     terminal: { columns: () => 80, rows: () => 24 },
-    exit: undefined,
+    exit,
     startup: { cwd: '/ws', task: undefined, resume: undefined },
     pricing: pricingFrom(undefined),
     peakHours: [],
@@ -130,6 +132,7 @@ async function fixture(options: {
     clear: () => {},
     refreshModelInfo: () => {},
     setDispatch: handler => { dispatch = handler },
+    setExit: () => {},
   } as unknown as Window
 
   const agent = {
@@ -153,6 +156,7 @@ async function fixture(options: {
     dispatch: () => dispatch,
     agent,
     commands,
+    exit,
     resolveRead: events => read.resolve({ events: events ?? REPLAYED_EVENTS }),
     commits,
     frames,
@@ -247,6 +251,19 @@ describe('the replay input gate', () => {
     expect(agent.steer).not.toHaveBeenCalled()
     const message = agent.followup.mock.calls[0]?.[0] as { content?: Array<{ text?: string }> }
     expect(message.content?.[0]?.text).toBe('hi!')
+  })
+
+  it('lets /exit bypass the replay gate while the log read is still pending', async () => {
+    const { dispatch, exit, agent, resolveRead } = await fixture()
+    typeText(dispatch(), '/exit')
+    press(dispatch(), { kind: 'key', name: 'enter' })
+
+    // The command is global: it must request shutdown without waiting for the
+    // deferred read or the synchronous replay projection to finish.
+    expect(exit).toHaveBeenCalledTimes(1)
+    expect(agent.followup).not.toHaveBeenCalled()
+    expect(agent.steer).not.toHaveBeenCalled()
+    resolveRead()
   })
 
   it('suppresses persisted reasoning while replaying but keeps the answer', async () => {

--- a/packages/dshline/tests/skills-submit.spec.ts
+++ b/packages/dshline/tests/skills-submit.spec.ts
@@ -154,6 +154,7 @@ async function fixture(options: {
     clear: () => {},
     refreshModelInfo: () => {},
     setDispatch: (handler: (key: Key) => void) => { dispatch = handler },
+    setExit: () => {},
   } as unknown as Window
 
   const agent = {

--- a/packages/dshline/tests/window.spec.ts
+++ b/packages/dshline/tests/window.spec.ts
@@ -9,11 +9,11 @@
  * no preset roster is left a no-op.
  */
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { Context } from '@deepseek-ai/cordis'
 import { Session, SessionId } from '@deepseek-ai/dsh-session'
 import { stripAnsi } from '@dshline/renderer'
-import { mountAgentPreset } from '../src/window.ts'
+import { mountAgentPreset, routeWindowKey } from '../src/window.ts'
 import type { AgentPresetRow, AgentPresetsSeam } from '../src/plugins/harness.ts'
 
 /** One fake roster preset. */
@@ -113,6 +113,19 @@ function fakeAgentCtx(agentPresets: AgentPresetsSeam | undefined, facts?: Facts)
     agent: session === undefined ? undefined : { session },
   } as unknown as Context
 }
+
+describe('global window key routing', () => {
+  it('sends ctrl-d to the attachment-aware exit request before dispatching anything', () => {
+    const requestExit = vi.fn()
+    const dispatch = vi.fn()
+    routeWindowKey({ kind: 'key', name: 'ctrl-d' }, requestExit, dispatch)
+    expect(requestExit).toHaveBeenCalledOnce()
+    expect(dispatch).not.toHaveBeenCalled()
+
+    routeWindowKey({ kind: 'text', text: 'x' }, requestExit, dispatch)
+    expect(dispatch).toHaveBeenCalledOnce()
+  })
+})
 
 describe('mountAgentPreset', () => {
   it('mounts the roster default for a fresh session with nothing recorded yet', async () => {


### PR DESCRIPTION
## Summary
- cancel active attachment work before `/exit`, `/quit`, `ctrl-d`, and idle `ctrl-c` request graceful shutdown
- connect command/image operations to attachment lifetime cancellation
- allow `/exit` and `/quit` during transcript replay

## Why
The launcher waits for graceful tree disposal. Without cancelling frontend-owned work first, exit could wait on an active model/tool operation or replay gate. Provider and persistence shutdown remains owned by Harness.

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- targeted replay/attachment tests