### PR TITLE
feat(dshline): render the structured metadata tool views already publish

### DIFF
--- a/.changeset/fluffy-moons-render.md
+++ b/.changeset/fluffy-moons-render.md
@@ -1,0 +1,5 @@
+---
+'@dshline/dshline': patch
+---
+
+Render more of the structured metadata tools already publish through their presentation views. A call card now lists the files its view declared via `locations` (with `:line` when the view focuses one), bounded by the same row budget as the body and reachable through the inspector when elided. A web search card shows the provider's `answer` above its sources, and each source now carries its `snippet` and `publishedAt` alongside the title and url. A web fetch card opens with a retrieval summary — url, HTTP status, and the view's own `truncated` flag — instead of showing only the fetched text.

--- a/packages/dshline/src/cards.ts
+++ b/packages/dshline/src/cards.ts
@@ -21,6 +21,7 @@ import type {
   DiffCallView,
   DiffResultView,
   FileDiff,
+  FileLocation,
   ReadResultView,
   SearchResultView,
   TerminalCallView,
@@ -28,12 +29,16 @@ import type {
   ToolCallView,
   ToolDefinition,
   ToolResultView,
+  WebFetchResultView,
   WebResultView,
+  WebSearchResultView,
+  WebSource,
 } from '@deepseek-ai/dsh-tools'
 import { diffRows } from './diff.ts'
 import {
   box,
   BOX_CHROME_COLUMNS,
+  displayWidth,
   escapeControls,
   hangingIndent,
   paint,
@@ -183,6 +188,12 @@ export interface InspectableToolCall {
   readonly name: string
   /** The call's own presented content, verbatim. */
   readonly content: readonly ContentBlock[]
+  /**
+   * The call's declared follow-along locations, when the view published any.
+   * Kept beside the content because either can be the thing a call card's row
+   * budget cut, and the inspector re-renders both.
+   */
+  readonly locations?: readonly FileLocation[]
 }
 
 /** Either retained shape the inspector ring holds, newest first. */
@@ -255,19 +266,19 @@ export class ToolCards extends PendingToolCalls {
     switch (view.card) {
       case 'terminal':
         return this.terminalCall(view, width, columns)
-      case 'diff':
-        return this.diffCall(view, columns)
+      case 'diff': {
+        const rendered = this.diffCall(view, columns)
+        if (rendered.truncated) this.rememberInspectableCall(call.name, undefined, view.locations)
+        return rendered.rows
+      }
       case 'generic': {
-        const rendered = this.genericCall(view.title, rawInputText(view.rawInput), view.kind, columns, view.content)
-        // Mirrors the result-side rule in `result()`: a call whose OWN content the
-        // row budget cut becomes inspectable, because those rows are committed
-        // into scrollback the moment this card's turn ends and are unreachable
-        // there. `hidden` never reports truncation (see `body()`), so it never
-        // arms this either.
-        if (rendered.truncated && view.content !== undefined) {
-          this.inspectables.unshift({ item: { kind: 'call', name: call.name, content: view.content }, offered: false })
-          this.inspectables.length = Math.min(this.inspectables.length, INSPECT_HISTORY)
-        }
+        const rendered = this.genericCall(view.title, rawInputText(view.rawInput), view.kind, columns, view.locations, view.content)
+        // Mirrors the result-side rule in `result()`: a call whose OWN content or
+        // location list the row budget cut becomes inspectable, because those
+        // rows are committed into scrollback the moment this card's turn ends
+        // and are unreachable there. `hidden` never reports truncation (see
+        // `body()` and `locationRows()`), so it never arms this either.
+        if (rendered.truncated) this.rememberInspectableCall(call.name, view.content, view.locations)
         return rendered.rows
       }
       default:
@@ -360,6 +371,33 @@ export class ToolCards extends PendingToolCalls {
   }
 
   /**
+   * Retain a call whose own presentation elided rows, newest first and bounded.
+   *
+   * Both the presented content and the declared locations are kept, because
+   * either can be the thing the row budget cut; the inspector re-renders the
+   * same sections at its own budget.
+   * @param name - the tool that made the call.
+   * @param content - the call's presented content, when the view declared any.
+   * @param locations - the call's follow-along locations, when the view declared any.
+   */
+  private rememberInspectableCall(
+    name: string,
+    content: readonly ContentBlock[] | undefined,
+    locations: readonly FileLocation[] | undefined,
+  ): void {
+    this.inspectables.unshift({
+      item: {
+        kind: 'call',
+        name,
+        content: content ?? [],
+        ...locations === undefined ? {} : { locations },
+      },
+      offered: false,
+    })
+    this.inspectables.length = Math.min(this.inspectables.length, INSPECT_HISTORY)
+  }
+
+  /**
    * Consume the inspect opportunity on the NEWEST retained card, if unseen.
    *
    * Only ever index 0. Searching the ring for the newest *unoffered* card would
@@ -449,7 +487,11 @@ export class ToolCards extends PendingToolCalls {
     // A call-shaped entry has no result to re-run `renderResult` against — it is
     // the call's own `presentCall` content, so it re-renders through the same
     // `body()` a generic call used, just at the inspector's budget.
-    if (item.kind === 'call') return this.body(textOf(item.content), columns, false, 'inspect')
+    if (item.kind === 'call') {
+      const declared = this.locationRows(item.locations, columns, 'inspect')
+      const content = this.body(textOf(item.content), columns, false, 'inspect')
+      return { rows: [...declared.rows, ...content.rows], truncated: declared.truncated || content.truncated }
+    }
     const call = {
       name: item.name,
       args: item.args,
@@ -523,6 +565,7 @@ export class ToolCards extends PendingToolCalls {
    *   in its title — `grep`'s title names the pattern its `rawInput` repeats.
    * @param kind - the call category, for its icon.
    * @param columns - the terminal's current width.
+   * @param locations - the files the view declared the call touches, when any.
    * @param content - extra content blocks the view asked to show.
    * @returns rows to write into scrollback.
    */
@@ -531,19 +574,25 @@ export class ToolCards extends PendingToolCalls {
     detail: string,
     kind: string | undefined,
     columns: number,
+    locations?: readonly FileLocation[],
     content?: readonly ContentBlock[],
   ): Rendered {
     const icon = kind === undefined ? MARK.call : KIND_ICON[kind] ?? MARK.call
     const head = paint(escapeControls(title), 'tool-name')
     const rows = hangingIndent(`${paint(icon, 'tool-icon')} `, BODY_INDENT, head, columns)
+    // Locations sit directly under the title rather than after the content: they
+    // are part of what the call IS (the files it touches), and trailing rows
+    // after a long content body would be buried under it.
+    const declared = this.locationRows(locations, columns, this.detail)
+    rows.push(...declared.rows)
     if (detail !== '' && this.detail === 'full') {
       rows.push(...hangingIndent(BODY_INDENT, BODY_INDENT, paint(escapeControls(detail), 'subdued'), columns))
     }
-    let truncated = false
+    let truncated = declared.truncated
     if (content !== undefined && content.length > 0) {
       const body = this.body(textOf(content), columns, false, this.detail)
       rows.push(...body.rows)
-      truncated = body.truncated
+      truncated = body.truncated || truncated
     }
     return { rows: ['', ...rows], truncated }
   }
@@ -623,15 +672,48 @@ export class ToolCards extends PendingToolCalls {
 
   /**
    * A diff call: its title alone, because the change is drawn once, at result time.
+   *
+   * Declared locations are the one addition, and they are not the change: they say
+   * where a follow-along UI would look (usually `path:line`), which the result-time
+   * diff body does not state.
    * @param view - the diff call view.
    * @param columns - the terminal's current width.
-   * @returns rows to write into scrollback.
+   * @returns rows to write into scrollback, and whether the location budget cut any.
    */
-  private diffCall(view: DiffCallView, columns: number): string[] {
-    return [
+  private diffCall(view: DiffCallView, columns: number): Rendered {
+    const rows = [
       '',
       ...hangingIndent(`${paint(KIND_ICON.edit ?? MARK.call, 'tool-icon')} `, BODY_INDENT, paint(escapeControls(view.title), 'tool-name'), columns),
     ]
+    const declared = this.locationRows(view.locations, columns, this.detail)
+    return { rows: [...rows, ...declared.rows], truncated: declared.truncated }
+  }
+
+  /**
+   * The files a call declared it touches, one bounded row each.
+   *
+   * The declared list is the only source: locations are never inferred from
+   * arguments or diffs, because a tool that declared none may still have touched
+   * files, and a row claiming it did would be the frontend inventing a fact.
+   * @param locations - the locations the call view declared, when it did.
+   * @param columns - the terminal's current width.
+   * @param detail - the detail level being drawn.
+   * @returns the location rows and whether the budget cut any.
+   */
+  private locationRows(locations: readonly FileLocation[] | undefined, columns: number, detail: RenderDetail): Rendered {
+    if (detail === 'hidden' || locations === undefined || locations.length === 0) return { rows: [], truncated: false }
+    const rows = locations.map(location => truncateToWidth(
+      paint(escapeControls(location.line === undefined
+        ? location.path
+        // The separator matches how a person names a position in an editor, which
+        // is also how the harness writes a location's meaning into the contract.
+        : `${location.path}:${String(location.line)}`), 'path'),
+      Math.max(1, columns - BODY_INDENT.length),
+    ))
+    const { rows: shown, elided } = this.limit(rows, detail)
+    const out = shown.map(row => `${BODY_INDENT}${row}`)
+    if (elided > 0) out.push(`${BODY_INDENT}${paint(elisionMarker(detail, `… ${String(elided)} more locations`), 'muted')}`)
+    return { rows: out, truncated: elided > 0 }
   }
 
   /**
@@ -764,32 +846,105 @@ export class ToolCards extends PendingToolCalls {
   }
 
   /**
-   * A web retrieval: its sources, or its fetched text.
+   * A web retrieval: a search's cited sources with its provider answer, or a
+   * fetch's retrieval summary and body.
    * @param view - the web result view.
    * @param columns - the terminal's current width.
    * @param result - the logged result, for the fallback text.
+   * @param detail - the detail level being drawn.
    * @returns rows to write into scrollback.
    */
   private webResult(view: WebResultView, columns: number, result: ResultInput, detail: RenderDetail): Rendered {
+    // The unions are merge-extensible: an arm this frontend has never seen is
+    // checked for explicitly, so it degrades to the raw content instead of
+    // reading a field it does not carry.
+    if (view.kind === 'fetch') return this.webFetch(view, columns, result, detail)
     if (view.kind !== 'search') return this.body(textOf(result.content), columns, result.isError, detail)
+    return this.webSearch(view, columns, detail)
+  }
+
+  /**
+   * A completed web search: the provider's answer, then its sources in the order
+   * the harness listed them.
+   *
+   * Every field is read from the structured view and nothing else: a snippet is
+   * the provider's own, never re-derived from result text, and `publishedAt` is
+   * shown exactly as the provider wrote it — reformatting it would claim a
+   * precision the string does not carry.
+   * @param view - the search result view.
+   * @param columns - the terminal's current width.
+   * @param detail - the detail level being drawn.
+   * @returns rows to write into scrollback.
+   */
+  private webSearch(view: WebSearchResultView, columns: number, detail: RenderDetail): Rendered {
     // The `+` marks a capped list, exactly as the search card does: without it a
     // truncated set of sources reads as the complete set.
     const count = `${String(view.sources.length)}${view.truncated ? '+' : ''}`
     const summary = `${count} ${view.sources.length === 1 && !view.truncated ? 'source' : 'sources'}`
     const head = `${BODY_INDENT}${paint(MARK.body, 'chrome')} ${paint(summary, 'subdued')}`
     if (detail === 'hidden') return { rows: [head], truncated: false }
-    const { rows, elided } = this.limit(view.sources.map(source => {
-      const title = source.title === undefined ? source.url : source.title
-      return `${paint(escapeControls(title), 'link')} ${paint(escapeControls(source.url), 'link-target')}`
-    }), detail)
-    return {
-      rows: [
-        head,
-        ...rows.map(row => `${BODY_INDENT}  ${truncateToWidth(row, columns - 4)}`),
-        ...elided > 0 ? [`${BODY_INDENT}  ${paint(elisionMarker(detail, `… ${String(elided)} more`), 'muted')}`] : [],
-      ],
-      truncated: elided > 0,
+    const out = [head]
+    // ONE budget across the answer and every source, not one per source — the
+    // same rule a bulk diff follows, and for the same reason: a search returning
+    // many sources must not bury the transcript under one card.
+    let remaining = rowBudget(detail)
+    let omitted = 0
+    const answer = view.answer === undefined ? '' : view.answer.trim()
+    if (answer !== '') {
+      const rows = hangingIndent(
+        `${BODY_INDENT}${paint(MARK.body, 'chrome')} `,
+        `${BODY_INDENT}  `,
+        paint(escapeControls(answer), 'subdued'),
+        columns,
+      )
+      const shown = rows.slice(0, remaining)
+      omitted += rows.length - shown.length
+      remaining -= shown.length
+      out.push(...shown)
     }
+    for (const source of view.sources) {
+      for (const row of webSourceRows(source, columns)) {
+        if (remaining <= 0) {
+          omitted += 1
+          continue
+        }
+        out.push(`${BODY_INDENT}  ${row}`)
+        remaining -= 1
+      }
+    }
+    if (omitted > 0) out.push(`${BODY_INDENT}  ${paint(elisionMarker(detail, `… ${String(omitted)} more rows`), 'muted')}`)
+    return { rows: out, truncated: omitted > 0 }
+  }
+
+  /**
+   * A completed web fetch: a retrieval summary from the structured view, then the
+   * fetched body.
+   *
+   * The summary is composed from the view's own fields, never parsed back out of
+   * the result text: the model-facing `Fetched …` envelope renders the same facts
+   * for the model, and the view is the authoritative copy for a UI.
+   * @param view - the fetch result view.
+   * @param columns - the terminal's current width.
+   * @param result - the logged result, for the body text.
+   * @param detail - the detail level being drawn.
+   * @returns rows to write into scrollback.
+   */
+  private webFetch(view: WebFetchResultView, columns: number, result: ResultInput, detail: RenderDetail): Rendered {
+    const separator = paint(' · ', 'muted')
+    const tail = [
+      separator + paint(String(view.statusCode), 'subdued'),
+      // The view's own truncation flag, never a length recomputed here: a body can
+      // fit the card entirely and still have been cut upstream, and that fact is
+      // not visible in the text.
+      ...view.truncated ? [separator + paint('truncated', 'warning')] : [],
+    ].join('')
+    // The status and the truncation marker are the parts a reader cannot do
+    // without, so the URL is what gives way when the row is tight.
+    const width = Math.max(1, columns - 4)
+    const url = truncateToWidth(paint(escapeControls(view.url), 'link-target'), Math.max(1, width - displayWidth(tail)))
+    const head = `${BODY_INDENT}${paint(MARK.body, 'chrome')} ${truncateToWidth(url + tail, width)}`
+    const body = this.body(textOf(result.content), columns, result.isError, detail)
+    return { rows: [head, ...body.rows], truncated: body.truncated }
   }
 
   /**
@@ -862,6 +1017,38 @@ function rawInputText(rawInput: unknown): string {
   if (rawInput === undefined || rawInput === null) return ''
   if (typeof rawInput === 'string') return rawInput
   return JSON.stringify(rawInput) ?? ''
+}
+
+/**
+ * One web source's rows: its title with its url, then the optional fields
+ * beneath, in the order the contract lists them.
+ *
+ * An untitled source shows its url once: the fallback IS the url row, and a url
+ * beside itself carries no information. A field that arrives with an embedded
+ * newline is folded to one row rather than split, because the row budget counts
+ * rows, and one source field silently becoming several rows would spend budget
+ * the reader did not see being spent.
+ * @param source - the structured source, exactly as the harness published it.
+ * @param columns - the terminal's current width.
+ * @returns the source's rows, already truncated to fit.
+ */
+function webSourceRows(source: WebSource, columns: number): string[] {
+  const width = Math.max(1, columns - 4)
+  const oneLine = (text: string): string => escapeControls(text).replace(/\n/gu, ' ')
+  const rows = [
+    source.title === undefined
+      ? truncateToWidth(paint(oneLine(source.url), 'link'), width)
+      : truncateToWidth(`${paint(oneLine(source.title), 'link')} ${paint(oneLine(source.url), 'link-target')}`, width),
+  ]
+  if (source.snippet !== undefined && source.snippet.trim() !== '') {
+    rows.push(truncateToWidth(paint(oneLine(source.snippet.trim()), 'subdued'), width))
+  }
+  if (source.publishedAt !== undefined && source.publishedAt.trim() !== '') {
+    // The provider's own string, verbatim: parsing it would invent a precision
+    // the contract never states.
+    rows.push(truncateToWidth(paint(`published ${oneLine(source.publishedAt.trim())}`, 'muted'), width))
+  }
+  return rows
 }
 
 /**

--- a/packages/dshline/src/cards.ts
+++ b/packages/dshline/src/cards.ts
@@ -485,12 +485,11 @@ export class ToolCards extends PendingToolCalls {
    */
   renderInspect(item: InspectableCard, columns: number): { rows: string[]; truncated: boolean } {
     // A call-shaped entry has no result to re-run `renderResult` against — it is
-    // the call's own `presentCall` content, so it re-renders through the same
-    // `body()` a generic call used, just at the inspector's budget.
+    // the call's own `presentCall` body, so it re-renders through the same
+    // `callSections` the card used, locations and content together under one
+    // budget, just at the inspector's far larger allowance.
     if (item.kind === 'call') {
-      const declared = this.locationRows(item.locations, columns, 'inspect')
-      const content = this.body(textOf(item.content), columns, false, 'inspect')
-      return { rows: [...declared.rows, ...content.rows], truncated: declared.truncated || content.truncated }
+      return this.callSections(item.locations, item.content, columns, 'inspect')
     }
     const call = {
       name: item.name,
@@ -580,21 +579,57 @@ export class ToolCards extends PendingToolCalls {
     const icon = kind === undefined ? MARK.call : KIND_ICON[kind] ?? MARK.call
     const head = paint(escapeControls(title), 'tool-name')
     const rows = hangingIndent(`${paint(icon, 'tool-icon')} `, BODY_INDENT, head, columns)
-    // Locations sit directly under the title rather than after the content: they
-    // are part of what the call IS (the files it touches), and trailing rows
-    // after a long content body would be buried under it.
-    const declared = this.locationRows(locations, columns, this.detail)
-    rows.push(...declared.rows)
     if (detail !== '' && this.detail === 'full') {
       rows.push(...hangingIndent(BODY_INDENT, BODY_INDENT, paint(escapeControls(detail), 'subdued'), columns))
     }
-    let truncated = declared.truncated
-    if (content !== undefined && content.length > 0) {
-      const body = this.body(textOf(content), columns, false, this.detail)
+    // Locations sit directly under the salient input rather than trailing the
+    // content: they are part of what the call IS (the files it touches), and rows
+    // after a long content body would be buried under it.
+    const sections = this.callSections(locations, content, columns, this.detail)
+    return { rows: ['', ...rows, ...sections.rows], truncated: sections.truncated }
+  }
+
+  /**
+   * A generic call's body sections — its declared locations, then its presented
+   * content — spending ONE row budget across both.
+   *
+   * The detail budgets bound the body of ONE card, not each section of it: an
+   * allowance per section would let a call that names many files and echoes much
+   * content show roughly two compact budgets before eliding, which is how the
+   * cap stops meaning anything. Locations come first, and the content spends
+   * whatever they leave; each section reports what the shared budget hid from
+   * it, and either one being cut leaves the card inspectable, so the compact
+   * card never silently discards metadata the harness published.
+   *
+   * Both the scrollback card and the inspector render through here, so the
+   * inspector reconstructs the same two sections at its own, far larger budget.
+   * @param locations - the files the view declared the call touches, when any.
+   * @param content - extra content blocks the view asked to show, when any.
+   * @param columns - the terminal's current width.
+   * @param detail - the detail level being drawn.
+   * @returns the section rows and whether the shared budget cut either section.
+   */
+  private callSections(
+    locations: readonly FileLocation[] | undefined,
+    content: readonly ContentBlock[] | undefined,
+    columns: number,
+    detail: RenderDetail,
+  ): Rendered {
+    if (detail === 'hidden') return { rows: [], truncated: false }
+    const budget = rowBudget(detail)
+    let remaining = budget
+    let truncated = false
+    const rows: string[] = []
+    const declared = this.locationRows(locations, columns, detail, remaining)
+    rows.push(...declared.rows)
+    remaining -= declared.drawn
+    truncated = declared.elided > 0
+    if (content !== undefined) {
+      const body = this.body(textOf(content), columns, false, detail, remaining)
       rows.push(...body.rows)
       truncated = body.truncated || truncated
     }
-    return { rows: ['', ...rows], truncated }
+    return { rows, truncated }
   }
 
   /**
@@ -685,8 +720,10 @@ export class ToolCards extends PendingToolCalls {
       '',
       ...hangingIndent(`${paint(KIND_ICON.edit ?? MARK.call, 'tool-icon')} `, BODY_INDENT, paint(escapeControls(view.title), 'tool-name'), columns),
     ]
-    const declared = this.locationRows(view.locations, columns, this.detail)
-    return { rows: [...rows, ...declared.rows], truncated: declared.truncated }
+    // A diff call has no other body to compete with, so its locations take the
+    // whole allowance for themselves.
+    const declared = this.locationRows(view.locations, columns, this.detail, rowBudget(this.detail))
+    return { rows: [...rows, ...declared.rows], truncated: declared.elided > 0 }
   }
 
   /**
@@ -697,12 +734,23 @@ export class ToolCards extends PendingToolCalls {
    * files, and a row claiming it did would be the frontend inventing a fact.
    * @param locations - the locations the call view declared, when it did.
    * @param columns - the terminal's current width.
-   * @param detail - the detail level being drawn.
-   * @returns the location rows and whether the budget cut any.
+   * @param detail - the detail level being drawn, for the elision marker.
+   * @param budget - rows the section may draw, from the allowance the card
+   *   shares across its body sections.
+   * @returns the rows (this section's own elision marker included, which is
+   *   chrome rather than a spent row), how many rows the allowance spent, and
+   *   how many locations the budget hid.
    */
-  private locationRows(locations: readonly FileLocation[] | undefined, columns: number, detail: RenderDetail): Rendered {
-    if (detail === 'hidden' || locations === undefined || locations.length === 0) return { rows: [], truncated: false }
-    const rows = locations.map(location => truncateToWidth(
+  private locationRows(
+    locations: readonly FileLocation[] | undefined,
+    columns: number,
+    detail: RenderDetail,
+    budget: number,
+  ): { rows: string[]; drawn: number; elided: number } {
+    if (detail === 'hidden' || locations === undefined || locations.length === 0) {
+      return { rows: [], drawn: 0, elided: 0 }
+    }
+    const labels = locations.map(location => truncateToWidth(
       paint(escapeControls(location.line === undefined
         ? location.path
         // The separator matches how a person names a position in an editor, which
@@ -710,10 +758,10 @@ export class ToolCards extends PendingToolCalls {
         : `${location.path}:${String(location.line)}`), 'path'),
       Math.max(1, columns - BODY_INDENT.length),
     ))
-    const { rows: shown, elided } = this.limit(rows, detail)
-    const out = shown.map(row => `${BODY_INDENT}${row}`)
+    const { rows, elided } = this.limit(labels, budget)
+    const out = rows.map(row => `${BODY_INDENT}${row}`)
     if (elided > 0) out.push(`${BODY_INDENT}${paint(elisionMarker(detail, `… ${String(elided)} more locations`), 'muted')}`)
-    return { rows: out, truncated: elided > 0 }
+    return { rows: out, drawn: rows.length, elided }
   }
 
   /**
@@ -778,7 +826,7 @@ export class ToolCards extends PendingToolCalls {
     if (view.shape === 'paths') {
       const summary = `${total} ${view.total === 1 ? 'path' : 'paths'}`
       if (detail === 'hidden') return { rows: [`${head}${paint(summary, 'subdued')}`], truncated: false }
-      const { rows, elided } = this.limit(view.paths, detail)
+      const { rows, elided } = this.limit(view.paths, rowBudget(detail))
       return {
         rows: [
           `${head}${paint(summary, 'subdued')}`,
@@ -834,7 +882,7 @@ export class ToolCards extends PendingToolCalls {
     const { rows, elided } = this.limit(view.lines.map(line => {
       const number = paint(String(line.number).padStart(4), 'muted')
       return `${number} ${paint(escapeControls(line.text), 'subdued')}`
-    }), detail)
+    }), rowBudget(detail))
     return {
       rows: [
         head,
@@ -952,13 +1000,17 @@ export class ToolCards extends PendingToolCalls {
    * @param text - the result text, unescaped.
    * @param columns - the terminal's current width.
    * @param isError - whether the call failed, which colours it.
+   * @param detail - the detail level being drawn.
+   * @param budget - rows the section may draw; defaults to the detail's own
+   *   budget. A card that spends one allowance across several sections hands
+   *   each section only what the sections before it left.
    * @returns rows to write into scrollback.
    */
-  private body(text: string, columns: number, isError: boolean, detail: RenderDetail): Rendered {
+  private body(text: string, columns: number, isError: boolean, detail: RenderDetail, budget: number = rowBudget(detail)): Rendered {
     const trimmed = text.trim()
     if (trimmed === '' || detail === 'hidden') return { rows: [], truncated: false }
     const all = escapeControls(trimmed).split('\n')
-    const { rows, elided } = this.limit(all, detail)
+    const { rows, elided } = this.limit(all, budget)
     const role = isError ? 'error' : 'subdued'
     const out = rows.map((row, index) => (index === 0
       ? `${BODY_INDENT}${paint(MARK.body, 'chrome')} ${truncateToWidth(paint(row, role), columns - 4)}`
@@ -968,13 +1020,13 @@ export class ToolCards extends PendingToolCalls {
   }
 
   /**
-   * Cut a body to a detail level's row budget.
+   * Cut a body to a row budget.
    * @param rows - every row the body could show.
-   * @param detail - the detail level being drawn.
+   * @param budget - rows the section may draw, from the allowance the card
+   *   shares across its body sections.
    * @returns the retained rows and how many were dropped.
    */
-  private limit(rows: readonly string[], detail: RenderDetail): { rows: readonly string[]; elided: number } {
-    const budget = rowBudget(detail)
+  private limit(rows: readonly string[], budget: number): { rows: readonly string[]; elided: number } {
     if (rows.length <= budget) return { rows, elided: 0 }
     return { rows: rows.slice(0, budget), elided: rows.length - budget }
   }

--- a/packages/dshline/src/cards.ts
+++ b/packages/dshline/src/cards.ts
@@ -732,6 +732,11 @@ export class ToolCards extends PendingToolCalls {
    * The declared list is the only source: locations are never inferred from
    * arguments or diffs, because a tool that declared none may still have touched
    * files, and a row claiming it did would be the frontend inventing a fact.
+   *
+   * Only the rows the budget will actually draw are formatted: the declared list
+   * can be arbitrarily long, and escaping, painting, and truncating rows the
+   * card is about to elide is work with no output. The visible prefix is known
+   * before any formatting, because a location is one structured row.
    * @param locations - the locations the call view declared, when it did.
    * @param columns - the terminal's current width.
    * @param detail - the detail level being drawn, for the elision marker.
@@ -750,18 +755,18 @@ export class ToolCards extends PendingToolCalls {
     if (detail === 'hidden' || locations === undefined || locations.length === 0) {
       return { rows: [], drawn: 0, elided: 0 }
     }
-    const labels = locations.map(location => truncateToWidth(
+    const shown = locations.slice(0, Math.max(0, budget))
+    const elided = locations.length - shown.length
+    const rows = shown.map(location => `${BODY_INDENT}${truncateToWidth(
       paint(escapeControls(location.line === undefined
         ? location.path
         // The separator matches how a person names a position in an editor, which
         // is also how the harness writes a location's meaning into the contract.
         : `${location.path}:${String(location.line)}`), 'path'),
       Math.max(1, columns - BODY_INDENT.length),
-    ))
-    const { rows, elided } = this.limit(labels, budget)
-    const out = rows.map(row => `${BODY_INDENT}${row}`)
-    if (elided > 0) out.push(`${BODY_INDENT}${paint(elisionMarker(detail, `… ${String(elided)} more locations`), 'muted')}`)
-    return { rows: out, drawn: rows.length, elided }
+    )}`)
+    if (elided > 0) rows.push(`${BODY_INDENT}${paint(elisionMarker(detail, `… ${String(elided)} more locations`), 'muted')}`)
+    return { rows, drawn: shown.length, elided }
   }
 
   /**
@@ -917,8 +922,8 @@ export class ToolCards extends PendingToolCalls {
    *
    * Every field is read from the structured view and nothing else: a snippet is
    * the provider's own, never re-derived from result text, and `publishedAt` is
-   * shown exactly as the provider wrote it — reformatting it would claim a
-   * precision the string does not carry.
+   * displayed without date parsing or reformatting — interpreting the string as
+   * a date would claim a precision it does not carry.
    * @param view - the search result view.
    * @param columns - the terminal's current width.
    * @param detail - the detail level being drawn.
@@ -1096,8 +1101,9 @@ function webSourceRows(source: WebSource, columns: number): string[] {
     rows.push(truncateToWidth(paint(oneLine(source.snippet.trim()), 'subdued'), width))
   }
   if (source.publishedAt !== undefined && source.publishedAt.trim() !== '') {
-    // The provider's own string, verbatim: parsing it would invent a precision
-    // the contract never states.
+    // Displayed without date parsing or reformatting: the provider value is
+    // preserved without interpreting it as a date, whose precision the
+    // contract never states.
     rows.push(truncateToWidth(paint(`published ${oneLine(source.publishedAt.trim())}`, 'muted'), width))
   }
   return rows

--- a/packages/dshline/tests/cards.spec.ts
+++ b/packages/dshline/tests/cards.spec.ts
@@ -1191,6 +1191,58 @@ describe('the locations a call view declared', () => {
     expect(expanded.truncated).toBe(false)
   })
 
+  it('spends ONE row budget across a call\'s locations and content together', () => {
+    // COMPACT_ROWS bounds the body of ONE card, not each section of it: an
+    // allowance per section would let a call that names many files AND echoes
+    // much content show roughly two compact budgets before eliding, which is
+    // how the cap stops meaning anything.
+    const view = {
+      card: 'generic' as const,
+      title: 'Touch and echo',
+      kind: 'other' as const,
+      locations: Array.from({ length: 5 }, (_, i) => ({ path: `file${String(i)}.ts` })),
+      content: [{ type: 'text' as const, text: Array.from({ length: 10 }, (_, i) => `echoed ${String(i)}`).join('\n') }],
+    }
+    const cards = new ToolCards(tool({ call: () => view }), '/w')
+    const rows = plain(cards.call({ callId: 'c1', name: 'demo', arguments: '{}' }, COLUMNS))
+    const secondary = rows.filter(row => row.startsWith('  file') || row.includes('echoed'))
+    // Five locations leave the content one row of the shared six; both sections
+    // are present, and together they never exceed one compact budget.
+    expect(secondary).toHaveLength(COMPACT_BUDGET)
+    expect(secondary.some(row => row.startsWith('  file'))).toBe(true)
+    expect(secondary.some(row => row.includes('echoed'))).toBe(true)
+    expect(rows.at(-1)).toBe('    … 9 more lines · ctrl+o view')
+    // The inspector reconstructs BOTH sections at its own budget: nothing the
+    // harness published is discarded because the compact card ran out of rows.
+    const item = cards.takeInspectable()
+    expect(item).toBeDefined()
+    const expanded = cards.renderInspect(item!, COLUMNS)
+    const seen = stripAnsi(expanded.rows.join('\n'))
+    expect(seen).toContain('file4')
+    expect(seen).toContain('echoed 9')
+    expect(expanded.truncated).toBe(false)
+  })
+
+  it('gives locations and content the full budget at full detail, through the same sections', () => {
+    // Full detail resolves through the same callSections helper, so the shared
+    // rule holds there too: fifteen rows fit FULL_ROWS, so nothing is elided,
+    // nothing is marked, and the inspector is never armed.
+    const view = {
+      card: 'generic' as const,
+      title: 'Touch and echo',
+      kind: 'other' as const,
+      locations: Array.from({ length: 5 }, (_, i) => ({ path: `file${String(i)}.ts` })),
+      content: [{ type: 'text' as const, text: Array.from({ length: 10 }, (_, i) => `echoed ${String(i)}`).join('\n') }],
+    }
+    const cards = new ToolCards(tool({ call: () => view }), '/w')
+    cards.detail = 'full'
+    const rows = plain(cards.call({ callId: 'c1', name: 'demo', arguments: '{}' }, COLUMNS))
+    expect(rows.filter(row => row.startsWith('  file'))).toHaveLength(5)
+    expect(rows.filter(row => row.includes('echoed'))).toHaveLength(10)
+    expect(rows.join('\n')).not.toContain('more')
+    expect(cards.takeInspectable()).toBeUndefined()
+  })
+
   it('invents no location row when the view declared none', () => {
     // A tool that declared no locations may still have touched files, and a row
     // claiming it did would be the frontend inventing a fact.

--- a/packages/dshline/tests/cards.spec.ts
+++ b/packages/dshline/tests/cards.spec.ts
@@ -282,6 +282,16 @@ describe('render intent', () => {
     expect(rows.slice(0, 3)).toEqual(['', '⏺ demo', '  a=1'])
   })
 
+  it('falls a web arm it has never seen back to the raw result content', () => {
+    // Same rule on the result side: an unknown arm must degrade to the fallback
+    // rather than read a field it does not carry.
+    const rows = draw(
+      tool({ result: () => ({ card: 'web', kind: 'future-kind' } as unknown as ToolResultView) }),
+      { text: 'raw content' },
+    )
+    expect(rows).toEqual(['', '⏺ demo', '  ⎿ raw content'])
+  })
+
   it('falls back to raw content when a presenter throws', () => {
     // Presenters read the model's arguments, which may be any JSON at all. A throw
     // must not take down the render.
@@ -1109,5 +1119,249 @@ describe('which end of a body survives the budget', () => {
     expect(rows).toContain('read 5')
     expect(rows).not.toContain('read 6')
     expect(rows).toContain('… 24 more lines')
+  })
+})
+
+describe('the locations a call view declared', () => {
+  it('lists the files a call declared it touches', () => {
+    const rows = draw(tool({ call: () => ({ card: 'generic', title: 'Read config', kind: 'read', locations: [{ path: 'src/config.ts' }] }) }))
+    expect(rows).toEqual(['', '◇ Read config', '  src/config.ts'])
+  })
+
+  it('keeps a location\'s line when the view declared one', () => {
+    const rows = draw(tool({
+      call: () => ({ card: 'generic', title: 'Read config', kind: 'read', locations: [{ path: 'src/config.ts', line: 40 }] }),
+    }))
+    expect(rows[2]).toBe('  src/config.ts:40')
+  })
+
+  it('lists several locations in the order the view declared them', () => {
+    const rows = draw(tool({
+      call: () => ({
+        card: 'generic',
+        title: 'Touch many',
+        kind: 'edit',
+        locations: [{ path: 'a.ts' }, { path: 'b.ts', line: 7 }, { path: 'c.ts' }],
+      }),
+    }))
+    expect(rows.slice(2)).toEqual(['  a.ts', '  b.ts:7', '  c.ts'])
+  })
+
+  it('shows a diff call\'s declared locations beside its title', () => {
+    // The change itself is still drawn once, at result time; a location says where
+    // a follow-along UI would look, which the diff body never states.
+    const rows = draw(tool({
+      call: () => ({
+        card: 'diff',
+        title: 'Edit f.ts',
+        diffs: [{ path: 'f.ts', oldText: 'a', newText: 'b' }],
+        locations: [{ path: 'f.ts', line: 3 }],
+      }),
+    }))
+    expect(rows.slice(0, 3)).toEqual(['', '◆ Edit f.ts', '  f.ts:3'])
+  })
+
+  it('escapes a control character in a location path', () => {
+    const rows = draw(tool({ call: () => ({ card: 'generic', title: 'Read', locations: [{ path: 'evi\u001b[2Jl.ts' }] }) }))
+    expect(rows[2]).toBe('  evi^[[2Jl.ts')
+  })
+
+  it('truncates a long path to the card width rather than wrapping it', () => {
+    // One location is one row: a path that wrapped would shift every following
+    // row of the card.
+    const rows = draw(tool({
+      call: () => ({ card: 'generic', title: 'Read', locations: [{ path: `${'deep/'.repeat(40)}config.ts` }] }),
+    }))
+    expect(rows).toHaveLength(3)
+    expect(displayWidth(rows[2]!)).toBeLessThanOrEqual(COLUMNS)
+  })
+
+  it('bounds many locations at the compact budget and says how many it hid', () => {
+    const locations = Array.from({ length: 10 }, (_, i) => ({ path: `file${String(i)}.ts` }))
+    const cards = new ToolCards(tool({ call: () => ({ card: 'generic', title: 'Touch many', locations }) }), '/w')
+    const rows = plain(cards.call({ callId: 'c1', name: 'demo', arguments: '{}' }, COLUMNS))
+    expect(rows.filter(row => row.startsWith('  file'))).toHaveLength(COMPACT_BUDGET)
+    expect(rows.at(-1)).toBe('  … 4 more locations · ctrl+o view')
+    // Elided locations arm the inspector exactly as elided content does: those
+    // rows are committed to scrollback and otherwise unreachable.
+    const item = cards.takeInspectable()
+    expect(item).toBeDefined()
+    const expanded = cards.renderInspect(item!, COLUMNS)
+    expect(stripAnsi(expanded.rows.join('\n'))).toContain('file9')
+    expect(expanded.truncated).toBe(false)
+  })
+
+  it('invents no location row when the view declared none', () => {
+    // A tool that declared no locations may still have touched files, and a row
+    // claiming it did would be the frontend inventing a fact.
+    const rows = draw(tool({ call: () => ({ card: 'generic', title: 'Grep MIT in LICENSE', kind: 'search', rawInput: 'MIT' }) }))
+    expect(rows).toEqual(['', '⌕ Grep MIT in LICENSE'])
+  })
+
+  it('hides locations at hidden detail, where the title alone speaks', () => {
+    const rows = draw(tool({
+      call: () => ({ card: 'generic', title: 'Read config', kind: 'read', locations: [{ path: 'src/config.ts', line: 40 }] }),
+    }), { detail: 'hidden' })
+    expect(rows).toEqual(['', '◇ Read config'])
+  })
+})
+
+describe('a web search result', () => {
+  it('shows the provider answer before the source list', () => {
+    const rows = draw(tool({
+      result: () => ({
+        card: 'web',
+        kind: 'search',
+        sources: [{ url: 'https://e.com/a', title: 'A page' }],
+        truncated: false,
+        answer: 'The answer is 42.',
+      }),
+    }))
+    expect(rows[2]).toBe('  ⎿ 1 source')
+    expect(rows[3]).toBe('  ⎿ The answer is 42.')
+    expect(rows[4]).toBe('    A page https://e.com/a')
+  })
+
+  it('shows a source\'s snippet and publication date when the provider sent them', () => {
+    const rows = draw(tool({
+      result: () => ({
+        card: 'web',
+        kind: 'search',
+        truncated: false,
+        sources: [{
+          url: 'https://e.com/a',
+          title: 'A page',
+          snippet: 'An excerpt about the page.',
+          publishedAt: '2024-05-01T00:00:00Z',
+        }],
+      }),
+    }))
+    expect(rows).toContain('    An excerpt about the page.')
+    // The provider's own timestamp string, not one reformatted into a precision
+    // the contract never states.
+    expect(rows).toContain('    published 2024-05-01T00:00:00Z')
+  })
+
+  it('degrades cleanly when every optional field is absent', () => {
+    const rows = draw(tool({
+      result: () => ({ card: 'web', kind: 'search', sources: [{ url: 'https://e.com/a' }], truncated: false }),
+    }))
+    // An untitled source shows its url once: the url beside itself says nothing.
+    expect(rows).toEqual(['', '⏺ demo', '  ⎿ 1 source', '    https://e.com/a'])
+  })
+
+  it('keeps the harness\'s source order', () => {
+    const rows = draw(tool({
+      result: () => ({
+        card: 'web',
+        kind: 'search',
+        truncated: false,
+        sources: [{ url: 'https://b.com/1', title: 'B' }, { url: 'https://a.com/2', title: 'A' }],
+      }),
+    }))
+    expect(rows[3]).toBe('    B https://b.com/1')
+    expect(rows[4]).toBe('    A https://a.com/2')
+  })
+
+  it('escapes control characters in the structured fields', () => {
+    const rows = draw(tool({
+      result: () => ({
+        card: 'web',
+        kind: 'search',
+        truncated: false,
+        sources: [{
+          url: 'https://e.com/\u001b[2Ja',
+          title: 'Ti\u001b[2Jtle',
+          snippet: 'Sni\u0007ppet',
+          publishedAt: '2024\u0007-05-01',
+        }],
+      }),
+    }))
+    const joined = rows.join('\n')
+    expect(joined).toContain('Ti^[[2Jtle')
+    expect(joined).toContain('Sni^Gppet')
+    expect(joined).toContain('published 2024^G-05-01')
+    expect(joined).toContain('https://e.com/^[[2Ja')
+  })
+
+  it('spends one row budget across every source and reports what it hid', () => {
+    const sources = Array.from({ length: 9 }, (_, i) => ({ url: `https://e.com/${String(i)}`, title: `Page ${String(i)}` }))
+    const view = { card: 'web' as const, kind: 'search' as const, sources, truncated: false }
+    expect(draw(tool({ result: () => view })).filter(row => row.includes('Page '))).toHaveLength(COMPACT_BUDGET)
+    expect(draw(tool({ result: () => view })).at(-1)).toBe('    … 3 more rows · ctrl+o view')
+    expect(draw(tool({ result: () => view }), { detail: 'full' }).filter(row => row.includes('Page '))).toHaveLength(9)
+    expect(draw(tool({ result: () => view }), { detail: 'hidden' })).toEqual(['', '⏺ demo', '  ⎿ 9 sources'])
+  })
+
+  it('makes an elided search inspectable and expands every source', () => {
+    const sources = Array.from({ length: 9 }, (_, i) => ({ url: `https://e.com/${String(i)}`, title: `Page ${String(i)}` }))
+    const cards = new ToolCards(tool({ result: () => ({ card: 'web', kind: 'search', sources, truncated: false }) }), '/w')
+    cards.call({ callId: 'c1', name: 'demo', arguments: '{}' }, COLUMNS)
+    cards.result(result(''), COLUMNS)
+    const item = cards.takeInspectable()
+    expect(item).toBeDefined()
+    const expanded = cards.renderInspect(item!, COLUMNS)
+    expect(stripAnsi(expanded.rows.join('\n'))).toContain('Page 8')
+    expect(expanded.truncated).toBe(false)
+  })
+})
+
+describe('a web fetch result', () => {
+  it('summarizes the retrieval from the structured view, then the body', () => {
+    const rows = draw(tool({
+      result: () => ({ card: 'web', kind: 'fetch', url: 'https://e.com/page', statusCode: 200, truncated: false }),
+    }), { text: '# Page\nBody text.' })
+    expect(rows[2]).toBe('  ⎿ https://e.com/page · 200')
+    expect(rows[3]).toBe('  ⎿ # Page')
+    expect(rows[4]).toBe('    Body text.')
+  })
+
+  it('marks a fetch the provider cut, and never one it did not', () => {
+    const cut = draw(tool({ result: () => ({ card: 'web', kind: 'fetch', url: 'https://e.com/a', statusCode: 200, truncated: true }) }))
+    expect(cut[2]).toBe('  ⎿ https://e.com/a · 200 · truncated')
+
+    const whole = draw(tool({ result: () => ({ card: 'web', kind: 'fetch', url: 'https://e.com/a', statusCode: 200, truncated: false }) }), { text: 'body' })
+    expect(whole.join('\n')).not.toContain('truncated')
+  })
+
+  it('never recomputes truncation from the body\'s length', () => {
+    // A body that fits the card entirely can still have been cut upstream, and
+    // only the view's flag says so.
+    const rows = draw(tool({
+      result: () => ({ card: 'web', kind: 'fetch', url: 'https://e.com/a', statusCode: 200, truncated: true }),
+    }), { text: 'tiny body' })
+    expect(rows[2]).toContain('· truncated')
+  })
+
+  it('reads the summary from the view, not the Fetched envelope in the result text', () => {
+    const rows = draw(tool({
+      result: () => ({ card: 'web', kind: 'fetch', url: 'https://real.example/page', statusCode: 200, truncated: false }),
+    }), { text: 'Fetched https://decoy.example/other\nstatus 999\ncontent' })
+    expect(rows[2]).toBe('  ⎿ https://real.example/page · 200')
+  })
+
+  it('keeps the body inside the card\'s row budget', () => {
+    const long = Array.from({ length: 30 }, (_, i) => `line ${String(i)}`).join('\n')
+    const rows = draw(tool({
+      result: () => ({ card: 'web', kind: 'fetch', url: 'https://e.com/a', statusCode: 200, truncated: false }),
+    }), { text: long })
+    expect(rows.at(-1)).toBe('    … 24 more lines · ctrl+o view')
+  })
+
+  it('keeps the url and status visible when the body is hidden', () => {
+    const rows = draw(tool({
+      result: () => ({ card: 'web', kind: 'fetch', url: 'https://e.com/a', statusCode: 404, truncated: false }),
+    }), { detail: 'hidden', text: 'body' })
+    expect(rows).toEqual(['', '⏺ demo', '  ⎿ https://e.com/a · 404'])
+  })
+
+  it('lets the url give way before the status on a narrow row', () => {
+    // The status and truncation marker are what a reader cannot do without; a
+    // long url must not push them off the row.
+    const rows = draw(tool({
+      result: () => ({ card: 'web', kind: 'fetch', url: `https://e.com/${'x'.repeat(80)}`, statusCode: 200, truncated: true }),
+    }))
+    expect(rows[2]).toContain('· 200 · truncated')
+    expect(displayWidth(rows[2]!)).toBeLessThanOrEqual(COLUMNS)
   })
 })

--- a/packages/dshline/tests/cards.spec.ts
+++ b/packages/dshline/tests/cards.spec.ts
@@ -1191,6 +1191,23 @@ describe('the locations a call view declared', () => {
     expect(expanded.truncated).toBe(false)
   })
 
+  it('draws only the budgeted prefix of a large declared location list', () => {
+    // The declared list can be arbitrarily long, and only the rows the budget
+    // will actually draw are formatted: bounded presentation is bounded work,
+    // the omitted count comes from the list's own length, and the inspector
+    // still reaches everything the compact card elided.
+    const locations = Array.from({ length: 5_000 }, (_, i) => ({ path: `file${String(i)}.ts` }))
+    const cards = new ToolCards(tool({ call: () => ({ card: 'generic', title: 'Touch many', locations }) }), '/w')
+    const rows = plain(cards.call({ callId: 'c1', name: 'demo', arguments: '{}' }, COLUMNS))
+    expect(rows.filter(row => row.startsWith('  file'))).toHaveLength(COMPACT_BUDGET)
+    expect(rows.at(-1)).toBe('  … 4994 more locations · ctrl+o view')
+    const item = cards.takeInspectable()
+    expect(item).toBeDefined()
+    const expanded = cards.renderInspect(item!, COLUMNS)
+    expect(stripAnsi(expanded.rows.join('\n'))).toContain('file4999')
+    expect(expanded.truncated).toBe(false)
+  })
+
   it('spends ONE row budget across a call\'s locations and content together', () => {
     // COMPACT_ROWS bounds the body of ONE card, not each section of it: an
     // allowance per section would let a call that names many files AND echoes
@@ -1289,8 +1306,8 @@ describe('a web search result', () => {
       }),
     }))
     expect(rows).toContain('    An excerpt about the page.')
-    // The provider's own timestamp string, not one reformatted into a precision
-    // the contract never states.
+    // Displayed without date parsing or reformatting: the provider value is
+    // shown without interpreting it as a date.
     expect(rows).toContain('    published 2024-05-01T00:00:00Z')
   })
 


### PR DESCRIPTION
## What

Render the structured metadata the pinned Harness presentation contract already publishes, which the cards currently omit — without special-casing any tool name and without new domain state.

- **Declared locations (`FileLocation[]`)** — a `generic` or `diff` call view's `locations` now render as one `path` (or `path:line`) row under the call title, in the view's declared order. The list shares the call card's row budget, hides entirely at `hidden`, and arms ctrl+o when elided (`InspectableToolCall` carries the locations; the inspector re-renders them at its own budget). Locations are **never** inferred from arguments or diffs when the field is absent.
- **Web search** — the provider's `answer` renders as wrapped card content above the source list; each source now shows its snippet and publishedAt beneath its title/url; publishedAt is displayed safely without date parsing or reformatting. Source order, the count, and the `+` capped indicator are unchanged. One row budget is spent across the answer and all sources, the same rule a bulk diff already follows.
- **Web fetch** — the card opens with a retrieval summary from the structured view — url, HTTP status, and the view's own `truncated` flag (`⎿ https://… · 200 · truncated`, marker in the `warning` role) — with the fetched body below at the existing budgets. Truncation is never recomputed from content length, and the model-facing `Fetched …` envelope is rendered as content, never parsed for metadata.

## Why

The metadata rode on every `tool/call` and `tool/result` event and never reached the screen: a reader watching a multi-file call saw only its title, a search showed titles beside urls and nothing the provider said about them, and a fetch was indistinguishable from any raw text dump.

The obvious shortcut — routing every non-`search` web arm to the new fetch renderer — would have broken forward compatibility: an unknown future arm must degrade to raw content rather than read fields it does not carry. The dispatch checks for the arms it knows explicitly.

## Forward compatibility

At compile time the pinned union types are used naturally; at runtime every unknown `ToolCallView`/`ToolResultView` arm keeps the sanctioned raw-content fallback. A test pins this for the web union.

## Tests

25 new tests in `cards.spec.ts` (23 across three new describes, plus a web-union fallback pin). Each new behavior was broken on purpose and confirmed to fail tests by name: dropping the `:line` suffix (3 failures), ignoring `answer` (1), hard-disabling the fetch `truncated` marker (4).

## Changeset

`patch` for `@dshline/dshline` (presentation-only, per the precedent of prior card-presentation changes).