### PR TITLE
feat(dshline): answer multi-select and custom user questions

### DIFF
--- a/.changeset/question-answer-parity.md
+++ b/.changeset/question-answer-parity.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': minor
+---
+
+Ask `ask_user_question` questions with the full Harness answer contract: multi-select questions present a bounded checkbox list (space toggles, enter confirms), every option question gains an `Other…` route into the existing single-line editor, and a question with no options is answered as free text instead of through a stand-in `OK` choice. Custom answers encode exactly as Harness defines them — replacing the selection for single-select, supplementing it for multi-select — and option-less answers arrive as `custom` text.

--- a/packages/dshline/src/multiselect.ts
+++ b/packages/dshline/src/multiselect.ts
@@ -5,7 +5,10 @@
  * (`multiSelect`), which the single-choice picker in `./select.ts` cannot
  * express: its confirm is whichever row the cursor rests on. This overlay is
  * that picker with the confirm decoupled from the cursor — space flips the row
- * under it, and enter submits every flipped row at once. Movement, bounding,
+ * under it, and enter submits every flipped row at once. The Other… route is
+ * the one row Enter reads by its state: while its answer is unwritten, Enter
+ * opens the editor; once committed, the row is the finished answer and Enter
+ * confirms in place, with tab back into the text. Movement, bounding,
  * framing, and the once-only settlement discipline are the same, and anything
  * beyond the offered rows (an `Other…` route, the editor behind it) is composed
  * by the caller: the overlay draws the row and hands back what was committed,
@@ -52,8 +55,40 @@ const ROW_PREFIX_COLUMNS = 6
 /** The row appended after the offered choices, opening the free-text answer. */
 const OTHER_LABEL = 'Other…'
 
-/** Navigation help, surrendered whole segments at a time by `fitFooterHelp`. */
-const MULTI_HELP = '↑↓ move · space toggle · enter confirm · esc cancel'
+/**
+ * The route's display text when an offered option already claims `Other…`.
+ * The Harness contract reserves no label and requires none to be unique, so
+ * the route names itself out of the way rather than presenting two rows a
+ * reader cannot tell apart.
+ */
+const OTHER_DISAMBIGUATED = 'Other… (free text)'
+
+/** Navigation help over the offered rows, surrendered whole segments at a time. */
+const CHOICE_HELP = '↑↓ move · space toggle · enter confirm · esc cancel'
+
+/** The route row before anything is committed: Enter opens the editor there. */
+const ROUTE_EMPTY_HELP = '↑↓ move · enter edit · esc cancel'
+
+/**
+ * The route row once an answer is committed: the receipt IS the finished
+ * answer, so Enter confirms in place and tab is the way back into the text.
+ */
+const ROUTE_EDITED_HELP = '↑↓ move · tab edit · enter confirm · esc cancel'
+
+/**
+ * The Other… row's display text for one question's offer.
+ * @param offered - every label the question itself offers.
+ * @returns a display text no offered option shares, so the custom route can
+ *   always be told apart from the choices around it. The routing value stays
+ *   the caller's private sentinel; only what is drawn adapts.
+ */
+export function otherDisplay(offered: readonly string[]): string {
+  if (!offered.includes(OTHER_LABEL)) return OTHER_LABEL
+  if (!offered.includes(OTHER_DISAMBIGUATED)) return OTHER_DISAMBIGUATED
+  let suffix = 2
+  while (offered.includes(`${OTHER_DISAMBIGUATED} (${String(suffix)})`)) suffix += 1
+  return `${OTHER_DISAMBIGUATED} (${String(suffix)})`
+}
 
 /** What a confirmed multi-select carries, ready for the Harness answer item. */
 export interface MultiSelectAnswer {
@@ -149,17 +184,23 @@ export function createMultiSelectOverlay(spec: MultiSelectSpec): TuiOverlay {
       spec.invalidate()
     })
   }
+  /** The answer as it stands: flipped labels in offer order, plus any committed text. */
+  const answer = (): MultiSelectAnswer => ({
+    // Offer order, whatever order the boxes were flipped in: the answer quotes
+    // the question's own list, it does not record the reader's path through it.
+    selected: spec.choices.flatMap((choice, index) => (checked[index] ? [choice.label] : [])),
+    ...custom === '' ? {} : { custom },
+  })
   const confirm = (): void => {
-    if (cursor >= spec.choices.length) {
+    // On the route row Enter reads the row's state: an unanswered Other…
+    // opens its editor, while a committed receipt IS the finished answer — a
+    // custom-only submission must not need a detour onto an unrelated option.
+    // Tab is the way back into the text either way.
+    if (cursor >= spec.choices.length && custom === '') {
       openEditor()
       return
     }
-    settle({
-      // Offer order, whatever order the boxes were flipped in: the answer quotes
-      // the question's own list, it does not record the reader's path through it.
-      selected: spec.choices.flatMap((choice, index) => (checked[index] ? [choice.label] : [])),
-      ...custom === '' ? {} : { custom },
-    })
+    settle(answer())
   }
   return {
     render(columns, terminalRows = 24) {
@@ -176,13 +217,19 @@ export function createMultiSelectOverlay(spec: MultiSelectSpec): TuiOverlay {
       const cursorEnd = rendered.cursorRow + rendered.cursorHeight
       const overshoot = cursorEnd - viewport.end
       if (overshoot > 0) viewport.move(Math.min(overshoot, rendered.cursorRow - viewport.start))
+      // The footer states what Enter does on the ACTIVE row, which is the
+      // whole point of a help line: on the route row it differs, and space
+      // toggles nothing there at all.
+      const helpText = cursor >= spec.choices.length
+        ? custom === '' ? ROUTE_EMPTY_HELP : ROUTE_EDITED_HELP
+        : CHOICE_HELP
       const frame = [
         '',
         ...rootFrame({
           columns,
           context: paint(escapeControls(spec.view ?? spec.title), 'overlay-title'),
           body: [...heading, ...rendered.rows.slice(viewport.start, viewport.end)],
-          footer: fitFooterHelp(MULTI_HELP, footerBudget(columns)),
+          footer: fitFooterHelp(helpText, footerBudget(columns)),
         }),
       ]
       // A backstop, not the primary bound: every content row above is already
@@ -223,6 +270,12 @@ export function createMultiSelectOverlay(spec: MultiSelectSpec): TuiOverlay {
           cursor = Math.max(0, lastRow)
           viewport.last()
           spec.invalidate()
+          return
+        case 'tab':
+          // The editor is a row-level action, offered on the route row — the
+          // one row where space toggles nothing. Elsewhere tab does nothing,
+          // and the footer never advertises it.
+          if (cursor >= spec.choices.length) openEditor()
           return
         case 'enter':
           confirm()
@@ -304,11 +357,14 @@ function renderRows(
   if (spec.editCustom !== undefined) {
     if (cursor >= spec.choices.length) cursorRow = rows.length
     const active = cursor >= spec.choices.length
-    // The committed supplement is shown on the row itself, tail first, so what
-    // will actually be submitted stays visible however long it has grown.
-    const prefix = `${OTHER_LABEL}: `
+    // The route names itself out of the way of any offered label (see
+    // otherDisplay), and the committed supplement is shown on the row itself,
+    // tail first, so what will actually be submitted stays visible however
+    // long it has grown.
+    const routeLabel = otherDisplay(spec.choices.map(choice => choice.label))
+    const prefix = `${routeLabel}: `
     const text = custom === ''
-      ? OTHER_LABEL
+      ? routeLabel
       : prefix + tailToWidth(escapeControls(custom), Math.max(1, budget - displayWidth(prefix)))
     const label = truncateToWidth(text, budget)
     const pointer = active ? paint('❯ ', 'selection-mark') : '  '
@@ -354,8 +410,12 @@ function compactFallback(
   const rendered = renderRows(spec, checked, cursor, custom, Math.max(1, width - ROW_PREFIX_COLUMNS))
   const lines = [rendered.rows[rendered.cursorRow] ?? '']
   if (rows > 1) {
-    const hint = ['space · enter · esc', 'enter · esc', 'esc']
-      .find(candidate => displayWidth(candidate) <= width)
+    // The same row-truth as the framed footer: space toggles nothing on the
+    // route row, so the compact hint drops it there.
+    const candidates = cursor >= spec.choices.length
+      ? ['enter · esc', 'esc']
+      : ['space · enter · esc', 'enter · esc', 'esc']
+    const hint = candidates.find(candidate => displayWidth(candidate) <= width)
     if (hint !== undefined) lines.push(paint(hint, 'muted'))
   }
   return lines.slice(0, rows)

--- a/packages/dshline/src/multiselect.ts
+++ b/packages/dshline/src/multiselect.ts
@@ -147,6 +147,9 @@ export function createMultiSelectOverlay(spec: MultiSelectSpec): TuiOverlay {
   // and flipping one must not flip the other. Offer order is preserved by
   // construction, which is the order the answer reports.
   const checked = spec.choices.map(() => false)
+  // The choice set is immutable for the overlay's lifetime, so the route's
+  // display label is resolved once here rather than on every render.
+  const routeLabel = otherDisplay(spec.choices.map(choice => choice.label))
   // The Other… row sits at index `choices.length`; without an editor behind it
   // there is nothing for it to open, so it is not offered at all.
   const lastRow = spec.editCustom === undefined ? spec.choices.length - 1 : spec.choices.length
@@ -209,9 +212,9 @@ export function createMultiSelectOverlay(spec: MultiSelectSpec): TuiOverlay {
       const heading = headingRows(spec, inner)
       const capacity = terminalRows - MULTI_FIXED_ROWS - heading.length
       if (capacity <= 0 || columns < MULTI_MIN_COLUMNS) {
-        return compactFallback(spec, checked, cursor, custom, columns, terminalRows)
+        return compactFallback(spec, checked, cursor, custom, routeLabel, columns, terminalRows)
       }
-      const rendered = renderRows(spec, checked, cursor, custom, inner)
+      const rendered = renderRows(spec, checked, cursor, custom, routeLabel, inner)
       viewport.update(rendered.rows.length, capacity)
       if (rendered.cursorRow < viewport.start) viewport.move(rendered.cursorRow - viewport.start)
       const cursorEnd = rendered.cursorRow + rendered.cursorHeight
@@ -239,7 +242,7 @@ export function createMultiSelectOverlay(spec: MultiSelectSpec): TuiOverlay {
       // exists to prevent, so it is checked rather than assumed.
       return physicalRows(frame, columns).length <= terminalRows
         ? frame
-        : compactFallback(spec, checked, cursor, custom, columns, terminalRows)
+        : compactFallback(spec, checked, cursor, custom, routeLabel, columns, terminalRows)
     },
     handleKey(key: Key) {
       if (key.kind === 'paste') return
@@ -314,6 +317,7 @@ function headingRows(spec: MultiSelectSpec, inner: number): string[] {
  * @param checked - which rows are flipped.
  * @param cursor - the highlighted row index.
  * @param custom - the committed free-text supplement, if any.
+ * @param routeLabel - the Other… row's display text, resolved once per overlay.
  * @param inner - the frame's inner width in columns.
  * @returns the rows and the cursor's row index among them.
  */
@@ -322,6 +326,7 @@ function renderRows(
   checked: readonly boolean[],
   cursor: number,
   custom: string,
+  routeLabel: string,
   inner: number,
 ): Rendered {
   if (spec.choices.length === 0) {
@@ -357,11 +362,10 @@ function renderRows(
   if (spec.editCustom !== undefined) {
     if (cursor >= spec.choices.length) cursorRow = rows.length
     const active = cursor >= spec.choices.length
-    // The route names itself out of the way of any offered label (see
-    // otherDisplay), and the committed supplement is shown on the row itself,
-    // tail first, so what will actually be submitted stays visible however
-    // long it has grown.
-    const routeLabel = otherDisplay(spec.choices.map(choice => choice.label))
+    // The route's label already names itself out of the way of any offered
+    // label (see otherDisplay), and the committed supplement is shown on the
+    // row itself, tail first, so what will actually be submitted stays visible
+    // however long it has grown.
     const prefix = `${routeLabel}: `
     const text = custom === ''
       ? routeLabel
@@ -393,6 +397,7 @@ function physicalRows(lines: readonly string[], columns: number): string[] {
  * @param checked - which rows are flipped.
  * @param cursor - the highlighted row index.
  * @param custom - the committed free-text supplement, if any.
+ * @param routeLabel - the Other… row's display text, resolved once per overlay.
  * @param columns - the terminal's width.
  * @param rows - the terminal's height.
  * @returns at most `rows` lines.
@@ -402,12 +407,13 @@ function compactFallback(
   checked: readonly boolean[],
   cursor: number,
   custom: string,
+  routeLabel: string,
   columns: number,
   rows: number,
 ): string[] {
   if (rows <= 0) return []
   const width = Math.max(1, columns)
-  const rendered = renderRows(spec, checked, cursor, custom, Math.max(1, width - ROW_PREFIX_COLUMNS))
+  const rendered = renderRows(spec, checked, cursor, custom, routeLabel, Math.max(1, width - ROW_PREFIX_COLUMNS))
   const lines = [rendered.rows[rendered.cursorRow] ?? '']
   if (rows > 1) {
     // The same row-truth as the framed footer: space toggles nothing on the
@@ -441,21 +447,27 @@ export async function promptMultiSelect(
   return new Promise<MultiSelectAnswer | undefined>(resolve => {
     let dismiss = (): void => {}
     let settled = false
+    const signal = spec.signal
     // Shared by the overlay and the withdrawal listener, because either can be
     // first and the loser must not dismiss an overlay someone else has replaced.
     const finish = (value: MultiSelectAnswer | undefined): void => {
       if (settled) return
       settled = true
+      // Whatever settled the prompt, its stake in the signal ends here: a
+      // listener left attached would fire on a signal that may outlive the
+      // question — or never abort at all.
+      signal?.removeEventListener('abort', withdraw)
       dismiss()
       resolve(value)
     }
+    const withdraw = (): void => { finish(undefined) }
     const overlay = createMultiSelectOverlay({
       ...spec,
       invalidate: () => { ctx.tuiSlots.invalidate() },
       settle: finish,
     })
     dismiss = ctx.tuiSlots.pushOverlay(overlay)
-    if (spec.signal?.aborted === true) finish(undefined)
-    else spec.signal?.addEventListener('abort', () => { finish(undefined) }, { once: true })
+    if (signal?.aborted === true) finish(undefined)
+    else signal?.addEventListener('abort', withdraw, { once: true })
   })
 }

--- a/packages/dshline/src/multiselect.ts
+++ b/packages/dshline/src/multiselect.ts
@@ -1,0 +1,401 @@
+/**
+ * A multiple-choice list overlay, bounded to the terminal.
+ *
+ * Harness's question contract lets one question carry several answers
+ * (`multiSelect`), which the single-choice picker in `./select.ts` cannot
+ * express: its confirm is whichever row the cursor rests on. This overlay is
+ * that picker with the confirm decoupled from the cursor — space flips the row
+ * under it, and enter submits every flipped row at once. Movement, bounding,
+ * framing, and the once-only settlement discipline are the same, and anything
+ * beyond the offered rows (an `Other…` route, the editor behind it) is composed
+ * by the caller: the overlay draws the row and hands back what was committed,
+ * the way the picker hands back a value it does not interpret.
+ *
+ * The list is a viewport over its rows for the reason `./select.ts` is: a
+ * picker that draws a row per choice hands `Screen` a live region taller than
+ * the screen, and the rows that scrolled off can no longer be reached or
+ * erased. There is deliberately no query box: a question's options are one
+ * model turn's worth, not a provider's route catalogue, and the viewport keeps
+ * a long list reachable without spending a row on search.
+ * @module dshline/multiselect
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import type { Key } from '@dshline/renderer'
+import {
+  BOX_CHROME_COLUMNS,
+  displayWidth,
+  escapeControls,
+  paint,
+  tailToWidth,
+  truncateToWidth,
+  wrapToWidth,
+} from '@dshline/renderer'
+import { chromeWidth, fitFooterHelp, footerBudget, rootFrame } from './chrome.ts'
+import { RowViewport } from './scroll.ts'
+import type { SelectChoice } from './select.ts'
+import type { TuiOverlay } from './slots.ts'
+
+/** Rows outside the heading and scrolling list: the leading blank and two borders. */
+const MULTI_FIXED_ROWS = 3
+
+/** Narrowest terminal that can hold the framed list rather than the bare answer. */
+const MULTI_MIN_COLUMNS = BOX_CHROME_COLUMNS + 16
+
+/**
+ * Display columns a checkbox row spends before its label: the pointer gutter,
+ * the box, and the space between box and label. Labels, descriptions, and the
+ * Other… row budget against this so no row can push the frame into wrapping.
+ */
+const ROW_PREFIX_COLUMNS = 6
+
+/** The row appended after the offered choices, opening the free-text answer. */
+const OTHER_LABEL = 'Other…'
+
+/** Navigation help, surrendered whole segments at a time by `fitFooterHelp`. */
+const MULTI_HELP = '↑↓ move · space toggle · enter confirm · esc cancel'
+
+/** What a confirmed multi-select carries, ready for the Harness answer item. */
+export interface MultiSelectAnswer {
+  /** Labels of the checked rows, in the order they were offered. */
+  readonly selected: readonly string[]
+  /** The free-text answer committed through `Other…`, when one is present. */
+  readonly custom?: string
+}
+
+/** How a multi-select overlay is built and what it reports. */
+export interface MultiSelectSpec {
+  /** Headline shown above the list. */
+  title: string
+  /** Concise identity shown in the shared root chrome. */
+  readonly view?: string
+  /** Optional supporting text between the title and the list. */
+  detail?: string
+  /** The offered rows; an empty list is a programming error and renders as such. */
+  choices: readonly SelectChoice[]
+  /**
+   * Opens the editor behind the `Other…` row, which exists only when this is
+   * given. Resolves with the committed text — an empty string clears an
+   * existing supplement — or with undefined when the reader backed out, which
+   * keeps what was there.
+   */
+  editCustom?(current: string): Promise<string | undefined>
+  /**
+   * Called once with the confirmed answer, or with undefined when the user
+   * cancelled. The overlay never calls this twice.
+   */
+  settle(answer: MultiSelectAnswer | undefined): void
+  /** Asks the runner to redraw after a move, a toggle, or a committed edit. */
+  invalidate(): void
+}
+
+/** Rendered rows for the list, and which row holds the cursor. */
+interface Rendered {
+  readonly rows: readonly string[]
+  readonly cursorRow: number
+  /**
+   * Rows the cursor occupies, which is two when the highlighted choice carries
+   * a description. The viewport follows the whole block, exactly as the
+   * single-choice picker follows its selection's description.
+   */
+  readonly cursorHeight: number
+}
+
+/**
+ * Build a multi-select overlay.
+ * @param spec - the prompt, the offered rows, and the settlement callback.
+ * @returns the overlay to push onto the slot registry.
+ */
+export function createMultiSelectOverlay(spec: MultiSelectSpec): TuiOverlay {
+  const viewport = new RowViewport()
+  // Checked state is per INDEX, not per label: two options may share a label,
+  // and flipping one must not flip the other. Offer order is preserved by
+  // construction, which is the order the answer reports.
+  const checked = spec.choices.map(() => false)
+  // The Other… row sits at index `choices.length`; without an editor behind it
+  // there is nothing for it to open, so it is not offered at all.
+  const lastRow = spec.editCustom === undefined ? spec.choices.length - 1 : spec.choices.length
+  let custom = ''
+  let cursor = 0
+  let settled = false
+  const settle = (answer: MultiSelectAnswer | undefined): void => {
+    // Once-only for the reason the select overlay's is: the registry can deliver
+    // one more keystroke between the decision and the unmount.
+    if (settled) return
+    settled = true
+    spec.settle(answer)
+  }
+  const move = (amount: number): void => {
+    const rowCount = lastRow + 1
+    if (rowCount === 0) return
+    cursor = (cursor + amount + rowCount) % rowCount
+    spec.invalidate()
+  }
+  const toggle = (): void => {
+    // Space over the Other… row flips nothing: it is an action, not a checkbox.
+    if (cursor >= spec.choices.length) return
+    checked[cursor] = !checked[cursor]
+    spec.invalidate()
+  }
+  const openEditor = (): void => {
+    if (settled || spec.editCustom === undefined) return
+    const current = custom
+    // The editor mounts above this overlay while this one waits underneath, so
+    // only the topmost surface ever takes a keystroke. The result applies
+    // whenever it resolves: an abort that dismisses this overlay in the
+    // meantime leaves the write on state nothing reads again.
+    void spec.editCustom(current).then(answer => {
+      if (answer !== undefined) custom = answer
+      spec.invalidate()
+    })
+  }
+  const confirm = (): void => {
+    if (cursor >= spec.choices.length) {
+      openEditor()
+      return
+    }
+    settle({
+      // Offer order, whatever order the boxes were flipped in: the answer quotes
+      // the question's own list, it does not record the reader's path through it.
+      selected: spec.choices.flatMap((choice, index) => (checked[index] ? [choice.label] : [])),
+      ...custom === '' ? {} : { custom },
+    })
+  }
+  return {
+    render(columns, terminalRows = 24) {
+      const width = chromeWidth(columns)
+      const inner = width - BOX_CHROME_COLUMNS
+      const heading = headingRows(spec, inner)
+      const capacity = terminalRows - MULTI_FIXED_ROWS - heading.length
+      if (capacity <= 0 || columns < MULTI_MIN_COLUMNS) {
+        return compactFallback(spec, checked, cursor, custom, columns, terminalRows)
+      }
+      const rendered = renderRows(spec, checked, cursor, custom, inner)
+      viewport.update(rendered.rows.length, capacity)
+      if (rendered.cursorRow < viewport.start) viewport.move(rendered.cursorRow - viewport.start)
+      const cursorEnd = rendered.cursorRow + rendered.cursorHeight
+      const overshoot = cursorEnd - viewport.end
+      if (overshoot > 0) viewport.move(Math.min(overshoot, rendered.cursorRow - viewport.start))
+      const frame = [
+        '',
+        ...rootFrame({
+          columns,
+          context: paint(escapeControls(spec.view ?? spec.title), 'overlay-title'),
+          body: [...heading, ...rendered.rows.slice(viewport.start, viewport.end)],
+          footer: fitFooterHelp(MULTI_HELP, footerBudget(columns)),
+        }),
+      ]
+      // A backstop, not the primary bound: every content row above is already
+      // truncated to `inner`, so nothing here should wrap. The root frame WOULD
+      // wrap a row that forgot to be, and a frame one row too tall pushes a line
+      // into committed scrollback — which is the corruption this whole viewport
+      // exists to prevent, so it is checked rather than assumed.
+      return physicalRows(frame, columns).length <= terminalRows
+        ? frame
+        : compactFallback(spec, checked, cursor, custom, columns, terminalRows)
+    },
+    handleKey(key: Key) {
+      if (key.kind === 'paste') return
+      if (key.kind === 'text') {
+        // The spacebar decodes as text in every keyboard encoding this renderer
+        // asks for, and it is the one printable key this overlay means something
+        // by: it flips the row under the cursor. Any other typed text has no job
+        // in a list without a query box, so it is dropped rather than inserted
+        // nowhere, which would read as a hang.
+        if (key.text === ' ') toggle()
+        return
+      }
+      switch (key.name) {
+        case 'up':
+          move(-1)
+          return
+        case 'down':
+          move(1)
+          return
+        case 'home':
+        case 'ctrl-a':
+          cursor = 0
+          viewport.first()
+          spec.invalidate()
+          return
+        case 'end':
+        case 'ctrl-e':
+          cursor = Math.max(0, lastRow)
+          viewport.last()
+          spec.invalidate()
+          return
+        case 'enter':
+          confirm()
+          return
+        case 'escape':
+        case 'ctrl-c':
+          settle(undefined)
+          return
+        default:
+          return
+      }
+    },
+  }
+}
+
+/**
+ * The rows above the list: the title, then the detail.
+ * @param spec - the prompt being rendered.
+ * @param inner - the frame's inner width in columns.
+ * @returns the heading rows, ending in a separator.
+ */
+function headingRows(spec: MultiSelectSpec, inner: number): string[] {
+  const rows = [paint(truncateToWidth(escapeControls(spec.title), inner), 'overlay-title')]
+  if (spec.detail !== undefined && spec.detail !== '') {
+    for (const line of escapeControls(spec.detail).split('\n')) {
+      rows.push(paint(truncateToWidth(line, inner), 'subdued'))
+    }
+  }
+  rows.push('')
+  return rows
+}
+
+/**
+ * Draw the list at a known width.
+ * @param spec - the prompt whose choices and Other… row are drawn.
+ * @param checked - which rows are flipped.
+ * @param cursor - the highlighted row index.
+ * @param custom - the committed free-text supplement, if any.
+ * @param inner - the frame's inner width in columns.
+ * @returns the rows and the cursor's row index among them.
+ */
+function renderRows(
+  spec: MultiSelectSpec,
+  checked: readonly boolean[],
+  cursor: number,
+  custom: string,
+  inner: number,
+): Rendered {
+  if (spec.choices.length === 0) {
+    // An empty OFFER is a programming error — the answerer routes option-less
+    // questions to free text — and saying so is the answer a stray direct call
+    // gets, exactly as the single-choice picker renders one.
+    return {
+      rows: [paint(truncateToWidth('Nothing to choose from.', inner), 'muted')],
+      cursorRow: 0,
+      cursorHeight: 1,
+    }
+  }
+  const budget = Math.max(1, inner - ROW_PREFIX_COLUMNS)
+  const rows: string[] = []
+  let cursorRow = 0
+  let cursorHeight = 1
+  spec.choices.forEach((choice, index) => {
+    const active = index === cursor
+    if (active) cursorRow = rows.length
+    // State and cursor are painted as separate segments, never one colour over
+    // the whole row: an outer paint would be closed by the checkbox's own reset
+    // and leave the rest of the row repainted by whatever is drawn beside it.
+    const pointer = active ? paint('❯ ', 'selection-mark') : '  '
+    const box = paint(checked[index] ? '[x]' : '[ ]', checked[index] ? 'success' : 'muted')
+    const label = truncateToWidth(escapeControls(choice.label), budget)
+    rows.push(`${pointer}${box} ${active ? paint(label, 'selection') : label}`)
+    if (active && choice.description !== undefined && choice.description !== '') {
+      const detail = truncateToWidth(escapeControls(choice.description), budget)
+      rows.push(paint(`${' '.repeat(ROW_PREFIX_COLUMNS)}${detail}`, 'muted'))
+      cursorHeight = 2
+    }
+  })
+  if (spec.editCustom !== undefined) {
+    if (cursor >= spec.choices.length) cursorRow = rows.length
+    const active = cursor >= spec.choices.length
+    // The committed supplement is shown on the row itself, tail first, so what
+    // will actually be submitted stays visible however long it has grown.
+    const prefix = `${OTHER_LABEL}: `
+    const text = custom === ''
+      ? OTHER_LABEL
+      : prefix + tailToWidth(escapeControls(custom), Math.max(1, budget - displayWidth(prefix)))
+    const label = truncateToWidth(text, budget)
+    const pointer = active ? paint('❯ ', 'selection-mark') : '  '
+    rows.push(`${pointer}${active ? paint(label, 'selection') : label}`)
+  }
+  return { rows, cursorRow, cursorHeight }
+}
+
+/**
+ * Count the physical rows Screen will draw for candidate live-region lines.
+ * @param lines - the candidate logical lines.
+ * @param columns - the terminal's width.
+ * @returns the wrapped physical rows.
+ */
+function physicalRows(lines: readonly string[], columns: number): string[] {
+  return lines.flatMap(line => wrapToWidth(line, Math.max(1, columns)))
+}
+
+/**
+ * An answerable picker for a terminal too small to hold the frame.
+ *
+ * Only the row under the cursor is drawn, its checkbox state with it — the
+ * frame is what is given up, never the decision, and space, enter, and escape
+ * keep working on exactly what is shown.
+ * @param spec - the prompt whose cursor row is drawn.
+ * @param checked - which rows are flipped.
+ * @param cursor - the highlighted row index.
+ * @param custom - the committed free-text supplement, if any.
+ * @param columns - the terminal's width.
+ * @param rows - the terminal's height.
+ * @returns at most `rows` lines.
+ */
+function compactFallback(
+  spec: MultiSelectSpec,
+  checked: readonly boolean[],
+  cursor: number,
+  custom: string,
+  columns: number,
+  rows: number,
+): string[] {
+  if (rows <= 0) return []
+  const width = Math.max(1, columns)
+  const rendered = renderRows(spec, checked, cursor, custom, Math.max(1, width - ROW_PREFIX_COLUMNS))
+  const lines = [rendered.rows[rendered.cursorRow] ?? '']
+  if (rows > 1) {
+    const hint = ['space · enter · esc', 'enter · esc', 'esc']
+      .find(candidate => displayWidth(candidate) <= width)
+    if (hint !== undefined) lines.push(paint(hint, 'muted'))
+  }
+  return lines.slice(0, rows)
+}
+
+/**
+ * Show a multi-select list and wait for the answer.
+ *
+ * The twin of `promptSelect` in `./select.ts`: same push-await-dismiss dance,
+ * same once-only settlement, so a caller alternating between picking one and
+ * picking many writes the same three lines for both. The optional `signal`
+ * takes the question down without an answer, for a caller whose request can
+ * stop being worth asking.
+ * @param ctx - context carrying the slot registry.
+ * @param spec - the prompt and its choices; settlement is this function's.
+ * @returns the confirmed answer, or undefined when the user cancelled or the
+ *   question was withdrawn.
+ */
+export async function promptMultiSelect(
+  ctx: Context,
+  spec: Omit<MultiSelectSpec, 'settle' | 'invalidate'> & { signal?: AbortSignal },
+): Promise<MultiSelectAnswer | undefined> {
+  return new Promise<MultiSelectAnswer | undefined>(resolve => {
+    let dismiss = (): void => {}
+    let settled = false
+    // Shared by the overlay and the withdrawal listener, because either can be
+    // first and the loser must not dismiss an overlay someone else has replaced.
+    const finish = (value: MultiSelectAnswer | undefined): void => {
+      if (settled) return
+      settled = true
+      dismiss()
+      resolve(value)
+    }
+    const overlay = createMultiSelectOverlay({
+      ...spec,
+      invalidate: () => { ctx.tuiSlots.invalidate() },
+      settle: finish,
+    })
+    dismiss = ctx.tuiSlots.pushOverlay(overlay)
+    if (spec.signal?.aborted === true) finish(undefined)
+    else spec.signal?.addEventListener('abort', () => { finish(undefined) }, { once: true })
+  })
+}

--- a/packages/dshline/src/questions.ts
+++ b/packages/dshline/src/questions.ts
@@ -36,13 +36,10 @@ import type {
 // importing from there also carries the `ctx.userQuestions` Context merge and
 // the `user-questions/request` waterfall declaration this module registers on.
 import { UserQuestionError } from '@deepseek-ai/dsh-user-questions'
-import { promptMultiSelect } from './multiselect.ts'
+import { otherDisplay, promptMultiSelect } from './multiselect.ts'
 import { createPlanReviewOverlay } from './plan-review.ts'
 import { promptText } from './prompt.ts'
 import { promptSelect } from './select.ts'
-
-/** The row appended to an option list, offering the free-text answer. */
-const OTHER_LABEL = 'Other…'
 
 /**
  * Offered when a plan-review question carries no options of its own. The
@@ -216,7 +213,10 @@ async function askSingleSelect(
     ...option.description === undefined ? {} : { description: option.description },
   }))
   const other = otherValue(choices.map(choice => choice.value))
-  const offer = [...choices, { value: other, label: OTHER_LABEL }]
+  // The route's display label names itself out of the way of any offered
+  // option, so a question may offer `Other…` itself and the two rows still
+  // read apart; routing stays on the private sentinel value either way.
+  const offer = [...choices, { value: other, label: otherDisplay(choices.map(choice => choice.label)) }]
   let initial: string | undefined
   for (;;) {
     const picked = await promptSelect(ctx, {

--- a/packages/dshline/src/questions.ts
+++ b/packages/dshline/src/questions.ts
@@ -5,6 +5,14 @@
  * question lists, a `plan-review` intent naming a real option, caller
  * liveness), so this answerer only renders, collects, and honours the signal.
  *
+ * Presentation follows the pinned Harness answer contract exactly: a question
+ * with options is a picker (single- or multi-select per `multiSelect`), and
+ * every question also admits a free-text `custom` answer — for a single-select
+ * question it replaces the selected option, for a multi-select one it
+ * supplements the selected labels, and a question with no options can only be
+ * answered with it. All three encodings come from the Harness types; nothing
+ * here invents a protocol.
+ *
  * dshline is one concrete terminal answerer on Harness's scoped
  * `user-questions/request` waterfall: when a request reaches it and its active
  * terminal surface can present that request, it claims the request by
@@ -28,11 +36,33 @@ import type {
 // importing from there also carries the `ctx.userQuestions` Context merge and
 // the `user-questions/request` waterfall declaration this module registers on.
 import { UserQuestionError } from '@deepseek-ai/dsh-user-questions'
+import { promptMultiSelect } from './multiselect.ts'
 import { createPlanReviewOverlay } from './plan-review.ts'
+import { promptText } from './prompt.ts'
 import { promptSelect } from './select.ts'
 
-/** Offered when a question carries no options of its own. */
-const ACKNOWLEDGE = [{ value: 'ok', label: 'OK' }] as const
+/** The row appended to an option list, offering the free-text answer. */
+const OTHER_LABEL = 'Other…'
+
+/**
+ * Offered when a plan-review question carries no options of its own. The
+ * service rejects such a request before dispatch, so this is a direct-caller
+ * backstop only; generic questions no longer need it, because an option-less
+ * question is answered in free text.
+ */
+const PLAN_REVIEW_ACKNOWLEDGE = [{ value: 'ok', label: 'OK' }] as const
+
+/**
+ * A `promptSelect` value reserved for the Other… row.
+ * @param offered - every label the question itself offers.
+ * @returns a value no offered label can collide with, so a Harness option can
+ *   never be mistaken for the custom-answer route.
+ */
+function otherValue(offered: readonly string[]): string {
+  let sentinel = '\u0000other'
+  while (offered.includes(sentinel)) sentinel += '\u0000'
+  return sentinel
+}
 
 /** Whether a borrowed request signal has already been withdrawn. */
 function aborted(signal: AbortSignal | undefined): boolean {
@@ -43,6 +73,18 @@ function aborted(signal: AbortSignal | undefined): boolean {
 function abortedQuestion(): UserQuestionError {
   return new UserQuestionError('ask_user_question was aborted before the user answered', 'ASK_ABORTED')
 }
+
+/**
+ * The headline every presentation of one question shares.
+ * @param item - the question being presented.
+ * @returns the header-prefixed question, or the question alone.
+ */
+function questionTitle(item: AskUserQuestionItem): string {
+  return item.header === undefined ? item.question : `${item.header}: ${item.question}`
+}
+
+/** The editor prompt behind an Other… row, shared by both option flows. */
+const OTHER_EDITOR_MESSAGE = 'Type your own answer'
 
 /**
  * Ask for a completed plan's approval, keeping cancellation distinct from a
@@ -76,7 +118,7 @@ function askPlanReview(ctx: Context, item: AskUserQuestionItem, signal: AbortSig
     const overlay = createPlanReviewOverlay({
       plan: item.detail ?? '',
       question: item.question,
-      choices: choices.length > 0 ? choices : ACKNOWLEDGE,
+      choices: choices.length > 0 ? choices : PLAN_REVIEW_ACKNOWLEDGE,
       invalidate: () => { ctx.tuiSlots.invalidate() },
       settle: value => {
         finish(value, value === undefined
@@ -105,25 +147,150 @@ async function askOne(
   if (item.intent?.kind === 'plan-review' && item.detail !== undefined) {
     return { id: item.id, selected: [await askPlanReview(ctx, item, signal)] }
   }
+  const answer = (item.options ?? []).length > 0
+    ? item.multiSelect === true
+      ? await askMultiSelect(ctx, item, signal)
+      : await askSingleSelect(ctx, item, signal)
+    : await askFreeText(ctx, item, signal)
+  // Harness keeps caller withdrawal and reader dismissal distinct at this
+  // boundary: a withdrawn signal is an error, while a reader who dismissed the
+  // overlay answered nothing rather than inventing a choice — the calling tool
+  // sees an empty selection and decides what an unanswered question means.
+  if (aborted(signal)) throw abortedQuestion()
+  return answer ?? { id: item.id, selected: [] }
+}
+
+/**
+ * Ask a question that offers no options.
+ *
+ * Harness's answer contract carries a free-text `custom` answer, and with no
+ * labels to select it is the only thing the contract can hold — so no
+ * stand-in Acknowledge choice is invented for the reader to click past.
+ * Enter on an empty field answers nothing and asks again.
+ * @param ctx - the plugin context owning the overlay.
+ * @param item - the question to ask.
+ * @param signal - abort signal for the calling tool.
+ * @returns the answer, or undefined when the reader dismissed the question.
+ */
+async function askFreeText(
+  ctx: Context,
+  item: AskUserQuestionItem,
+  signal: AbortSignal | undefined,
+): Promise<AskUserQuestionAnswerItem | undefined> {
+  for (;;) {
+    // The shared title already carries the question, so the field's message
+    // row would only repeat it; the field itself is the answer surface.
+    const typed = await promptText(ctx, {
+      title: questionTitle(item),
+      view: 'Question',
+      message: '',
+      ...item.detail === undefined ? {} : { detail: item.detail },
+      kind: 'text',
+      ...signal === undefined ? {} : { signal },
+    })
+    if (aborted(signal)) throw abortedQuestion()
+    if (typed === undefined) return undefined
+    if (typed.trim() !== '') return { id: item.id, selected: [], custom: typed }
+  }
+}
+
+/**
+ * Ask a single-select question: pick an offered option, or answer in free text.
+ *
+ * The Other… route is one more picker row, not a second question surface;
+ * backing out of its editor (or committing nothing) returns to the list, so a
+ * dismissed editor never reads as a dismissed question.
+ * @param ctx - the plugin context owning the overlay.
+ * @param item - the question to ask.
+ * @param signal - abort signal for the calling tool.
+ * @returns the answer, or undefined when the reader dismissed the question.
+ */
+async function askSingleSelect(
+  ctx: Context,
+  item: AskUserQuestionItem,
+  signal: AbortSignal | undefined,
+): Promise<AskUserQuestionAnswerItem | undefined> {
   const choices = (item.options ?? []).map(option => ({
     value: option.label,
     label: option.label,
     ...option.description === undefined ? {} : { description: option.description },
   }))
-  const selected = await promptSelect(ctx, {
-    title: item.header === undefined ? item.question : `${item.header}: ${item.question}`,
+  const other = otherValue(choices.map(choice => choice.value))
+  const offer = [...choices, { value: other, label: OTHER_LABEL }]
+  let initial: string | undefined
+  for (;;) {
+    const picked = await promptSelect(ctx, {
+      title: questionTitle(item),
+      view: 'Question',
+      ...item.detail === undefined ? {} : { detail: item.detail },
+      choices: offer,
+      ...initial === undefined ? {} : { initialValue: initial },
+      ...signal === undefined ? {} : { signal },
+    })
+    if (aborted(signal)) throw abortedQuestion()
+    if (picked === undefined) return undefined
+    // A custom answer REPLACES the selection: Harness's contract keeps the
+    // two encodings apart, so `selected` stays empty beside it.
+    if (picked !== other) return { id: item.id, selected: [picked] }
+    const typed = await promptText(ctx, {
+      title: questionTitle(item),
+      view: 'Question',
+      message: OTHER_EDITOR_MESSAGE,
+      kind: 'text',
+      ...signal === undefined ? {} : { signal },
+    })
+    if (aborted(signal)) throw abortedQuestion()
+    if (typed !== undefined && typed.trim() !== '') {
+      return { id: item.id, selected: [], custom: typed }
+    }
+    // Not an answer yet: the list comes back with the cursor on the row that
+    // led here, and the next escape dismisses the question itself.
+    initial = other
+  }
+}
+
+/**
+ * Ask a multi-select question: flip any number of offered options, optionally
+ * supplementing them with free text.
+ * @param ctx - the plugin context owning the overlay.
+ * @param item - the question to ask.
+ * @param signal - abort signal for the calling tool.
+ * @returns the answer, or undefined when the reader dismissed the question.
+ */
+async function askMultiSelect(
+  ctx: Context,
+  item: AskUserQuestionItem,
+  signal: AbortSignal | undefined,
+): Promise<AskUserQuestionAnswerItem | undefined> {
+  const choices = (item.options ?? []).map(option => ({
+    value: option.label,
+    label: option.label,
+    ...option.description === undefined ? {} : { description: option.description },
+  }))
+  const answer = await promptMultiSelect(ctx, {
+    title: questionTitle(item),
     view: 'Question',
     ...item.detail === undefined ? {} : { detail: item.detail },
-    choices: choices.length > 0 ? choices : ACKNOWLEDGE,
+    choices,
+    editCustom: current => promptText(ctx, {
+      title: questionTitle(item),
+      view: 'Question',
+      // The supplement semantics are the one thing this editor must say:
+      // unlike the single-select route, the text is kept BESIDE the selections.
+      message: `${OTHER_EDITOR_MESSAGE}, kept alongside the selections`,
+      ...current === '' ? {} : { initial: current },
+      kind: 'text',
+      ...signal === undefined ? {} : { signal },
+    }),
     ...signal === undefined ? {} : { signal },
   })
-  // `promptSelect` correctly removes a withdrawn overlay, but its `undefined`
-  // result also represents an explicit reader dismissal. Harness keeps those
-  // outcomes distinct at this answerer boundary.
   if (aborted(signal)) throw abortedQuestion()
-  // Cancelling answers nothing rather than inventing a choice: the calling tool
-  // sees an empty selection and decides what an unanswered question means.
-  return { id: item.id, selected: selected === undefined ? [] : [selected] }
+  if (answer === undefined) return undefined
+  return {
+    id: item.id,
+    selected: [...answer.selected],
+    ...answer.custom === undefined ? {} : { custom: answer.custom },
+  }
 }
 
 /**

--- a/packages/dshline/tests/capability/user-questions.probe.spec.ts
+++ b/packages/dshline/tests/capability/user-questions.probe.spec.ts
@@ -16,7 +16,8 @@
 
 import { Context } from '@deepseek-ai/cordis'
 import UserQuestionService from '@deepseek-ai/dsh-user-questions'
-import { describe, expect, it } from 'vitest'
+import { stripAnsi } from '@dshline/renderer'
+import { describe, expect, it, vi } from 'vitest'
 import { installQuestionProvider } from '../../src/questions.ts'
 import { TuiSlots } from '../../src/slots.ts'
 
@@ -37,6 +38,42 @@ describe('capability: userQuestions', () => {
       expect(bells).toBe(1)
       ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
       await expect(answer).resolves.toEqual({ answers: [{ id: 'confirm', selected: ['yes'] }] })
+      expect(ctx.tuiSlots.activeOverlay).toBeUndefined()
+    } finally {
+      dispose()
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('carries a real multiSelect request and its custom supplement through the real service', async () => {
+    const ctx = new Context()
+    await ctx.plugin(TuiSlots)
+    await ctx.plugin(UserQuestionService)
+    const dispose = installQuestionProvider(ctx, () => {})
+    try {
+      const answer = ctx.userQuestions.ask({
+        questions: [{
+          id: 'stack',
+          question: 'Which layers?',
+          multiSelect: true,
+          options: [{ label: 'web' }, { label: 'api' }],
+        }],
+      })
+      const shown = (): string => stripAnsi(ctx.tuiSlots.activeOverlay?.render(80).join('\n') ?? '')
+      expect(shown()).toContain('[ ] web')
+      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'text', text: ' ' })
+      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'end' })
+      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
+      expect(shown()).toContain('kept alongside the selections')
+      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'text', text: 'cli too' })
+      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
+      // The committed supplement lands on the waiting list one microtask later.
+      await vi.waitFor(() => { expect(shown()).toContain('Other…: cli too') })
+      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'up' })
+      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
+      await expect(answer).resolves.toEqual({
+        answers: [{ id: 'stack', selected: ['web'], custom: 'cli too' }],
+      })
       expect(ctx.tuiSlots.activeOverlay).toBeUndefined()
     } finally {
       dispose()

--- a/packages/dshline/tests/capability/user-questions.probe.spec.ts
+++ b/packages/dshline/tests/capability/user-questions.probe.spec.ts
@@ -69,7 +69,7 @@ describe('capability: userQuestions', () => {
       ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
       // The committed supplement lands on the waiting list one microtask later.
       await vi.waitFor(() => { expect(shown()).toContain('Other…: cli too') })
-      ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'up' })
+      // The receipt row is the finished answer; Enter confirms it in place.
       ctx.tuiSlots.activeOverlay?.handleKey({ kind: 'key', name: 'enter' })
       await expect(answer).resolves.toEqual({
         answers: [{ id: 'stack', selected: ['web'], custom: 'cli too' }],

--- a/packages/dshline/tests/questions.spec.ts
+++ b/packages/dshline/tests/questions.spec.ts
@@ -362,6 +362,29 @@ describe('multi-select questions', () => {
     })
   })
 
+  it('unregisters its withdrawal listener whenever the question settles', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    // A real signal, spied rather than mocked: settlement — confirmation or
+    // dismissal alike — must end the prompt's stake in it.
+    const confirmed = new AbortController()
+    const confirmedRemovals = vi.spyOn(confirmed.signal, 'removeEventListener')
+    const answer = send({ signal: confirmed.signal, questions: [MULTI_QUESTION] })
+    overlay()?.handleKey({ kind: 'text', text: ' ' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'stack', selected: ['web'] }] })
+    expect(confirmedRemovals).toHaveBeenCalledTimes(1)
+    expect(confirmedRemovals).toHaveBeenCalledWith('abort', expect.any(Function))
+
+    const dismissed = new AbortController()
+    const dismissedRemovals = vi.spyOn(dismissed.signal, 'removeEventListener')
+    const second = send({ signal: dismissed.signal, questions: [MULTI_QUESTION] })
+    overlay()?.handleKey({ kind: 'key', name: 'escape' })
+    await expect(second).resolves.toEqual({ answers: [{ id: 'stack', selected: [] }] })
+    expect(dismissedRemovals).toHaveBeenCalledTimes(1)
+    expect(dismissedRemovals).toHaveBeenCalledWith('abort', expect.any(Function))
+  })
+
   it('dismisses without fabricating an answer', async () => {
     const { ctx, send, overlay } = questionContext()
     installQuestionProvider(ctx, () => {})

--- a/packages/dshline/tests/questions.spec.ts
+++ b/packages/dshline/tests/questions.spec.ts
@@ -170,6 +170,37 @@ describe('single-select questions', () => {
     await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: ['B'] }] })
   })
 
+  it('keeps a real Other… option selectable beside the renamed custom route', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({
+      questions: [{ id: 'q', question: 'Pick', options: [{ label: 'A' }, { label: 'Other…' }] }],
+    })
+    // Harness reserves no label, so the offered option renders verbatim while
+    // the route names itself out of its way: two rows, visibly not the same.
+    // The frame's border columns come off each line before matching.
+    const rows = shown(overlay()).split('\n').map(row => row.replaceAll('│', ' ').trim())
+    expect(rows).toContain('Other…')
+    expect(rows).toContain('Other… (free text)')
+    overlay()?.handleKey({ kind: 'key', name: 'down' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: ['Other…'] }] })
+  })
+
+  it('routes the renamed custom row to the editor when a real option claims Other…', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({
+      questions: [{ id: 'q', question: 'Pick', options: [{ label: 'A' }, { label: 'Other…' }] }],
+    })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(shown(overlay())).toContain('Type your own answer') })
+    overlay()?.handleKey({ kind: 'text', text: 'off-menu' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: [], custom: 'off-menu' }] })
+  })
+
   it('dismisses an unanswered picker without fabricating a selection', async () => {
     const { ctx, send, overlay } = questionContext()
     installQuestionProvider(ctx, () => {})
@@ -212,11 +243,71 @@ describe('multi-select questions', () => {
     overlay()?.handleKey({ kind: 'text', text: 'embedded too' })
     overlay()?.handleKey({ kind: 'key', name: 'enter' })
     await vi.waitFor(() => { expect(shown(overlay())).toContain('Other…: embedded too') })
-    overlay()?.handleKey({ kind: 'key', name: 'up' })
+    // The receipt row IS the finished answer: Enter confirms it in place, and
+    // the footer says so instead of promising a toggle that cannot happen here.
+    const receipt = shown(overlay())
+    expect(receipt).toContain('tab edit')
+    expect(receipt).toContain('enter confirm')
+    expect(receipt).not.toContain('space toggle')
     overlay()?.handleKey({ kind: 'key', name: 'enter' })
     await expect(answer).resolves.toEqual({
       answers: [{ id: 'stack', selected: ['web'], custom: 'embedded too' }],
     })
+  })
+
+  it('confirms a custom-only answer from the Other… row without moving', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({ questions: [MULTI_QUESTION] })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    expect(shown(overlay())).toContain('kept alongside the selections')
+    overlay()?.handleKey({ kind: 'text', text: 'only this' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(shown(overlay())).toContain('Other…: only this') })
+    // No ordinary option is touched, and none is needed to submit.
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({
+      answers: [{ id: 'stack', selected: [], custom: 'only this' }],
+    })
+  })
+
+  it('reopens the editor with the committed text, and a further commit replaces it', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({ questions: [MULTI_QUESTION] })
+    overlay()?.handleKey({ kind: 'text', text: ' ' })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    overlay()?.handleKey({ kind: 'text', text: 'first' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(shown(overlay())).toContain('Other…: first') })
+    overlay()?.handleKey({ kind: 'key', name: 'tab' })
+    // The editor alone is on top, so the visible 'first' is the field's
+    // prefill, not the receipt row underneath.
+    expect(shown(overlay())).toContain('kept alongside the selections')
+    expect(shown(overlay())).toContain('first')
+    overlay()?.handleKey({ kind: 'key', name: 'ctrl-u' })
+    overlay()?.handleKey({ kind: 'text', text: 'round two' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(shown(overlay())).toContain('Other…: round two') })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({
+      answers: [{ id: 'stack', selected: ['web'], custom: 'round two' }],
+    })
+  })
+
+  it('states the true Enter behavior for the active row', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    send({ questions: [MULTI_QUESTION] })
+    const onChoice = shown(overlay())
+    expect(onChoice).toContain('space toggle')
+    expect(onChoice).toContain('enter confirm')
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    const onRoute = shown(overlay())
+    expect(onRoute).toContain('enter edit')
+    expect(onRoute).not.toContain('space toggle')
   })
 
   it('answers a deliberate none with no labels and no custom text', async () => {
@@ -225,6 +316,50 @@ describe('multi-select questions', () => {
     const answer = send({ questions: [MULTI_QUESTION] })
     overlay()?.handleKey({ kind: 'key', name: 'enter' })
     await expect(answer).resolves.toEqual({ answers: [{ id: 'stack', selected: [] }] })
+  })
+
+  it('keeps a real Other… option checkable beside the renamed custom route', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({
+      questions: [{
+        id: 'stack',
+        question: 'Which layers?',
+        multiSelect: true,
+        options: [{ label: 'web' }, { label: 'Other…' }],
+      }],
+    })
+    const rows = shown(overlay()).split('\n').map(row => row.replaceAll('│', ' ').trim())
+    expect(rows).toContain('[ ] Other…')
+    expect(rows).toContain('Other… (free text)')
+    overlay()?.handleKey({ kind: 'key', name: 'down' })
+    overlay()?.handleKey({ kind: 'text', text: ' ' })
+    expect(shown(overlay())).toContain('[x] Other…')
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'stack', selected: ['Other…'] }] })
+  })
+
+  it('routes the renamed custom row to the editor when a real option claims Other…', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({
+      questions: [{
+        id: 'stack',
+        question: 'Which layers?',
+        multiSelect: true,
+        options: [{ label: 'web' }, { label: 'Other…' }],
+      }],
+    })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    expect(shown(overlay())).toContain('kept alongside the selections')
+    overlay()?.handleKey({ kind: 'text', text: 'mine' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(shown(overlay())).toContain('Other… (free text): mine') })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({
+      answers: [{ id: 'stack', selected: [], custom: 'mine' }],
+    })
   })
 
   it('dismisses without fabricating an answer', async () => {

--- a/packages/dshline/tests/questions.spec.ts
+++ b/packages/dshline/tests/questions.spec.ts
@@ -1,4 +1,4 @@
-/** Plan-review questions take their dedicated overlay instead of a generic detail picker. */
+/** The user-questions answerer: option pickers, free text, and plan review. */
 
 import { describe, expect, it, vi } from 'vitest'
 import type { Context } from '@deepseek-ai/cordis'
@@ -14,12 +14,14 @@ type Answerer = (
 ) => Promise<AskUserQuestionAnswer>
 
 /**
- * A context just large enough to retain the questions answerer and its overlay.
+ * A context just large enough to retain the questions answerer and its overlays.
  *
  * The registration is the real one: `ctx.on('user-questions/request', …)`, the
  * scoped waterfall Harness publishes. `ask()` is what the service's own
- * `ctx.waterfall(...)` would invoke.
- * @returns the context plus readers for the answerer and active overlay.
+ * `ctx.waterfall(...)` would invoke. Overlays are kept as a STACK, not a single
+ * slot: a question's Other… editor mounts on top of the list that raised it,
+ * and only the topmost surface is on screen.
+ * @returns the context plus readers for the answerer and the top overlay.
  */
 function questionContext(): {
   ctx: Context
@@ -29,7 +31,7 @@ function questionContext(): {
   events(): string[]
 } {
   let answerer: Answerer | undefined
-  let active: TuiOverlay | undefined
+  const stack: TuiOverlay[] = []
   const events: string[] = []
   const ctx = {
     on(event: string, listener: Answerer) {
@@ -40,8 +42,11 @@ function questionContext(): {
     tuiSlots: {
       invalidate: () => {},
       pushOverlay(next: TuiOverlay) {
-        active = next
-        return () => { active = undefined }
+        stack.push(next)
+        return () => {
+          const index = stack.indexOf(next)
+          if (index >= 0) stack.splice(index, 1)
+        }
       },
     },
   } as unknown as Context
@@ -51,9 +56,22 @@ function questionContext(): {
     // A `next` that fails loudly: this answerer is terminal, so reaching for
     // it is the regression, not a fallback.
     send: request => answerer?.(request, () => Promise.reject(new Error('delegated down the waterfall'))),
-    overlay: () => active,
+    overlay: () => stack.at(-1),
     events: () => events,
   }
+}
+
+/** The question every multi-select case below asks. */
+const MULTI_QUESTION = {
+  id: 'stack',
+  question: 'Which layers?',
+  multiSelect: true,
+  options: [{ label: 'web' }, { label: 'api' }, { label: 'cli', description: 'command line' }],
+} as const
+
+/** The visible rows of whatever overlay is on top right now. */
+function shown(overlay: TuiOverlay | undefined): string {
+  return stripAnsi(overlay?.render(80).join('\n') ?? '')
 }
 
 describe('the user-questions registration', () => {
@@ -83,6 +101,168 @@ describe('the user-questions registration', () => {
   })
 })
 
+describe('single-select questions', () => {
+  it('offers an Other… route without offering it as an answer', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({
+      questions: [{ id: 'q', question: 'Pick', options: [{ label: 'A' }, { label: 'B' }] }],
+    })
+    expect(shown(overlay())).toContain('Other…')
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    // Confirming the ordinary option encodes only that option's label; the
+    // Other… row itself is a route, never a value.
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: ['A'] }] })
+  })
+
+  it('takes a free-text answer through Other… as a replacement for the selection', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({
+      questions: [{ id: 'q', question: 'Pick', options: [{ label: 'A' }, { label: 'B' }] }],
+    })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    // The picker settled before the editor mounted, so whatever is on top now
+    // is the text field, not the list.
+    await vi.waitFor(() => { expect(overlay()).toBeDefined() })
+    expect(shown(overlay())).toContain('Type your own answer')
+    overlay()?.handleKey({ kind: 'text', text: 'Blue-ish' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: [], custom: 'Blue-ish' }] })
+  })
+
+  it('returns to the option list when the Other… editor is backed out, and the next escape dismisses', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({
+      questions: [{ id: 'q', question: 'Pick', options: [{ label: 'A' }, { label: 'B' }] }],
+    })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(shown(overlay())).toContain('Type your own answer') })
+    overlay()?.handleKey({ kind: 'key', name: 'escape' })
+    // Backing out of the editor is not dismissing the question: the list comes
+    // back, and dismissing IT is a second, separate escape.
+    await vi.waitFor(() => { expect(overlay()).toBeDefined() })
+    const returned = shown(overlay())
+    expect(returned).toContain('Pick')
+    expect(returned).not.toContain('Type your own answer')
+    overlay()?.handleKey({ kind: 'key', name: 'escape' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: [] }] })
+  })
+
+  it('asks again when the Other… editor is committed empty, then accepts an ordinary option', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({
+      questions: [{ id: 'q', question: 'Pick', options: [{ label: 'A' }, { label: 'B' }] }],
+    })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(shown(overlay())).toContain('Type your own answer') })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(overlay()).toBeDefined() })
+    // The re-presented list starts on the row that led here; one up, then
+    // confirm, proves the loop still answers through the ordinary route.
+    overlay()?.handleKey({ kind: 'key', name: 'up' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: ['B'] }] })
+  })
+
+  it('dismisses an unanswered picker without fabricating a selection', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({
+      questions: [{ id: 'q', question: 'Pick', options: [{ label: 'A' }, { label: 'B' }] }],
+    })
+    overlay()?.handleKey({ kind: 'key', name: 'escape' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: [] }] })
+  })
+})
+
+describe('multi-select questions', () => {
+  it('toggles several options and reports their labels in offer order', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({ questions: [MULTI_QUESTION] })
+    expect(shown(overlay())).toContain('[ ] web')
+    expect(shown(overlay())).toContain('[ ] api')
+    expect(shown(overlay())).toContain('Other…')
+    // The spacebar decodes as text, and it is the toggle.
+    overlay()?.handleKey({ kind: 'text', text: ' ' })
+    expect(shown(overlay())).toContain('[x] web')
+    overlay()?.handleKey({ kind: 'key', name: 'down' })
+    overlay()?.handleKey({ kind: 'key', name: 'down' })
+    overlay()?.handleKey({ kind: 'text', text: ' ' })
+    expect(shown(overlay())).toContain('[x] cli')
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'stack', selected: ['web', 'cli'] }] })
+  })
+
+  it('supplements the selections with custom text committed through Other…', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({ questions: [MULTI_QUESTION] })
+    overlay()?.handleKey({ kind: 'text', text: ' ' })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    // The editor mounts on top of the waiting list, which keeps its toggles.
+    expect(shown(overlay())).toContain('kept alongside the selections')
+    overlay()?.handleKey({ kind: 'text', text: 'embedded too' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(shown(overlay())).toContain('Other…: embedded too') })
+    overlay()?.handleKey({ kind: 'key', name: 'up' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({
+      answers: [{ id: 'stack', selected: ['web'], custom: 'embedded too' }],
+    })
+  })
+
+  it('answers a deliberate none with no labels and no custom text', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({ questions: [MULTI_QUESTION] })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'stack', selected: [] }] })
+  })
+
+  it('dismisses without fabricating an answer', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({ questions: [MULTI_QUESTION] })
+    overlay()?.handleKey({ kind: 'text', text: ' ' })
+    overlay()?.handleKey({ kind: 'key', name: 'escape' })
+    // The flip is discarded with the overlay; nothing checked, typed, or
+    // offered is reported as the reader's answer.
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'stack', selected: [] }] })
+  })
+})
+
+describe('option-less questions', () => {
+  it('answers in free text, as the Harness answer contract permits', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({ questions: [{ id: 'q', question: 'Why?' }] })
+    // No stand-in Acknowledge choice is offered: with no options, `custom` is
+    // the only answer the contract can hold.
+    expect(shown(overlay())).not.toContain('OK')
+    overlay()?.handleKey({ kind: 'text', text: 'because' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: [], custom: 'because' }] })
+  })
+
+  it('asks again when the field is committed empty, and dismisses on escape', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const answer = send({ questions: [{ id: 'q', question: 'Why?' }] })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(overlay()).toBeDefined() })
+    overlay()?.handleKey({ kind: 'key', name: 'escape' })
+    await expect(answer).resolves.toEqual({ answers: [{ id: 'q', selected: [] }] })
+  })
+})
+
 describe('question attention', () => {
   it('rings once for a multi-question request before presenting its first overlay', async () => {
     const { ctx, send, overlay } = questionContext()
@@ -91,17 +271,21 @@ describe('question attention', () => {
     const answer = send({
       questions: [
         { id: 'first', question: 'First?' },
-        { id: 'second', question: 'Second?' },
+        { id: 'second', question: 'Second?', options: [{ label: 'A' }, { label: 'B' }] },
       ],
     })
     expect(bells).toBe(1)
+    overlay()?.handleKey({ kind: 'text', text: 'done' })
     overlay()?.handleKey({ kind: 'key', name: 'enter' })
     // The remaining questions are deliberately sequential, but this request has
     // already claimed the single attention event for its whole batch.
     await vi.waitFor(() => { expect(overlay()).toBeDefined() })
     overlay()?.handleKey({ kind: 'key', name: 'enter' })
     await expect(answer).resolves.toEqual({
-      answers: [{ id: 'first', selected: ['ok'] }, { id: 'second', selected: ['ok'] }],
+      answers: [
+        { id: 'first', selected: [], custom: 'done' },
+        { id: 'second', selected: ['A'] },
+      ],
     })
     expect(bells).toBe(1)
   })
@@ -120,8 +304,9 @@ describe('question attention', () => {
       ],
     })
     expect(bells).toBe(1)
+    overlay()?.handleKey({ kind: 'text', text: 'done' })
     overlay()?.handleKey({ kind: 'key', name: 'enter' })
-    // The first picker has settled, but its async continuation has not begun
+    // The first question has settled, but its async continuation has not begun
     // presenting the second. A caller withdrawal wins the whole request.
     abort.abort()
     await expect(answer).rejects.toMatchObject({ code: 'ASK_ABORTED' })
@@ -152,6 +337,39 @@ describe('question attention', () => {
     abort.abort()
     await expect(answer).rejects.toMatchObject({ code: 'ASK_ABORTED' })
     expect(bells).toBe(1)
+    expect(overlay()).toBeUndefined()
+  })
+})
+
+describe('withdrawal while a nested editor is open', () => {
+  it('takes down the Other… editor and rejects when the calling tool is aborted', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const abort = new AbortController()
+    const answer = send({
+      signal: abort.signal,
+      questions: [{ id: 'q', question: 'Pick', options: [{ label: 'A' }] }],
+    })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    await vi.waitFor(() => { expect(shown(overlay())).toContain('Type your own answer') })
+    abort.abort()
+    await expect(answer).rejects.toMatchObject({ code: 'ASK_ABORTED' })
+    expect(overlay()).toBeUndefined()
+  })
+
+  it('unmounts both the multi-select and its editor when aborted mid-edit', async () => {
+    const { ctx, send, overlay } = questionContext()
+    installQuestionProvider(ctx, () => {})
+    const abort = new AbortController()
+    const answer = send({ signal: abort.signal, questions: [MULTI_QUESTION] })
+    overlay()?.handleKey({ kind: 'key', name: 'end' })
+    // The editor mounts synchronously on top of the still-mounted list, so an
+    // abort here has TWO overlays to remove.
+    overlay()?.handleKey({ kind: 'key', name: 'enter' })
+    expect(shown(overlay())).toContain('kept alongside the selections')
+    abort.abort()
+    await expect(answer).rejects.toMatchObject({ code: 'ASK_ABORTED' })
     expect(overlay()).toBeUndefined()
   })
 })


### PR DESCRIPTION
## What

Completes dshline's generic `ctx.userQuestions` presentation against the pinned Harness question-answer contract (`HARNESS_TARGET` → `@deepseek-ai/dsh-user-questions@0.1.2-rc.1`). Harness owns question semantics and answer encoding; dshline owns only bounded terminal presentation. No second question protocol, no persistence, no provider-specific path, no compatibility shim.

### The gap

`askOne()` routed every ordinary question through the single-choice picker, so it could produce zero or exactly one selected label:

- a `multiSelect` question collapsed to one option;
- an off-menu answer had no route at all;
- a question with no options was answered through a fabricated `OK` choice, reporting `selected: ["ok"]` as if the model had offered it.

### What a reader gets now

**Single-select** — the existing picker, plus one appended `Other…` row. Confirming an ordinary option still returns `{ id, selected: [label] }`. `Other…` opens the existing bounded single-line editor (`promptText`); a non-empty commit returns `{ id, selected: [], custom }` — a custom answer *replaces* the selection, exactly as the contract separates the two encodings. Backing out of the editor (escape or empty commit) returns to the list with the cursor on the row that led here; a second escape dismisses the question itself.

**Multi-select** (`item.multiSelect === true`) — a new bounded checkbox overlay (`src/multiselect.ts`), same viewport/framing/settlement discipline as `select.ts`: space flips the row under the cursor (space decodes as `text` in both keyboard encodings), `[x]`/`[ ]` shows state per row, and Enter submits from any offered row. The `Other…` row is the one row Enter reads by its state: while its answer is unwritten, Enter opens the editor (an accidental press cannot submit an unfinished answer); once committed, the row *is* the receipt and Enter confirms in place — so selections-only, custom-only, and selections+custom all submit without moving onto an unrelated option. `tab` on the route row reopens the editor, prefilled with the committed text. The footer states the Enter behavior of the *active* row and drops `space toggle` there, where it toggles nothing. Committed text supplements the selections: `{ id, selected: ['A', 'C'], custom: 'Something else too' }`. Labels return in offer order; nothing is invented.

**Option-less** — asked as free text via `promptText` (the only answer the contract can hold without options; the model-facing tool passes `custom` through verbatim). Empty commit asks again; escape dismisses.

**Label collision** — the Harness contract reserves no label and requires none to be unique, so a real option labeled `Other…` renders verbatim and stays selectable as itself (`selected: ['Other…']`), while the custom route's display label names itself out of the way of every offered label (`Other… (free text)`, then a numbered fallback). The route's routing value remains a private sentinel no offered label can collide with; `Other…` itself is never encoded as a selection.

**Cancellation** — the documented distinctions hold: caller withdrawal → `ASK_ABORTED` with every overlay (including a stacked editor) unmounted; explicit reader dismissal → `{ id, selected: [] }`, never a fabricated choice; plan-review → unchanged, including `ASK_CANCELLED` on dismissal.

## Out of scope (deliberate)

No alternate-screen/full-screen UI, no search box in the multi-select (the viewport keeps long lists reachable), no persistent question history, no generic form framework, no changes to plan review, `HARNESS_TARGET`, or unrelated overlays.

## Tests

`tests/questions.spec.ts` (29 tests) covers: ordinary single-select still answers by label; single-select custom yields `selected: []` + `custom`; multi-select chooses several options in offer order; custom supplements selections and confirms in place from the receipt row; a custom-only answer confirms without moving; `tab` reopens the editor prefilled and a further commit replaces it; the footer states the true Enter behavior for the active row; a real `Other…` option stays selectable/checkable beside the renamed route, in both single- and multi-select, with the route reaching the editor; no custom → labels only; option-less free text per the real contract; dismissal fabricates nothing; abort removes the overlay (including both overlays of a stacked editor) and keeps `ASK_ABORTED`; batched questions stay sequential and keyed by id; plan-review unchanged.

`tests/capability/user-questions.probe.spec.ts` drives real `UserQuestionService` requests through the real waterfall, including a `multiSelect` request whose custom supplement is confirmed in place on the receipt row.

Per the testing rule, deliberate breaks were applied and each failed its named test before being reverted: fabricating `Other…` as a selection, dropping the multi-select custom, withholding the abort signal from the nested editor, reversing offer order, fabricating a free-text selection, ignoring the label collision, never confirming in place, and a dead `tab` key.

## Validation

- `pnpm typecheck` — clean
- `pnpm test` — 3006 passed, 22 skipped (pre-existing), 142 files
- focused: `questions.spec.ts` + `user-questions.probe.spec.ts` — 34 passed

## Changeset

`minor` — new capability (`.changeset/question-answer-parity.md`).