### PR TITLE
docs: make dshline.xyz the canonical project homepage

### DIFF
--- a/.changeset/dshline-canonical-website.md
+++ b/.changeset/dshline-canonical-website.md
@@ -1,0 +1,12 @@
+---
+'@dshline/dshline': patch
+---
+
+Point the dshline package homepage at dshline.xyz, the canonical project website.
+
+npm's package homepage now sends visitors to the product front door instead of
+back to the repository README. Nothing else about the package changes:
+`repository` and `bugs` still point at GitHub, and source, issues, releases and
+every document stay there. `@dshline/renderer` deliberately keeps its GitHub
+homepage — it is published as an agent-agnostic renderer, and the website
+positions the product, not that package.

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write README.md
-README.md: 26bbb10693482adfd9e6af2c4eaa09708a17fe29
-README.zh.md: 1def7a7dc1cf8a3bd5be494119f7c8ad9e1b29e6
+README.md: 6a45623f8ccfa62e9eecc0f98e8028fa90e38de6
+README.zh.md: 150442db83de392df0ee26e435892e5004f0dbc8

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ English | [中文](README.zh.md)
 
 **The terminal-native frontend for the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) plugin ecosystem.**
 
+An agent in your terminal — not instead of it. Finished output stays in your terminal's own scrollback; only a bounded live region redraws.
+
+**Website:** [dshline.xyz](https://dshline.xyz)
+
 [![npm](https://img.shields.io/npm/v/%40dshline%2Fdshline?color=ff6b35&labelColor=black&style=flat-square)](https://www.npmjs.com/package/@dshline/dshline)
 [![CI](https://img.shields.io/github/actions/workflow/status/riesbri/dshline/ci.yml?branch=main&color=369eff&labelColor=black&logo=github&style=flat-square&label=ci)](https://github.com/riesbri/dshline/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/riesbri/dshline?color=c4f042&labelColor=black&style=flat-square&label=scorecard)](https://scorecard.dev/viewer/?uri=github.com/riesbri/dshline)

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,6 +8,10 @@
 
 **面向 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 插件生态系统的终端原生前端。**
 
+agent（智能体）在你的终端里，而不是取代你的终端。完成后的输出会留在终端自身的滚动缓冲区（scrollback）中，只有有界的活动区域会重绘。
+
+**网站：**[dshline.xyz](https://dshline.xyz)
+
 [![npm](https://img.shields.io/npm/v/%40dshline%2Fdshline?color=ff6b35&labelColor=black&style=flat-square)](https://www.npmjs.com/package/@dshline/dshline)
 [![CI](https://img.shields.io/github/actions/workflow/status/riesbri/dshline/ci.yml?branch=main&color=369eff&labelColor=black&logo=github&style=flat-square&label=ci)](https://github.com/riesbri/dshline/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/riesbri/dshline?color=c4f042&labelColor=black&style=flat-square&label=scorecard)](https://scorecard.dev/viewer/?uri=github.com/riesbri/dshline)

--- a/packages/dshline/package.json
+++ b/packages/dshline/package.json
@@ -106,7 +106,7 @@
     "url": "git+https://github.com/riesbri/dshline.git",
     "directory": "packages/dshline"
   },
-  "homepage": "https://github.com/riesbri/dshline#readme",
+  "homepage": "https://dshline.xyz",
   "bugs": {
     "url": "https://github.com/riesbri/dshline/issues"
   },


### PR DESCRIPTION
<!--
Read AGENTS.md before opening this — it lists the rules that are easy to break
by accident, and most review comments here are one of them.
-->

## What this changes, and why

The GitHub About/homepage URL already points at <https://dshline.xyz>, so the
site is the product front door. This makes the repository agree with that in
the two places that still sent a visitor somewhere else.

**The README names it.** Under the existing category statement there is now one
benefit sentence and one `**Website:**` line, ahead of the badges. The statement
itself is unchanged: it is the accurate technical description, and the site's own
subhead says the same thing. The sentence is the site's headline plus the
invariant it rests on, so a reader arriving from either direction gets one story.

The wording is the repository's, not the site's. The site says *"only the input
line and the status line ever redraw"*; this says *"only a bounded live region
redraws"* — what AGENTS.md rule 4 and [Design](docs/design.md) actually
guarantee. The live region carries the streaming reply too, and a README
promising less than the code does would be wrong the first time someone watched
a reply arrive.

**No badge was added.** The site's own `src/content/site.ts` records that this
README carries four; a fifth would put that comment out of date to say something
a text link says better. No nav row either — `## Install` is the next heading and
`## Documentation` already lists Usage and the Roadmap, so a link row would be a
duplicate rather than a route.

**npm metadata points at the canonical site.** `packages/dshline/package.json`'s
`homepage` is the link npm exposes for the package; pointing it at `#readme` sent
visitors back to the repository README rather than to the canonical product site.
That is also not the document npm renders as the package page — npm publishes
`packages/dshline/README.md` from the package root — so the field's only job is to
name a destination, and the destination is now the front door. `repository` and
`bugs` stay on GitHub, so source, issues and releases are unaffected.

**`@dshline/renderer` keeps its GitHub homepage** — deliberately. It is published
separately precisely because it knows nothing about agents, its own README sends
a reader to the repository for source and tests, and the site's link table notes
that `npmRenderer` is kept out of the structured data's `sameAs` because it is
not the same entity as dshline. The product site is not that package's landing
page.

**This is not a documentation rewrite.** Detailed documentation, source, issues,
releases and the canonical Roadmap all stay on GitHub. No section was moved,
rewritten, or mirrored onto the site, and description, keywords, screenshots and
install instructions are untouched.

### The Chinese side

Patched against the English diff, not retranslated. It takes the site's Chinese
headline verbatim, and the terminology this corpus already fixed:

- `scrollback` → `滚动缓冲区` with the English in parentheses at what is now the
  file's first occurrence — never `回滚缓冲区`, per [docs/i18n.md](docs/i18n.md#terminology).
- live region → `有界的活动区域`, matching the "原生终端设计" section further down
  rather than the site's `实时区域`.
- `agent（智能体）` is glossed here because this is now the first occurrence in the
  file; `README.zh.md` previously reached a bare `agent` without one.

`README.i18n.yaml` re-records the pair.

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm test` pass — 141 files, 2969 tests passed, 1 file / 22 tests skipped
- [x] `pnpm security` passes — the dependency and workflow checks CI runs (no advisories; zizmor clean)
- [x] `pnpm run verify-docs` passes — 9 bilingual pairs consistent; `README` re-recorded with `--write README.md`
- [x] A changeset is included, or nothing under `packages/` changed — `patch` on `@dshline/dshline`, since the npm `homepage` is published, user-visible package metadata; the fixed group versions both packages from it

Versions and `CHANGELOG.md` were not touched — the generated `Version Packages`
pull request (#165) owns those, and nothing here was taken from its branch.

## If this touches the terminal

Not applicable — no code, no drawing, no keys.
