### PR TITLE
fix(dshline): prevent duplicate streamed reasoning

### DIFF
--- a/.changeset/quiet-reasoning-reconcile.md
+++ b/.changeset/quiet-reasoning-reconcile.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': patch
+---
+
+Prevent streamed Codex/OpenAI reasoning from appearing twice when its assembled block omits only the trailing line break emitted by the stream.

--- a/packages/dshline/src/stream.ts
+++ b/packages/dshline/src/stream.ts
@@ -330,7 +330,14 @@ export class StreamBuffer {
       return []
     }
     if (full === '' && state.pending === '') return []
-    if (!full.startsWith(state.pushed)) {
+    // Some providers close a reasoning item without preserving the trailing line
+    // break that arrived in its deltas. The bytes are the same content for a
+    // reader, but a strict prefix check would fall into the divergence fallback
+    // and append that content a second time. Ignore only trailing whitespace here;
+    // an internal mismatch still uses the authoritative assembled fallback below.
+    const reasoningMatchesWithoutTrailingWhitespace = channel === 'reasoning'
+      && full.trimEnd() === state.pushed.trimEnd()
+    if (!full.startsWith(state.pushed) && !reasoningMatchesWithoutTrailingWhitespace) {
       if (channel === 'reasoning' && this.reasoningHadHiddenContent) {
         // Once hidden and visible epochs share one assembled block, divergence
         // makes its origin unknowable. Keep only the current visible tail, which

--- a/packages/dshline/src/stream.ts
+++ b/packages/dshline/src/stream.ts
@@ -343,7 +343,7 @@ export class StreamBuffer {
     // reader, but a strict prefix check would fall into the divergence fallback
     // and append that content a second time. Ignore only trailing whitespace here;
     // substantive, internal, or other content divergence still uses the
-     // authoritative assembled fallback below.
+    // authoritative assembled fallback below.
     const reasoningMatchesWithoutTrailingWhitespace = channel === 'reasoning'
       && full.trimEnd() === state.pushed.trimEnd()
     if (!full.startsWith(state.pushed) && !reasoningMatchesWithoutTrailingWhitespace) {

--- a/packages/dshline/src/stream.ts
+++ b/packages/dshline/src/stream.ts
@@ -7,9 +7,12 @@
  * scrollback one completed line at a time, and only its unfinished trailing line
  * stays in the live region. `assistant/message` then contributes what streaming
  * could not have shown — the last partial line, or the whole reply from a
- * provider that does not stream at all. The assembled message is authoritative;
- * reasoning may differ from its streamed form only at a trailing-whitespace
- * boundary that does not change what a reader sees.
+ * provider that does not stream at all. The assembled assistant message is
+ * authoritative, and streamed content normally corresponds to its prefix. The
+ * only reasoning mismatch treated as presentation-equivalent is trailing
+ * whitespace at the stream boundary; substantive or internal divergence is not
+ * equivalent and falls back to the assembled form. Native scrollback already
+ * committed from the stream cannot be retracted.
  *
  * Committing as lines complete is what keeps the cost flat. Holding the whole
  * reply live meant re-escaping, re-splitting, and retransmitting all of it on
@@ -79,8 +82,9 @@ const CONTINUATION = '  '
 interface ChannelState {
   /**
    * Everything pushed on this channel, kept to reconcile with the assembled
-   * message. Normally the assembled text starts with it; reasoning may differ
-   * only at its trailing-whitespace boundary.
+   * message. Normally the assembled text starts with it. For reasoning, only
+   * trailing whitespace at the stream boundary is presentation-equivalent;
+   * substantive or internal divergence is handled by the assembled fallback.
    */
   pushed: string
   /** The unfinished trailing line, which has not been committed. */
@@ -202,15 +206,15 @@ export class StreamBuffer {
   /**
    * Reconcile the streamed presentation with the assembled assistant message.
    *
-   * The assembled message is authoritative. Streamed content normally corresponds
-   * to its prefix, so the assembled message contributes only the remainder — the
-   * last unterminated line for a streamed reply, or the whole reply for a provider
-   * that does not stream. Reasoning can differ at the boundary where the stream
-   * ends with whitespace that the assembled block omits; that boundary-only form
-   * is equivalent for presentation and contributes no duplicate rows. Any real
-   * internal or content mismatch falls back to the authoritative assembled form:
-   * committed rows cannot be taken back, and dropping the assembled text would be
-   * invisible to the reader.
+   * The assembled assistant message is authoritative. Streamed content normally
+   * corresponds to its prefix, so the assembled message contributes only the
+   * remainder — the last unterminated line for a streamed reply, or the whole
+   * reply for a provider that does not stream. Only a reasoning mismatch made of
+   * trailing whitespace at the stream boundary is presentation-equivalent and
+   * contributes no duplicate rows. Substantive, internal, or other content
+   * divergence is not equivalent and falls back to the authoritative assembled
+   * form. Already committed native scrollback cannot be retracted, so preserving
+   * the assembled form is safer than silently dropping it.
    * @param content - the assembled assistant message's content blocks.
    * @param columns - the terminal's current width.
    * @returns rows to write into scrollback, reasoning before reply.
@@ -338,7 +342,8 @@ export class StreamBuffer {
     // break that arrived in its deltas. The bytes are the same content for a
     // reader, but a strict prefix check would fall into the divergence fallback
     // and append that content a second time. Ignore only trailing whitespace here;
-    // an internal mismatch still uses the authoritative assembled fallback below.
+    // substantive, internal, or other content divergence still uses the
+     // authoritative assembled fallback below.
     const reasoningMatchesWithoutTrailingWhitespace = channel === 'reasoning'
       && full.trimEnd() === state.pushed.trimEnd()
     if (!full.startsWith(state.pushed) && !reasoningMatchesWithoutTrailingWhitespace) {

--- a/packages/dshline/src/stream.ts
+++ b/packages/dshline/src/stream.ts
@@ -2,12 +2,14 @@
  * The assistant's own output: reasoning, then reply, as it arrives.
  *
  * This module owns every line the assistant produces, both the streamed form and
- * the committed one, because they are the same text and only one of them may
- * reach the screen. A reply arrives as deltas, is written into scrollback one
- * completed line at a time, and only its unfinished trailing line stays in the
- * live region. `assistant/message` then contributes what streaming could not
- * have shown — the last partial line, or the whole reply from a provider that
- * does not stream at all.
+ * the committed one, because they represent one response and only one
+ * presentation may reach the screen. A reply arrives as deltas, is written into
+ * scrollback one completed line at a time, and only its unfinished trailing line
+ * stays in the live region. `assistant/message` then contributes what streaming
+ * could not have shown — the last partial line, or the whole reply from a
+ * provider that does not stream at all. The assembled message is authoritative;
+ * reasoning may differ from its streamed form only at a trailing-whitespace
+ * boundary that does not change what a reader sees.
  *
  * Committing as lines complete is what keeps the cost flat. Holding the whole
  * reply live meant re-escaping, re-splitting, and retransmitting all of it on
@@ -76,8 +78,9 @@ const CONTINUATION = '  '
 /** What one channel has produced so far. */
 interface ChannelState {
   /**
-   * Everything pushed on this channel, kept to compare against the assembled
-   * message: the remainder beyond it is what has not been shown yet.
+   * Everything pushed on this channel, kept to reconcile with the assembled
+   * message. Normally the assembled text starts with it; reasoning may differ
+   * only at its trailing-whitespace boundary.
    */
   pushed: string
   /** The unfinished trailing line, which has not been committed. */
@@ -197,16 +200,17 @@ export class StreamBuffer {
   }
 
   /**
-   * Commit whatever the assembled message adds beyond what streamed.
+   * Reconcile the streamed presentation with the assembled assistant message.
    *
-   * The message is the authority, and what streamed is a prefix of it by
-   * construction — the assembler concatenates the same deltas this buffer
-   * received. So only the remainder is new, which for a streamed reply is its
-   * last unterminated line and for a provider that does not stream is the whole
-   * thing. If the two forms are not in that relationship the assembled form is
-   * committed whole: the lines already on screen cannot be taken back, and a
-   * duplicated reply is something a reader can see past, while a dropped one is
-   * invisible.
+   * The assembled message is authoritative. Streamed content normally corresponds
+   * to its prefix, so the assembled message contributes only the remainder — the
+   * last unterminated line for a streamed reply, or the whole reply for a provider
+   * that does not stream. Reasoning can differ at the boundary where the stream
+   * ends with whitespace that the assembled block omits; that boundary-only form
+   * is equivalent for presentation and contributes no duplicate rows. Any real
+   * internal or content mismatch falls back to the authoritative assembled form:
+   * committed rows cannot be taken back, and dropping the assembled text would be
+   * invisible to the reader.
    * @param content - the assembled assistant message's content blocks.
    * @param columns - the terminal's current width.
    * @returns rows to write into scrollback, reasoning before reply.

--- a/packages/dshline/tests/stream.spec.ts
+++ b/packages/dshline/tests/stream.spec.ts
@@ -250,6 +250,18 @@ describe('reasoning', () => {
     ], COLUMNS))).toEqual(['', '✻ authoritative assembled thought', '', '● answer'])
   })
 
+  it('does not replay reasoning when assembly only omits its streamed line break', () => {
+    // Codex can finish a commentary item without the newline that its streamed
+    // deltas carried. The content is already committed; treating that harmless
+    // boundary difference as divergence printed the same thought twice.
+    const buffer = new StreamBuffer()
+    expect(plain(buffer.push('reasoning', '**Preparing to export current index**\n', COLUMNS)))
+      .toEqual(['', '✻ **Preparing to export current index**'])
+    expect(plain(buffer.settle([
+      { type: 'reasoning', text: '**Preparing to export current index**' },
+    ], COLUMNS))).toEqual([])
+  })
+
   it('clears hidden-epoch divergence state when a turn resets', () => {
     const buffer = new StreamBuffer(false)
     buffer.push('reasoning', 'old hidden thought', COLUMNS)


### PR DESCRIPTION
## Summary
- reconcile streamed reasoning with the assembled message when only trailing whitespace differs
- prevent Codex/OpenAI Responses reasoning summaries from appearing twice
- preserve the authoritative fallback for substantive divergence

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- focused StreamBuffer regression test

Closes the live-stream boundary mismatch where Codex emits a synthetic trailing separator in deltas but omits it from the assembled block.