### PR TITLE
feat(dshline): name deterministic Harness capability evidence

### DIFF
--- a/docs/architecture.i18n.yaml
+++ b/docs/architecture.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/architecture.md
-architecture.md: b26d361abcc6bb05b7b6ff6d9cb367b805832805
-architecture.zh.md: 26392cfc76dce317a0a7a8a1eca84b0f9c7d6ae2
+architecture.md: 36b29e9896c0cc8670389f69674c0361b2a87f4c
+architecture.zh.md: 841da6ee212436e774c779c1fead9936dc80b591

--- a/docs/architecture.i18n.yaml
+++ b/docs/architecture.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/architecture.md
-architecture.md: 2bcb99fef88e21887b5c1f143c9c5006871b52a6
-architecture.zh.md: d30b3d44b89c9d3f27b41c7566f1496ec9c8b76e
+architecture.md: b26d361abcc6bb05b7b6ff6d9cb367b805832805
+architecture.zh.md: 26392cfc76dce317a0a7a8a1eca84b0f9c7d6ae2

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,7 @@ Prefer a standard Harness surface over a concrete package or provider:
 | --- | --- | --- |
 | background work | `ctx.jobs` | Observe generic job snapshots and changes. |
 | delegated work | `ctx.subagents` | Observe provider-neutral lifecycle and discovery. |
+| live agent registry | `ctx.agents` | Resolve live local Agents and delegate fresh/resumed attachment through the published factory seam; do not own AgentLoop or persistence policy. |
 | orchestrated work | `ctx.workflowEngine` + durable `tool-workflow/*` records | Observe run identity, phases, and members; own no run handle. |
 | models | `ctx.llm` | Read registered provider/model metadata, and the configurable-provider directory of routes configuration can activate. |
 | default model | `ctx.agentDefaultModel` | Read or save the composition's default selection when the optional service is mounted; do not persist a second copy in dshline. |
@@ -77,7 +78,7 @@ Prefer a standard Harness surface over a concrete package or provider:
 | session statistics | `ctx.sessionProjections` (`sessionStats`) | Read the whole-log counts and wall times; derive nothing beyond one division over two published totals. Treat the unit as optional. |
 | request metadata | `Session.requestHeader()` | Read the logged route, system prompt, and tool counts for cache/usage views; do not maintain a parallel header. |
 | context composition per entry | `ctx.tokenMeter` | Ask for the per-node measurement only when an inspector needs it; its own contract calls it O(surface). |
-| plan mode | `plan/mode` events + `ctx.sessionProjections` (`plan`) | Read the logged mode through the projection; do not maintain a live mirror or call `ctx.planMode` from the presentation layer. |
+| plan mode | committed `plan/mode` events; Harness's `plan` projection as contract evidence | Fold committed mode events with `planModeAfter()`; do not maintain a mutable second state or read `ctx.planMode` as a presentation mirror. |
 | reducing context | `ctx.commands` (`/compact`) | Dispatch the registered command; observe `compaction/*` events. Never call `ctx.compaction`. |
 | agent composition | `ctx.agentPresets` | Read the roster, one preset's composition, and which preset a session actually runs; join or switch an agent through the seam, never a private registry. |
 | host composition | `ctx.dshHomePath`, `ctx.baseUrl`, `dsh plugin` | Read the profile roster from Harness's own home-path service and the booted profile from the Loader's base URL; mutate only by forwarding to `dsh plugin`, never by writing a profile manifest. |
@@ -1295,10 +1296,12 @@ verify the production dshline consumer over that seam where relevant. The
 table points to generic surfaces production dshline consumes that can
 reasonably be exercised deterministically in-process; it is not a copied
 contract or a completeness claim about host/bootstrap-only surfaces. The
-pointer deliberately excludes `agents`, `appExit`, `loader`, `cmdlineArgs`,
-`dshHomePath`, and `baseUrl`; TUI-owned surfaces are not capability rows. The
-agent factory and host-plane boot reads need a booting Host and remain the
-published consumer lane's responsibility. An upstream change to a named seam reads as
+pointer deliberately excludes `appExit`, `loader`, `cmdlineArgs`, `dshHomePath`,
+and `baseUrl`; these are launcher/Host-plane inputs outside the named in-process
+service inventory, and TUI-owned surfaces are not capability rows. The published
+consumer lane proves real install/boot integration at that Host boundary, while
+focused tests cover dshline's local forwarding and policy; this does not claim to
+exercise every `/profiles` or host-accessor behavior. An upstream change to a named seam reads as
 `sessionQuery contract changed` rather than only a generic `pnpm typecheck
 failed`; a seam not in this table still has `pnpm typecheck`/`pnpm test` as its
 backstop. `tools/capability-probes.mjs` remains a pointer table, not a second

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,21 +62,27 @@ Prefer a standard Harness surface over a concrete package or provider:
 | delegated work | `ctx.subagents` | Observe provider-neutral lifecycle and discovery. |
 | orchestrated work | `ctx.workflowEngine` + durable `tool-workflow/*` records | Observe run identity, phases, and members; own no run handle. |
 | models | `ctx.llm` | Read registered provider/model metadata, and the configurable-provider directory of routes configuration can activate. |
+| default model | `ctx.agentDefaultModel` | Read or save the composition's default selection when the optional service is mounted; do not persist a second copy in dshline. |
 | user configuration | `ctx.settings` | Read redacted namespace descriptors; write path ops against the revision they were read at. |
 | secrets | `ctx.credentials` | Ask whether a reference or record is configured and writable; never hold a value. |
 | obtaining a credential | `ctx.authorization` | Render the seam's neutral notice and prompt vocabulary; own no login protocol. |
 | human commands | `ctx.commands` | Discover and execute the registered command contract. |
 | tools | `ctx.tools` | Render tool-owned presentation intents, not tool-name cases. |
 | human answers | `ctx.userQuestions` | Register a terminal answerer; claim a request this frontend can present, never assuming it was addressed only to this frontend. |
+| approvals | `ctx.approval` | Answer only requests owned by this frontend; let the waterfall fail closed for other agent identities. |
 | sessions | `ctx.sessionQuery` | Query Harness's live-preferred session corpus; do not build another database. Its full-text methods are abstract, so treat content search as optional. Its `SessionHeader.cwd` values are also the only working-directory authority: group them transiently, never store a directory list, a worktree registry, or a Git state cache. |
 | attachments | `ctx.fs` + `ctx.attachments` | Keep paths as session-local drafts; perform bounded reads through the active filesystem and publish durable image references as one batch. Never persist bytes, base64, or host paths. |
 | log-derived state | `ctx.sessionProjections` | Consume registered domain snapshots and changes. |
 | context occupancy | `ctx.sessionProjections` (`contextPressure`, `contextBreakdown`, `tokenUsage`) | Read the O(1) folds; never count tokens or tokenize. |
 | session statistics | `ctx.sessionProjections` (`sessionStats`) | Read the whole-log counts and wall times; derive nothing beyond one division over two published totals. Treat the unit as optional. |
+| request metadata | `Session.requestHeader()` | Read the logged route, system prompt, and tool counts for cache/usage views; do not maintain a parallel header. |
 | context composition per entry | `ctx.tokenMeter` | Ask for the per-node measurement only when an inspector needs it; its own contract calls it O(surface). |
+| plan mode | `plan/mode` events + `ctx.sessionProjections` (`plan`) | Read the logged mode through the projection; do not maintain a live mirror or call `ctx.planMode` from the presentation layer. |
 | reducing context | `ctx.commands` (`/compact`) | Dispatch the registered command; observe `compaction/*` events. Never call `ctx.compaction`. |
 | agent composition | `ctx.agentPresets` | Read the roster, one preset's composition, and which preset a session actually runs; join or switch an agent through the seam, never a private registry. |
 | host composition | `ctx.dshHomePath`, `ctx.baseUrl`, `dsh plugin` | Read the profile roster from Harness's own home-path service and the booted profile from the Loader's base URL; mutate only by forwarding to `dsh plugin`, never by writing a profile manifest. |
+| subprocess | `ctx.subprocess` | Forward the launcher argv, environment, and timeout through the Harness runtime; do not reimplement launcher or profile policy. |
+| session title | `ctx.sessionTitle` | Rename through the live-session service; do not mutate a copied header or maintain a title store. |
 | skills | `ctx.skills` | Observe the effective per-scope catalog with `snapshot({ cwd, scope: agent })`; offer and inspect the resolved summaries. Never discover, load, or inject a skill body — a leading `/name` line is sent verbatim and `dsh-tool-skill` owns what it means. |
 | provider health | `ctx.subagents` | Ask the registry which providers exist before presenting a row that names one as usable; never infer availability from a row being enabled. |
 
@@ -696,8 +702,11 @@ lifecycle where none is needed.
 
 Because the row is now dshline's to mount, its shape is dshline's compatibility
 problem too: `tests/capability/authorization.probe.spec.ts` mounts the real
-service over a real abstract `CredentialProvider` subclass, and
-`tools/capability-probes.mjs` names it as the `authorization` seam's evidence.
+`AuthorizationService` over a minimal local credentials service implementing
+its published record surface, and `tools/capability-probes.mjs` names that
+orchestration as the `authorization` seam's evidence. The separate credentials
+probe covers the abstract `CredentialProvider` contract; neither fixture claims
+production storage policy.
 
 The seam surfaces themselves are written out structurally in
 `connect/harness.ts` rather than depended on as whole services, for the reason
@@ -1276,29 +1285,27 @@ work unmergeable. Once the two defaults agree, an ordinary unqualified install
 resolves a coherent pair again, which is the only thing the gate was ever
 protecting.
 
-Each Harness lane additionally runs `tools/capability-report.mjs`, which turns a
-seam's real Harness contract — a real `SessionQueryEngine`, a real
-`SubagentRuntime`, a real abstract `JobRegistry` subclass, a real
-`UserQuestionService`, a real abstract `WorkflowEngine` subclass over a real
-`Session`, never a dshline-shaped fake — into a named pass/fail
-per capability. Coverage today is initial, not exhaustive: `sessionQuery`,
-`jobs`, `subagents`, `sessionProjections`, `workflows`, `userQuestions`,
-`tokenMeter` (the real `TokenMeter` over a real `SessionStore`),
-`compaction` (a real `CompactionEngine` subclass), `skills` (the real
-scope-layered `SkillRegistry`, plus the real `dsh-tool-skill` pre-step
-boundary that turns a typed `/name` line into an injection), and
-`requestHeader` (the `Session.requestHeader()` fold `/cache` reads the latest
-recorded route, system prompt, and tool count from), chosen because
-each already has (or could cheaply gain) a test built against the real class
-rather than a hand-typed fake. An upstream change to one of these reads as
-`sessionQuery contract changed` rather than only a generic
-`pnpm typecheck failed`; a seam not yet in the table still has
-`pnpm typecheck`/`pnpm test` as its backstop. `tools/capability-probes.mjs` is
-a pointer table, not a second copy of the contract: it names which existing or
-purpose-built test already exercises each seam, so growing this coverage means
-adding a line to that table (or a small new probe under
-`packages/dshline/tests/capability/`), never teaching this module the seam's
-shape itself.
+Each Harness lane additionally runs `tools/capability-report.mjs`, which turns
+named evidence into a PASS, FAIL, or MISSING result per capability. Capability
+evidence is built against the real Harness contract at the strongest
+deterministic layer available: concrete service or runtime behavior where
+practical, base-class orchestration where that is the contract, or a minimal
+subclass when the seam is intentionally abstract. Integration probes then
+verify the production dshline consumer over that seam where relevant. The
+table points to generic surfaces production dshline consumes that can
+reasonably be exercised deterministically in-process; it is not a copied
+contract or a completeness claim about host/bootstrap-only surfaces. The
+pointer deliberately excludes `agents`, `appExit`, `loader`, `cmdlineArgs`,
+`dshHomePath`, and `baseUrl`; TUI-owned surfaces are not capability rows. The
+agent factory and host-plane boot reads need a booting Host and remain the
+published consumer lane's responsibility. An upstream change to a named seam reads as
+`sessionQuery contract changed` rather than only a generic `pnpm typecheck
+failed`; a seam not in this table still has `pnpm typecheck`/`pnpm test` as its
+backstop. `tools/capability-probes.mjs` remains a pointer table, not a second
+copy of the contract: it names which existing or purpose-built test supplies
+evidence, so growing the coverage means adding a line to that table (or a
+small new probe under `packages/dshline/tests/capability/`), never teaching
+this module the seam's shape itself.
 
 `userQuestions` is this radar's first proof against a real break: Harness's
 `ctx.userQuestions` registration shape moved, and `packages/dshline/src/questions.ts`

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -40,6 +40,7 @@ native terminal
 | --- | --- | --- |
 | 后台工作 | `ctx.jobs` | 观察通用任务快照与变更。 |
 | 委派工作 | `ctx.subagents` | 观察提供方无关的生命周期与发现。 |
+| 活动 agent 注册表 | `ctx.agents` | 通过已发布的 factory seam 解析进程内活动 Agent，并委派新建/恢复附着；不拥有 AgentLoop 或持久化策略。 |
 | 编排工作 | `ctx.workflowEngine` + 持久 `tool-workflow/*` 记录 | 观察运行身份、阶段与成员；不持有运行句柄。 |
 | 模型 | `ctx.llm` | 读取已注册提供方/模型元数据，以及配置可激活路由的可配置提供方目录。 |
 | 默认模型 | `ctx.agentDefaultModel` | 在可选服务已挂载时读取或保存组合的默认选择；不在 dshline 中持久化第二份副本。 |
@@ -57,7 +58,7 @@ native terminal
 | 会话统计 | `ctx.sessionProjections`（`sessionStats`） | 读取全日志计数与墙钟时间；除了对两个已发布总量做一次除法之外不再推导任何东西。将该单元视为可选。 |
 | 请求元数据 | `Session.requestHeader()` | 为缓存/用量视图读取已记录的路由、系统提示与工具计数；不维护平行的 header。 |
 | 逐条目的上下文组成 | `ctx.tokenMeter` | 只在检视器需要时索取逐节点测量；其自身约定称之为 O(surface)。 |
-| 计划模式 | `plan/mode` 事件 + `ctx.sessionProjections`（`plan`） | 通过投影读取已记录的模式；不维护实时镜像，也不在呈现层调用 `ctx.planMode`。 |
+| 计划模式 | 已提交的 `plan/mode` 事件；Harness 的 `plan` 投影作为约定证据 | 用 `planModeAfter()` 折叠已提交的模式事件；不维护可变的第二份状态，也不把 `ctx.planMode` 作为呈现镜像来读取。 |
 | 缩减上下文 | `ctx.commands`（`/compact`） | 派发已注册的命令；观察 `compaction/*` 事件。绝不调用 `ctx.compaction`。 |
 | agent 组合 | `ctx.agentPresets` | 读取名册、某个预设的组合，以及某个会话实际运行的预设；只通过这个 seam 加入或切换一个 agent，绝不用私有注册表。 |
 | Host 组合 | `ctx.dshHomePath`、`ctx.baseUrl`、`dsh plugin` | 通过 Harness 自己的 home-path 服务读取配置文件名册，从 Loader 的 base URL 读取已启动的配置文件；变更只转发给 `dsh plugin`，绝不写入配置文件清单。 |
@@ -541,6 +542,6 @@ npm install -g @deepseek-ai/dsh @dshline/dshline
 
 这是一道发布闸门，不是兼容性车道，并且它丝毫不改变上面那句话——不是生成的发布 PR 的 pull request 永远不会解析 dist-tag，因此由 DeepSeek 移动的指针仍然永远无法让无关工作无法合并。一旦两个默认值一致，普通的不带限定安装就重新解析出一致的一对，而这正是这道闸门始终在保护的唯一东西。
 
-每条 Harness 车道都会额外运行 `tools/capability-report.mjs`，把命名证据转化为每项能力的 PASS、FAIL 或 MISSING。能力证据以真实 Harness 约定为基础，使用可获得的最强确定性层：可行时使用具体服务或运行时行为；当约定由基类实现时使用基类编排；seam 有意保持抽象时使用最小子类。随后，在相关之处，集成探针验证生产 dshline 对该 seam 的消费。这张表指向生产 dshline 消费、且适合在进程内以确定方式演练的通用 surface；它不是复制的约定，也不宣称覆盖只能由 Host 启动触及的 surface。指针表明确排除 `agents`、`appExit`、`loader`、`cmdlineArgs`、`dshHomePath` 与 `baseUrl`；TUI 自有的 surface 也不是能力行。agent 工厂与宿主平面的启动读取需要正在启动的 Host，仍由 published consumer 车道负责。上游对已命名 seam 的变更读起来是 `sessionQuery contract changed`，而不只是笼统的 `pnpm typecheck failed`；尚未进入这张表的 seam，仍以 `pnpm typecheck`/`pnpm test` 作为后备。`tools/capability-probes.mjs` 仍是一张指针表，不是约定的第二份拷贝：它只指出哪个既有或新建的测试提供证据，因此扩大这一覆盖意味着往那张表里加一行（或在 `packages/dshline/tests/capability/` 下新增一个小探针），而绝不是让这个模块自己学会该 seam 的形状。
+每条 Harness 车道都会额外运行 `tools/capability-report.mjs`，把命名证据转化为每项能力的 PASS、FAIL 或 MISSING。能力证据以真实 Harness 约定为基础，使用可获得的最强确定性层：可行时使用具体服务或运行时行为；当约定由基类实现时使用基类编排；seam 有意保持抽象时使用最小子类。随后，在相关之处，集成探针验证生产 dshline 对该 seam 的消费。这张表指向生产 dshline 消费、且适合在进程内以确定方式演练的通用 surface；它不是复制的约定，也不宣称覆盖只能由 Host 启动触及的 surface。指针表明确排除 `appExit`、`loader`、`cmdlineArgs`、`dshHomePath` 与 `baseUrl`；它们是命名的进程内服务 inventory 之外的 launcher/Host 平面输入，TUI 自有的 surface 也不是能力行。published consumer 车道在该 Host 边界验证真实安装/启动集成，而 focused tests 验证 dshline 自己的转发与策略；这不表示它覆盖每一种 `/profiles` 或 Host accessor 行为。上游对已命名 seam 的变更读起来是 `sessionQuery contract changed`，而不只是笼统的 `pnpm typecheck failed`；尚未进入这张表的 seam，仍以 `pnpm typecheck`/`pnpm test` 作为后备。`tools/capability-probes.mjs` 仍是一张指针表，不是约定的第二份拷贝：它只指出哪个既有或新建的测试提供证据，因此扩大这一覆盖意味着往那张表里加一行（或在 `packages/dshline/tests/capability/` 下新增一个小探针），而绝不是让这个模块自己学会该 seam 的形状。
 
 `userQuestions` 是这套雷达第一次证明它能发现真实的破坏：Harness 的 `ctx.userQuestions` 注册方式发生了变化，`packages/dshline/src/questions.ts` 一度用一个小的运行时判断把两种形态桥接起来。那个桥接属于债务而不是范式——它早于"一次只支持一代"的规则——随后的那次采纳已经删除了它：该模块现在直接注册在按作用域分层的 `user-questions/request` 瀑布上。不应再写出同类的新桥接。迁移是移除旧调用，而不是同时保留两者。

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -42,21 +42,27 @@ native terminal
 | 委派工作 | `ctx.subagents` | 观察提供方无关的生命周期与发现。 |
 | 编排工作 | `ctx.workflowEngine` + 持久 `tool-workflow/*` 记录 | 观察运行身份、阶段与成员；不持有运行句柄。 |
 | 模型 | `ctx.llm` | 读取已注册提供方/模型元数据，以及配置可激活路由的可配置提供方目录。 |
+| 默认模型 | `ctx.agentDefaultModel` | 在可选服务已挂载时读取或保存组合的默认选择；不在 dshline 中持久化第二份副本。 |
 | 用户配置 | `ctx.settings` | 读取脱敏的命名空间描述符；对读取时的修订号执行写入路径操作。 |
 | 密钥 | `ctx.credentials` | 询问引用或记录是否已配置且可写；绝不持有值。 |
 | 获取凭据 | `ctx.authorization` | 渲染 seam 的中立通知与提示词汇；不拥有登录协议。 |
 | 人类命令 | `ctx.commands` | 发现并执行已注册的命令约定。 |
 | 工具 | `ctx.tools` | 渲染工具拥有的呈现意图，而不是工具名的特例。 |
 | 人类应答 | `ctx.userQuestions` | 注册一个终端应答者；认领本前端能够呈现的请求，绝不假设该请求只发给了本前端。 |
+| 审批 | `ctx.approval` | 只回答属于本前端的请求；对于其他 agent 身份让 waterfall 失败关闭。 |
 | 会话 | `ctx.sessionQuery` | 查询 Harness 偏好活动的会话语料库；不构建另一个数据库。其全文方法是抽象的，因此把内容搜索视为可选。它的 `SessionHeader.cwd` 值也是唯一的工作目录权威：只做临时分组，绝不存储目录清单、worktree registry 或 Git 状态缓存。 |
 | 附件 | `ctx.fs` + `ctx.attachments` | 路径只作为会话本地草稿；通过当前文件系统执行有界读取，并把持久图片引用作为一个批次发布。绝不持久化字节、base64 或主机路径。 |
 | 日志派生的状态 | `ctx.sessionProjections` | 消费已注册的领域快照与变更。 |
 | 上下文占用 | `ctx.sessionProjections`（`contextPressure`、`contextBreakdown`、`tokenUsage`） | 读取 O(1) 折叠；绝不自行计数 token 或分词。 |
 | 会话统计 | `ctx.sessionProjections`（`sessionStats`） | 读取全日志计数与墙钟时间；除了对两个已发布总量做一次除法之外不再推导任何东西。将该单元视为可选。 |
+| 请求元数据 | `Session.requestHeader()` | 为缓存/用量视图读取已记录的路由、系统提示与工具计数；不维护平行的 header。 |
 | 逐条目的上下文组成 | `ctx.tokenMeter` | 只在检视器需要时索取逐节点测量；其自身约定称之为 O(surface)。 |
+| 计划模式 | `plan/mode` 事件 + `ctx.sessionProjections`（`plan`） | 通过投影读取已记录的模式；不维护实时镜像，也不在呈现层调用 `ctx.planMode`。 |
 | 缩减上下文 | `ctx.commands`（`/compact`） | 派发已注册的命令；观察 `compaction/*` 事件。绝不调用 `ctx.compaction`。 |
 | agent 组合 | `ctx.agentPresets` | 读取名册、某个预设的组合，以及某个会话实际运行的预设；只通过这个 seam 加入或切换一个 agent，绝不用私有注册表。 |
 | Host 组合 | `ctx.dshHomePath`、`ctx.baseUrl`、`dsh plugin` | 通过 Harness 自己的 home-path 服务读取配置文件名册，从 Loader 的 base URL 读取已启动的配置文件；变更只转发给 `dsh plugin`，绝不写入配置文件清单。 |
+| 子进程 | `ctx.subprocess` | 通过 Harness runtime 转发 launcher argv、环境与超时；不重新实现 launcher 或 profile 策略。 |
+| 会话标题 | `ctx.sessionTitle` | 通过活动会话服务重命名；不修改复制的 header，也不维护标题存储。 |
 | 技能 | `ctx.skills` | 用 `snapshot({ cwd, scope: agent })` 观察按作用域解析出的有效目录；提供并检视已解析的摘要。绝不发现、加载或注入技能正文——开头带 `/name` 的一行按原样发送，它的含义由 `dsh-tool-skill` 拥有。 |
 | 提供方健康 | `ctx.subagents` | 在呈现指名某个提供方可用的行之前，先向注册表询问哪些提供方存在；绝不从某一行被启用推断可用性。 |
 
@@ -314,7 +320,7 @@ ctx.settings      the PROFILE that registers a route         llm-pi-ai.providers
 
 另一条路被考虑过并被否决。`dsh-authorization` 不声明 `dsh.bundle`，所以 `dsh plugin add` 会把它作为一个什么都不组合的普通依赖装上——正是 `/profiles` 已经会报告的「装了却是惰性的」状态——而要把这件事做完，就意味着 dshline 往 profile 自己的 `cordis.patch.yml` 里写一行组合，而那个 patch 层没有任何 Harness 变更 API 拥有。为一个 bundle 直接组合就能得到的能力去做首次运行安装器，是在不需要生命周期的地方多造一个生命周期。
 
-由于这一行现在归 dshline 挂载，它的形状也就成了 dshline 的兼容性问题：`tests/capability/authorization.probe.spec.ts` 把真实服务挂载在一个真实的抽象 `CredentialProvider` 子类之上，而 `tools/capability-probes.mjs` 把它列为 `authorization` seam 的证据。
+由于这一行现在归 dshline 挂载，它的形状也就成了 dshline 的兼容性问题：`tests/capability/authorization.probe.spec.ts` 把真实的 `AuthorizationService` 挂载在一个实现其已发布记录 surface 的最小本地凭据服务之上，而 `tools/capability-probes.mjs` 把这项编排列为 `authorization` seam 的证据。单独的 credentials 探针覆盖抽象 `CredentialProvider` 约定；两处 fixture 都不声称证明生产存储策略。
 
 seam 接口本身在 `connect/harness.ts` 中结构化写出，而不是依赖整个服务，原因与 `SessionQueryReads` 给出的一样——点名一个视图调用比依赖整个服务更易读。该文件里的每一个导入仍然只是类型导入，所以 Connect 在运行时不携带任何 Harness 代码；`connectSeams` 中的三处赋值在每次构建时把每个窄视图与真实服务做校验，因为每个服务包都用自己的类型扩展了 `Context`。
 
@@ -535,6 +541,6 @@ npm install -g @deepseek-ai/dsh @dshline/dshline
 
 这是一道发布闸门，不是兼容性车道，并且它丝毫不改变上面那句话——不是生成的发布 PR 的 pull request 永远不会解析 dist-tag，因此由 DeepSeek 移动的指针仍然永远无法让无关工作无法合并。一旦两个默认值一致，普通的不带限定安装就重新解析出一致的一对，而这正是这道闸门始终在保护的唯一东西。
 
-每条 Harness 车道都会额外运行 `tools/capability-report.mjs`，它把一个 seam 的真实 Harness 约定——真实的 `SessionQueryEngine`、真实的 `SubagentRuntime`、真实的抽象 `JobRegistry` 子类、真实的 `UserQuestionService`、在真实 `Session` 之上的真实抽象 `WorkflowEngine` 子类，绝不是 dshline 臆造的假对象——转化为按能力命名的通过/失败结果。目前的覆盖是初始的，而非穷尽的：`sessionQuery`、`jobs`、`subagents`、`sessionProjections`、`workflows`、`userQuestions`、`tokenMeter`（真实 `SessionStore` 之上的真实 `TokenMeter`）、`compaction`（真实的 `CompactionEngine` 子类）、`skills`（真实的按作用域分层的 `SkillRegistry`，以及把打出的 `/name` 一行变成注入的真实 `dsh-tool-skill` pre-step 边界）与 `requestHeader`（`/cache` 用来读取最新记录的路由、系统提示词与工具数量的 `Session.requestHeader()` 折叠），之所以选择它们，是因为每一个都已经有（或能够低成本获得）一个针对真实类而非手工伪造对象构建的测试。上游对其中一个的变更读起来是 `sessionQuery contract changed`，而不只是笼统的 `pnpm typecheck failed`；尚未进入这张表的 seam，仍以 `pnpm typecheck`/`pnpm test` 作为后备。`tools/capability-probes.mjs` 是一张指针表，不是约定的第二份拷贝：它只指出哪个既有或新建的测试已经在验证每个 seam，因此扩大这一覆盖意味着往那张表里加一行（或在 `packages/dshline/tests/capability/` 下新增一个小探针），而绝不是让这个模块自己学会该 seam 的形状。
+每条 Harness 车道都会额外运行 `tools/capability-report.mjs`，把命名证据转化为每项能力的 PASS、FAIL 或 MISSING。能力证据以真实 Harness 约定为基础，使用可获得的最强确定性层：可行时使用具体服务或运行时行为；当约定由基类实现时使用基类编排；seam 有意保持抽象时使用最小子类。随后，在相关之处，集成探针验证生产 dshline 对该 seam 的消费。这张表指向生产 dshline 消费、且适合在进程内以确定方式演练的通用 surface；它不是复制的约定，也不宣称覆盖只能由 Host 启动触及的 surface。指针表明确排除 `agents`、`appExit`、`loader`、`cmdlineArgs`、`dshHomePath` 与 `baseUrl`；TUI 自有的 surface 也不是能力行。agent 工厂与宿主平面的启动读取需要正在启动的 Host，仍由 published consumer 车道负责。上游对已命名 seam 的变更读起来是 `sessionQuery contract changed`，而不只是笼统的 `pnpm typecheck failed`；尚未进入这张表的 seam，仍以 `pnpm typecheck`/`pnpm test` 作为后备。`tools/capability-probes.mjs` 仍是一张指针表，不是约定的第二份拷贝：它只指出哪个既有或新建的测试提供证据，因此扩大这一覆盖意味着往那张表里加一行（或在 `packages/dshline/tests/capability/` 下新增一个小探针），而绝不是让这个模块自己学会该 seam 的形状。
 
 `userQuestions` 是这套雷达第一次证明它能发现真实的破坏：Harness 的 `ctx.userQuestions` 注册方式发生了变化，`packages/dshline/src/questions.ts` 一度用一个小的运行时判断把两种形态桥接起来。那个桥接属于债务而不是范式——它早于"一次只支持一代"的规则——随后的那次采纳已经删除了它：该模块现在直接注册在按作用域分层的 `user-questions/request` 瀑布上。不应再写出同类的新桥接。迁移是移除旧调用，而不是同时保留两者。

--- a/packages/dshline/tests/capability/agent-default-model.probe.spec.ts
+++ b/packages/dshline/tests/capability/agent-default-model.probe.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Capability probe: `ctx.agentDefaultModel`, against the real service.
+ *
+ * The production selection path reads `currentSelection()` when a window opens
+ * and calls `saveSelection()` after `/model` or `/reasoning` changes a default.
+ * This probe uses the concrete Harness `AgentDefaultModelConfig` runtime over
+ * the real abstract `SettingsProvider` contract when persistence is available;
+ * the settings subclass supplies only an in-memory document. It therefore
+ * proves the service's composition fallback, the consumed selection shape, and
+ * the optional settings write, not any deployment's filesystem persistence.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import AgentDefaultModelConfig from '@deepseek-ai/dsh-agent-default-model'
+import type { ModelSelection } from '@deepseek-ai/dsh-agent'
+import { ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import SettingsProvider from '@deepseek-ai/dsh-settings'
+import { describe, expect, it } from 'vitest'
+
+/** In-memory persistence used only to expose the real settings-backed path. */
+class MemorySettings extends SettingsProvider {
+  static document: Record<string, unknown> = {}
+  readonly writable = true
+
+  protected async load(): Promise<Record<string, unknown>> {
+    return structuredClone(MemorySettings.document)
+  }
+
+  protected async persist(namespace: string, section: Record<string, unknown>): Promise<void> {
+    MemorySettings.document = { ...MemorySettings.document, [namespace]: structuredClone(section) }
+  }
+}
+
+/** Mount the concrete service with or without the optional settings seam. */
+async function mounted(withSettings: boolean): Promise<Context> {
+  const ctx = new Context()
+  if (withSettings) {
+    MemorySettings.document = {}
+    await ctx.plugin(MemorySettings)
+  }
+  await ctx.plugin(AgentDefaultModelConfig, { provider: 'probe-provider', model: 'probe-model' })
+  await new Promise<void>(resolve => setImmediate(resolve))
+  return ctx
+}
+
+const SAVED: ModelSelection = {
+  provider: 'saved-provider',
+  model: 'saved-model',
+  reasoningEffort: ReasoningEffortId('high'),
+}
+
+describe('capability: agentDefaultModel', () => {
+  it('publishes the composition selection without a settings provider', async () => {
+    const ctx = await mounted(false)
+    try {
+      expect(ctx.agentDefaultModel.currentSelection()).toEqual({
+        provider: 'probe-provider',
+        model: 'probe-model',
+      })
+      await expect(ctx.agentDefaultModel.saveSelection(SAVED)).resolves.toBeUndefined()
+      // Without settings the composition entry remains the source of truth.
+      expect(ctx.agentDefaultModel.currentSelection()).toEqual({
+        provider: 'probe-provider',
+        model: 'probe-model',
+      })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('reads a saved selection through the real SettingsProvider path', async () => {
+    const ctx = await mounted(true)
+    try {
+      await ctx.agentDefaultModel.saveSelection(SAVED)
+      expect(ctx.agentDefaultModel.currentSelection()).toEqual(SAVED)
+      expect(MemorySettings.document['agent-default-model']).toEqual({
+        provider: 'saved-provider',
+        model: 'saved-model',
+        reasoningEffort: 'high',
+      })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+})

--- a/packages/dshline/tests/capability/agent-presets.probe.spec.ts
+++ b/packages/dshline/tests/capability/agent-presets.probe.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Capability probe: `ctx.agentPresets`, against the real roster.
+ *
+ * dshline consumes this seam through the structural `AgentPresetsSeam` view in
+ * `plugins/harness.ts`, deliberately WITHOUT importing the service's values —
+ * a profile that mounts no roster must still start. That choice buys
+ * degradation at the cost of a drift risk: nothing in the production build
+ * compares the structural view with the real `@deepseek-ai/dsh-agent-presets`
+ * class. This probe is where that comparison lives, in both directions:
+ *
+ * - the real `AgentPresets` service is mounted over a real temp root with a
+ *   real composition file, and assigned to the structural view, so an
+ *   upstream shape change fails this file at compile time;
+ * - the roster reads `/plugins` browses with (`list`, `resolve`, `read`,
+ *   `defaultId`, `authorable`) are driven through the real discovery over
+ *   real directories;
+ * - `copy()` authors a real locally authored preset, the one authoring write
+ *   `/plugins` offers;
+ * - the `agentPreset` Session projection the roster registers folds the
+ *   creation-header case `sessionFacts()` reads through the real projection
+ *   registry.
+ *
+ * `mount`/`recompose`/`select` need a full agent composition to evaluate, so
+ * they are not exercised here; their shapes are held by the structural
+ * assignment above, and their behavior is upstream's own test territory.
+ * @module
+ */
+
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { afterAll, describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import { Session, SessionId, SESSION_FORMAT_VERSION } from '@deepseek-ai/dsh-session'
+import SessionProjectionRegistry from '@deepseek-ai/dsh-session-projection'
+import AgentPresets from '@deepseek-ai/dsh-agent-presets'
+import { sessionFacts } from '../../src/plugins/harness.ts'
+import type { AgentPresetsSeam } from '../../src/plugins/harness.ts'
+
+/** Temp roots this file creates; removed after the run. */
+const homes: string[] = []
+
+afterAll(async () => {
+  await Promise.all(homes.map(async home => rm(home, { recursive: true, force: true })))
+})
+
+/** An empty agent-plane composition: valid YAML, registers nothing. */
+const COMPOSITION = '[]\n'
+
+/**
+ * Lay out one preset under a root, the way a deployment ships or a user authors one.
+ * @param root - the preset root directory.
+ * @param id - the preset id; also its directory name.
+ * @returns the root path.
+ */
+async function presetRoot(root: string, id: string): Promise<string> {
+  await mkdir(join(root, id), { recursive: true })
+  await writeFile(join(root, id, 'agent.cordis.yml'), COMPOSITION)
+  await writeFile(join(root, id, 'preset.yml'), `name: ${id}\ndescription: probe preset ${id}\n`)
+  return root
+}
+
+/**
+ * Mount the real roster over a real temp root holding one preset.
+ * @returns the context carrying the real service, and the root.
+ */
+async function mounted(): Promise<{ ctx: Context; root: string }> {
+  const home = await mkdtemp(join(tmpdir(), 'dsh-probe-presets-'))
+  homes.push(home)
+  const root = await presetRoot(home, 'shipped')
+  const ctx = new Context()
+  await ctx.plugin(SessionProjectionRegistry)
+  // Injection precondition only: the roster declares `loader` alongside
+  // `sessionProjections`. The roster's discovery and authoring reads touch no
+  // loader surface — the stub exists so cordis applies the real plugin.
+  ctx.provide('loader', {} as never)
+  // The roster resolves a composition's package names against the base URL of
+  // the composition it was loaded by; a bare test context supplies one itself.
+  ctx.baseUrl = `${pathToFileURL(home).href}/`
+  await ctx.plugin(AgentPresets, {
+    default: 'shipped',
+    roots: [{ path: root, trust: 'user' }],
+    includeShippedRoot: false,
+    includeUserRoot: false,
+  })
+  return { ctx, root }
+}
+
+describe('capability: agentPresets', () => {
+  it('satisfies the structural seam view dshline consumes instead of the service', async () => {
+    const { ctx } = await mounted()
+    try {
+      // The compile-time check the production build cannot make for itself:
+      // the real service still satisfies every method and row shape
+      // `plugins/harness.ts` declares. The value is discarded; the
+      // assignability is the assertion.
+      const seam: AgentPresetsSeam = ctx.agentPresets
+      void seam
+      expect(ctx.agentPresets.defaultId).toBe('shipped')
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('discovers a real root and reads one preset\'s composition verbatim', async () => {
+    const { ctx, root } = await mounted()
+    try {
+      const rows = await ctx.agentPresets.list()
+      expect(rows.map(row => [row.id, row.trust, row.name])).toEqual([['shipped', 'user', 'shipped']])
+      expect(rows[0]?.broken).toBeUndefined()
+      expect(rows[0]?.path).toBe(join(root, 'shipped', 'agent.cordis.yml'))
+      const resolved = await ctx.agentPresets.resolve('shipped')
+      expect(resolved.id).toBe('shipped')
+      await expect(ctx.agentPresets.resolve('missing')).rejects.toThrow()
+      // Verbatim composition text — what /plugins' row editor toggles within.
+      await expect(ctx.agentPresets.read('shipped')).resolves.toBe(COMPOSITION)
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('authors a locally authored copy into a writable root', async () => {
+    const { ctx, root } = await mounted()
+    try {
+      expect(ctx.agentPresets.authorable).toBe(true)
+      await ctx.agentPresets.copy('shipped', 'my-copy', 'My Copy')
+      const rows = await ctx.agentPresets.list()
+      expect(rows.find(row => row.id === 'my-copy')).toMatchObject({ trust: 'user', name: 'My Copy' })
+      // The copy starts as the source's whole composition, which /plugins
+      // then edits one row at a time in the copy's own file.
+      await expect(ctx.agentPresets.read('my-copy')).resolves.toBe(COMPOSITION)
+      await expect(readFile(join(root, 'my-copy', 'agent.cordis.yml'), 'utf8')).resolves.toBe(COMPOSITION)
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('registers the agentPreset projection sessionFacts reads', async () => {
+    const { ctx } = await mounted()
+    try {
+      // A session created under a preset, the way the real creation header
+      // records it.
+      const id = SessionId('preset-probe')
+      const session = Session.create(id, undefined, {
+        version: SESSION_FORMAT_VERSION, id, createdAt: 0, cwd: '/ws', isSeeded: false,
+        agentPreset: 'shipped',
+      })
+      expect(sessionFacts(ctx, session)).toEqual({ presetId: 'shipped', started: false })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+})

--- a/packages/dshline/tests/capability/agents.probe.spec.ts
+++ b/packages/dshline/tests/capability/agents.probe.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Capability probe: the process-local `ctx.agents` registry.
+ *
+ * dshline uses the real registry in two places: Work resolves a live local
+ * child with `get(sessionId)`, while session attachment delegates fresh and
+ * resumed transitions to `create()` and `resume()`. This probe exercises the
+ * real service/runtime dispatch, its entered-agent lookup, and the published
+ * `AgentFactory` delegation seam without loading an AgentLoop.
+ *
+ * The factory below is deliberately local: its returned handles and agents do
+ * not prove concrete loop creation, persistence loading, setup, announcement
+ * policy, or lifecycle behavior. Those are owned by the installed provider.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import AgentRegistry, {
+  type Agent,
+  type AgentFactory,
+  type AgentHandle,
+  type CreateAgentOptions,
+  type ResumeAgentOptions,
+} from '@deepseek-ai/dsh-agent'
+import { SessionId } from '@deepseek-ai/dsh-session'
+import { describe, expect, it } from 'vitest'
+
+/** The minimum live shape the registry reads while storing an Agent. */
+function localAgent(ctx: Context, id: SessionId): Agent {
+  const session = { id }
+  return { id, session, ctx } as unknown as Agent
+}
+
+/**
+ * Publish a local handle through the real registry, as an AgentFactory would.
+ * @param ctx - context carrying the real registry.
+ * @param id - shared agent/session identity.
+ * @returns a local handle backed by the registry's real registration path.
+ */
+function localHandle(ctx: Context, id: SessionId): AgentHandle {
+  const agent = localAgent(ctx, id)
+  const detach = ctx.agents.enter(agent, undefined)
+  ctx.agents.announce(agent)
+  return {
+    agent,
+    dispose: async () => { detach() },
+  }
+}
+
+/** Mount the real registry without an agent loop or persistence plugin. */
+async function mounted(): Promise<Context> {
+  const ctx = new Context()
+  await ctx.plugin(AgentRegistry)
+  return ctx
+}
+
+describe('capability: agents', () => {
+  it('returns an entered and announced live Agent by SessionId', async () => {
+    const ctx = await mounted()
+    const id = SessionId('capability-probe-entered')
+    const agent = localAgent(ctx, id)
+    const detach = ctx.agents.enter(agent, undefined)
+    try {
+      expect(ctx.agents.get(id)).toBe(agent)
+      ctx.agents.announce(agent)
+      expect(ctx.agents.get(id)).toBe(agent)
+      detach()
+      expect(ctx.agents.get(id)).toBeUndefined()
+    } finally {
+      detach()
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('delegates create and resume options through the AgentFactory seam', async () => {
+    const ctx = await mounted()
+    const creates: CreateAgentOptions[] = []
+    const resumes: ResumeAgentOptions[] = []
+    const factory: AgentFactory = {
+      createAgent: async (_ownerCtx, options) => {
+        creates.push(options)
+        return localHandle(ctx, options.sessionId)
+      },
+      resume: async (_ownerCtx, options) => {
+        resumes.push(options)
+        return localHandle(ctx, options.resumeSessionId)
+      },
+    }
+    const disposeFactory = ctx.agents.setFactory(factory)
+    const createOptions: CreateAgentOptions = {
+      sessionId: SessionId('capability-probe-created'),
+      meta: { cwd: '/capability-probe' },
+    }
+    const resumeOptions: ResumeAgentOptions = {
+      resumeSessionId: SessionId('capability-probe-resumed'),
+    }
+    try {
+      const created = await ctx.agents.create(createOptions)
+      expect(creates).toEqual([createOptions])
+      expect(created.agent).toBe(ctx.agents.get(createOptions.sessionId))
+      await created.dispose()
+      expect(ctx.agents.get(createOptions.sessionId)).toBeUndefined()
+
+      const resumed = await ctx.agents.resume(resumeOptions)
+      expect(resumes).toEqual([resumeOptions])
+      expect(resumed.agent).toBe(ctx.agents.get(resumeOptions.resumeSessionId))
+      await resumed.dispose()
+      expect(ctx.agents.get(resumeOptions.resumeSessionId)).toBeUndefined()
+    } finally {
+      disposeFactory()
+      await ctx.fiber.dispose()
+    }
+  })
+})

--- a/packages/dshline/tests/capability/approval.probe.spec.ts
+++ b/packages/dshline/tests/capability/approval.probe.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Capability probe: Harness's `approval` seam, against the real service.
+ *
+ * `approval.spec.ts` proves dshline's answerer over a captured `ctx.on`, which
+ * exercises the overlay logic but never the real `@deepseek-ai/dsh-user-approval`
+ * waterfall the listener rides. This probe mounts the real `ApprovalService`
+ * beside a real `SessionStore`, registers dshline's actual
+ * `installApprovalAnswerer`, and asks through the service's own `request()` —
+ * asserting exactly what production depends on:
+ *
+ * - the real waterfall hands dshline's answerer an owned request, and the
+ *   answerer's overlay decision returns as the service's closed outcome, with
+ *   the audit pair appended to the requesting session's durable log;
+ * - a request for a different agent identity this frontend does NOT own falls
+ *   through `next()`, reaching the service's fail-closed `unavailable` — never
+ *   dshline answering for an agent outside its ownership;
+ * - a withdrawn request settles `cancelled` through the real service.
+ * @module
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import SessionStore, { SessionId } from '@deepseek-ai/dsh-session'
+import type { Session } from '@deepseek-ai/dsh-session'
+import ApprovalService from '@deepseek-ai/dsh-user-approval'
+import type { ApprovalOutcome, ApprovalRequest } from '@deepseek-ai/dsh-user-approval'
+import { TuiSlots } from '../../src/slots.ts'
+import type { TuiOverlay } from '../../src/slots.ts'
+import { installApprovalAnswerer } from '../../src/approval.ts'
+
+/** The agent this frontend owns in the probe. */
+const OWNED = SessionId('probe-owned')
+
+/** A distinct identity is all the ownership check requires. */
+function agentOf(id: string, session?: Session): Agent {
+  return session === undefined ? { id: SessionId(id) } as Agent : { id: SessionId(id), session } as Agent
+}
+
+/**
+ * Mount the real approval service and dshline's real answerer.
+ * @returns the pieces a case needs to ask and answer.
+ */
+async function mounted(): Promise<{
+  ctx: Context
+  session: Session
+  presented: TuiOverlay[]
+  ask: (agent: Agent, signal?: AbortSignal) => Promise<ApprovalOutcome>
+}> {
+  const ctx = new Context()
+  await ctx.plugin(TuiSlots)
+  await ctx.plugin(SessionStore)
+  await ctx.plugin(ApprovalService, { policy: 'ask' })
+  const session = ctx.sessions.create(OWNED)
+  // The real service requires an open turn: the audit pair must sit inside
+  // the durable log's commit/replay boundary.
+  session.append('turn/start', { turn: 1 })
+  // Ownership is object identity, exactly as in production: the window's
+  // `owned()` returns the one live agent, so the probe holds one instance too.
+  const owned = agentOf('probe-owned', session)
+  installApprovalAnswerer(ctx, () => owned, () => {})
+  // Capture what the answerer pushes onto the live region; TuiSlots has no
+  // reader for mounted overlays, and the probe needs to answer the prompt.
+  const presented: TuiOverlay[] = []
+  const pushOverlay = ctx.tuiSlots.pushOverlay.bind(ctx.tuiSlots)
+  ctx.tuiSlots.pushOverlay = overlay => {
+    presented.push(overlay)
+    return pushOverlay(overlay)
+  }
+  return {
+    ctx,
+    session,
+    presented,
+    ask: (agent, signal) => ctx.approval.request({
+      agent: agent ?? owned, toolName: 'bash', ...signal === undefined ? {} : { signal },
+    } satisfies ApprovalRequest),
+  }
+}
+
+describe('capability: approval', () => {
+  /** Let the real service's microtask-dispatched waterfall reach the answerer. */
+  async function flush(): Promise<void> {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  it('answers an owned request through the real waterfall and logs the audit pair', async () => {
+    const { ctx, session, presented, ask } = await mounted()
+    try {
+      const pending = ask(undefined)
+      await flush()
+      expect(presented, 'the real service must reach the terminal answerer').toHaveLength(1)
+      presented[0]?.handleKey({ kind: 'key', name: 'enter' })
+      await expect(pending).resolves.toBe('allowed-once')
+      // The service logged the ask and the decision onto the durable log.
+      const logged = session.snapshotEvents().filter(event => event.type.startsWith('approval/'))
+      expect(logged.map(event => event.type)).toEqual(['approval/asked', 'approval/decided'])
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('delegates a request for an agent it does not own, answering nothing', async () => {
+    const { ctx, session, presented, ask } = await mounted()
+    try {
+      // A waterfall with no further answerer is fail-closed `unavailable` for
+      // this different agent identity.
+      await expect(ask(agentOf('probe-child', session))).resolves.toBe('unavailable')
+      await flush()
+      expect(presented).toHaveLength(0)
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('settles a withdrawn request as cancelled through the real service', async () => {
+    const { ctx, presented, ask } = await mounted()
+    try {
+      const signal = new AbortController()
+      const pending = ask(undefined, signal.signal)
+      signal.abort()
+      await expect(pending).resolves.toBe('cancelled')
+      await flush()
+      expect(presented).toHaveLength(0)
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+})

--- a/packages/dshline/tests/capability/attachments.probe.spec.ts
+++ b/packages/dshline/tests/capability/attachments.probe.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Capability probe: `ctx.attachments`, against the base orchestration.
+ *
+ * `image-drafts.spec.ts` and `image-attachment-flow.spec.ts` prove dshline's
+ * drafting logic over hand-typed attachment stores. This probe subclasses the
+ * real abstract `AttachmentStore` from `@deepseek-ai/dsh-attachment`, so its
+ * concrete `saveImages()` base implementation validates a batch before calling
+ * the local backend's `saveImage()` method. The local subclass supplies the
+ * deployment limits, media-type policy, validation, and storage; those are not
+ * attributed to the abstract base or to a production deployment.
+ *
+ * The assertions cover the base-owned ordered references, count/aggregate
+ * admission, caller-correctable admission errors, and no writes after a failed
+ * validation—the shapes the production `/image` path consumes.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import AttachmentStore, { AttachmentId, isImageAdmissionError } from '@deepseek-ai/dsh-attachment'
+import type {
+  ImageAttachmentLimits,
+  ImageAttachmentRef,
+  ImageMediaType,
+  SaveImageAttachment,
+  StoredImageAttachment,
+} from '@deepseek-ai/dsh-attachment'
+import { describe, expect, it } from 'vitest'
+
+/** Limits this probe publishes through its local backend; dshline reads the same shape. */
+const LIMITS: ImageAttachmentLimits = {
+  maxImageBytes: 1 << 20,
+  maxImagesPerMessage: 2,
+  maxMessageImageBytes: 2 << 20,
+  maxImagePixels: 1 << 22,
+  maxImageDimension: 8192,
+  mediaTypes: ['image/png', 'image/jpeg'],
+}
+
+/** Minimal in-memory store satisfying the real abstract contract. */
+class MemoryAttachmentStore extends AttachmentStore {
+  /** Members actually persisted, in commit order. */
+  readonly stored: SaveImageAttachment[] = []
+  readonly #limits: ImageAttachmentLimits
+
+  constructor(ctx: Context, limits: ImageAttachmentLimits = LIMITS) {
+    super(ctx)
+    this.#limits = limits
+  }
+
+  override get imageLimits(): ImageAttachmentLimits {
+    return this.#limits
+  }
+
+  override async validateImage(input: SaveImageAttachment): Promise<void> {
+    if (!LIMITS.mediaTypes.includes(input.mediaType)) {
+      throw Object.assign(new Error(`unsupported ${input.mediaType}`), { code: 'UNSUPPORTED_IMAGE_TYPE' })
+    }
+    if (input.data.byteLength > LIMITS.maxImageBytes) {
+      throw Object.assign(new Error('single image too large'), { code: 'IMAGE_TOO_LARGE' })
+    }
+  }
+
+  override async saveImage(input: SaveImageAttachment): Promise<ImageAttachmentRef> {
+    this.stored.push(input)
+    return {
+      attachmentId: AttachmentId(`probe-${this.stored.length}`),
+      mediaType: input.mediaType,
+      bytes: input.data.byteLength,
+      width: 1,
+      height: 1,
+      ...input.name === undefined ? {} : { name: input.name },
+    }
+  }
+
+  override async readImage(ref: ImageAttachmentRef): Promise<StoredImageAttachment> {
+    throw new Error(`capability probe: nothing to read back for ${String(ref.attachmentId)}`)
+  }
+}
+
+/** One encoded input for the store.
+ * @param mediaType - declared type.
+ * @param name - optional display name.
+ * @param bytes - encoded byte count for admission cases.
+ * @returns the input. */
+function input(mediaType: ImageMediaType, name?: string, bytes = 3): SaveImageAttachment {
+  return { data: new Uint8Array(bytes), mediaType, ...name === undefined ? {} : { name } }
+}
+
+describe('capability: attachments', () => {
+  it('publishes the limits the image drafting policy reads', async () => {
+    const store = new MemoryAttachmentStore(new Context())
+    expect(store.imageLimits.maxImagesPerMessage).toBe(2)
+    expect(store.imageLimits.mediaTypes).toEqual(['image/png', 'image/jpeg'])
+    expect(store.imageLimits.maxImageBytes).toBeGreaterThan(0)
+    expect(store.imageLimits.maxMessageImageBytes).toBeGreaterThan(0)
+  })
+
+  it('commits an ordered batch and returns references in exact input order', async () => {
+    const store = new MemoryAttachmentStore(new Context())
+    const refs = await store.saveImages([input('image/png', 'first'), input('image/jpeg', 'second')])
+    expect(refs.map(ref => [ref.mediaType, ref.name])).toEqual([
+      ['image/png', 'first'],
+      ['image/jpeg', 'second'],
+    ])
+    expect(store.stored).toHaveLength(2)
+  })
+
+  it('refuses a batch over the published count limit as a caller-correctable admission error', async () => {
+    const store = new MemoryAttachmentStore(new Context())
+    const error = await store.saveImages([
+      input('image/png'), input('image/png'), input('image/png'),
+    ]).then(() => undefined, (thrown: unknown) => thrown)
+    expect(isImageAdmissionError(error)).toBe(true)
+    expect((error as { code: string }).code).toBe('TOO_MANY_IMAGES')
+    // Validation failures start no writes.
+    expect(store.stored).toHaveLength(0)
+  })
+
+  it('refuses a batch over the aggregate byte limit before local storage', async () => {
+    const store = new MemoryAttachmentStore(new Context(), {
+      ...LIMITS,
+      maxImagesPerMessage: 3,
+      maxMessageImageBytes: 5,
+    })
+    const error = await store.saveImages([input('image/png', undefined, 3), input('image/png', undefined, 3)])
+      .then(() => undefined, (thrown: unknown) => thrown)
+    expect(isImageAdmissionError(error)).toBe(true)
+    expect((error as { code: string }).code).toBe('IMAGES_TOO_LARGE')
+    expect(store.stored).toHaveLength(0)
+  })
+
+  it('refuses a type the local backend does not admit, storing nothing', async () => {
+    const store = new MemoryAttachmentStore(new Context())
+    const error = await store.saveImages([input('image/gif')])
+      .then(() => undefined, (thrown: unknown) => thrown)
+    expect(isImageAdmissionError(error)).toBe(true)
+    expect((error as { code: string }).code).toBe('UNSUPPORTED_IMAGE_TYPE')
+    expect(store.stored).toHaveLength(0)
+  })
+})

--- a/packages/dshline/tests/capability/authorization.probe.spec.ts
+++ b/packages/dshline/tests/capability/authorization.probe.spec.ts
@@ -2,39 +2,29 @@
  * Capability probe: Harness's `authorization` seam, against the real service.
  *
  * This is the compatibility evidence `tools/capability-probes.mjs` names for
- * the `authorization` seam, and it earns a probe of its own now rather than
- * before because dshline's bundle patch COMPOSES this package. A row dshline
- * inserts is a row whose failure to mount is dshline's boot failing, so the
- * shape it is mounted by — a default-exported `Service` class injecting
- * `credentials` — is now part of this frontend's contract with upstream and
- * not only part of `/connect`'s.
+ * the `authorization` seam. The concrete `AuthorizationService` is mounted
+ * over a local in-memory `CredentialProvider` subclass that supplies the
+ * credential record surface; it does not prove production provider storage
+ * semantics.
  *
- * The real `AuthorizationService` is mounted over a real abstract
- * `CredentialProvider` subclass, never a dshline-shaped fake, and everything
- * asserted is something a `/connect` decision is built on:
+ * The probe checks the deterministic service contract dshline relies on:
  *
- * 1. the package mounts by its published default export and provides
- *    `ctx.authorization` — the composition dshline's own patch performs;
- * 2. `list()` publishes the label, methods, and `inFlight` that
- *    `ConnectSignInRow` is assembled from, and its key is the `<scope>/<id>`
- *    string {@link piAiSignInRoute} reads to find the route a sign-in
- *    authenticates;
- * 3. an attempt's notices and prompts reach the CALLER's interaction, which is
- *    what lets `authorize.ts` put a sign-in URL in scrollback and a question in
- *    an overlay;
- * 4. `authorized` is reported only after a record was committed during the
- *    attempt — so the transcript row saying "signed in" is never ahead of the
- *    credential store;
- * 5. a withdrawn attempt settles `cancelled` rather than throwing, which is the
- *    whole basis of closing `/connect` mid-login.
+ * 1. the published service mounts and provides `ctx.authorization`;
+ * 2. `list()` publishes flow labels, methods, in-flight state, and the
+ *    `<scope>/<id>` key that the adapter's route-key helper consumes;
+ * 3. `begin()` routes notices/prompts through its supplied interaction and
+ *    reports authorization only after the local record was committed;
+ * 4. a withdrawn attempt settles `cancelled` rather than throwing.
  *
- * The seam's own internals are upstream's contract and upstream's tests. What
- * is under test here is dshline's dependence on them.
+ * The full bundle patch and browser `/connect` presentation are not exercised
+ * here. The useful evidence is AuthorizationService orchestration layered over
+ * a minimal local credential fixture.
  */
 
 import { describe, expect, it } from 'vitest'
-import { Context, Service } from '@deepseek-ai/cordis'
+import { Context } from '@deepseek-ai/cordis'
 import AuthorizationService from '@deepseek-ai/dsh-authorization'
+import CredentialProvider from '@deepseek-ai/dsh-credentials'
 import type { AuthorizationNotice, AuthorizationPrompt } from '@deepseek-ai/dsh-authorization'
 import { credentialKey } from '@deepseek-ai/dsh-credentials'
 import type {
@@ -49,66 +39,54 @@ import type {
 import { piAiSignInRoute } from '../../src/connect/pi-ai.ts'
 import type { ConnectProviderRow } from '../../src/connect/model.ts'
 
-/**
- * A real `CredentialProvider` over a Map.
- *
- * The abstract class from `@deepseek-ai/dsh-credentials` is subclassed rather
- * than replaced, so the seam's commit confirmation runs against the real
- * `describeRecord`/`modifyRecord` contract and the real
- * `credentials/record-updated` event it watches for.
- */
-class MemoryCredentials extends Service {
+/** A local credential record service; AuthorizationService owns the real orchestration. */
+class MemoryCredentials extends CredentialProvider {
   /** Records this provider holds, by key. */
   private readonly records = new Map<string, CredentialRecord>()
 
-  constructor(ctx: Context) {
-    super(ctx, 'credentials')
-  }
-
-  async resolve(_ref: CredentialRef): Promise<ResolvedCredential | undefined> {
+  override async resolve(_ref: CredentialRef): Promise<ResolvedCredential | undefined> {
     return undefined
   }
 
-  async describe(_ref: CredentialRef): Promise<CredentialInfo> {
+  override async describe(_ref: CredentialRef): Promise<CredentialInfo> {
     return { configured: false, writable: true }
   }
 
-  async set(_ref: CredentialRef, _value: string): Promise<void> {}
+  override async set(_ref: CredentialRef, _value: string): Promise<void> {}
 
-  async unset(_ref: CredentialRef): Promise<void> {}
+  override async unset(_ref: CredentialRef): Promise<void> {}
 
-  async readRecord(key: CredentialKey): Promise<CredentialRecord | undefined> {
+  override async readRecord(key: CredentialKey): Promise<CredentialRecord | undefined> {
     return this.records.get(key)
   }
 
-  async describeRecord(key: CredentialKey): Promise<CredentialRecordInfo> {
+  override async describeRecord(key: CredentialKey): Promise<CredentialRecordInfo> {
     const held = this.records.get(key)
     return held === undefined
       ? { configured: false, writable: true }
       : { configured: true, kind: held.kind, writable: true }
   }
 
-  async listRecords(): Promise<readonly CredentialRecordEntry[]> {
+  override async listRecords(): Promise<readonly CredentialRecordEntry[]> {
     return [...this.records].map(([key, record]) => ({ key: key as CredentialKey, kind: record.kind }))
   }
 
-  async modifyRecord(
+  override async modifyRecord(
     key: CredentialKey,
     mutate: (current: CredentialRecord | undefined) => Promise<CredentialRecord | undefined>,
   ): Promise<CredentialRecord | undefined> {
     const next = await mutate(this.records.get(key))
     if (next === undefined) this.records.delete(key)
     else this.records.set(key, next)
-    // The event the seam watches to confirm a commit happened during the
-    // attempt; without it a re-authorization could pass a stale record off as
-    // fresh, which is the failure `NOT_COMMITTED` exists to prevent.
-    this.ctx.emit('credentials/record-updated', key)
+    // The real base-class notifier supplies the event the authorization
+    // orchestration watches after a record commit.
+    this.notifyRecordUpdated(key)
     return next
   }
 
-  async deleteRecord(key: CredentialKey): Promise<void> {
+  override async deleteRecord(key: CredentialKey): Promise<void> {
     this.records.delete(key)
-    this.ctx.emit('credentials/record-updated', key)
+    this.notifyRecordUpdated(key)
   }
 }
 
@@ -131,8 +109,8 @@ async function harness(): Promise<Context> {
 describe('capability probe: the authorization seam', () => {
   it('mounts by its default export and provides ctx.authorization', async () => {
     const ctx = await harness()
-    // The row dshline's bundle patch inserts. A default export that stopped
-    // being a mountable Service would fail here rather than at a user's boot.
+    // The composition dependency publication relies on this being mountable. A
+    // default export that stopped being a Service would fail here early.
     expect(ctx.get('authorization')).toBeDefined()
   })
 
@@ -147,8 +125,8 @@ describe('capability probe: the authorization seam', () => {
     const [entry] = ctx.authorization.list()
     expect(entry?.label).toBe('ChatGPT (Codex)')
     expect(entry?.methods.map(method => method.id)).toEqual(['oauth', 'api-key'])
-    // `inFlight` is what lets a browser render the action unavailable rather
-    // than discovering ALREADY_IN_FLIGHT through an error.
+    // `inFlight` lets a consumer disable the action before it reaches the
+    // service's ALREADY_IN_FLIGHT error.
     expect(entry?.inFlight).toBe(false)
   })
 
@@ -188,8 +166,8 @@ describe('capability probe: the authorization seam', () => {
       label: 'OpenAI',
       methods: [{ id: 'oauth', label: 'Sign in' }],
       run: async session => {
-        // The two shapes `authorize.ts` splits between scrollback and an
-        // overlay: a one-way notice carrying a page and a code, and a question.
+        // Exercise the two interaction payload shapes a consumer may route to
+        // a transcript notice or overlay: a page/code notice and a question.
         session.notify({ message: 'Continue in your browser', url: 'https://auth.example/go', code: 'ABCD-1234' })
         const typed = await session.prompt({ kind: 'text', message: 'Paste the code' })
         await ctx.credentials.modifyRecord(OPENAI, async () => ({ kind: 'grant', payload: { token: typed } }))
@@ -238,8 +216,8 @@ describe('capability probe: the authorization seam', () => {
       label: 'OpenAI',
       methods: [{ id: 'oauth', label: 'Sign in' }],
       run: async session => {
-        // A login waiting on a browser callback with no question on screen —
-        // the exact shape closing `/connect` has to be able to take down.
+        // A flow waiting with no question on screen: cancellation must still
+        // reach its signal listener.
         await new Promise<void>((_resolve, reject) => {
           session.signal.addEventListener('abort', () => { reject(new Error('withdrawn')) }, { once: true })
         })
@@ -252,8 +230,8 @@ describe('capability probe: the authorization seam', () => {
       interaction: { notify: () => {}, prompt: async () => '' },
     })
     withdrawal.abort()
-    // Not a throw: `/connect` reports a withdrawn sign-in as a withdrawal, and
-    // would have to invent that distinction if the seam raised here.
+    // Not a throw: the service reports a withdrawn sign-in as cancellation,
+    // which a consumer can present distinctly from failure.
     expect(await running).toEqual({ status: 'cancelled' })
   })
 })

--- a/packages/dshline/tests/capability/compaction.probe.spec.ts
+++ b/packages/dshline/tests/capability/compaction.probe.spec.ts
@@ -1,55 +1,23 @@
 /**
- * Capability probe: Harness compaction, against the real seam.
+ * Capability probe: Harness compaction events, against the real event contract.
  *
- * The compatibility evidence `tools/capability-probes.mjs` names for the
- * `compaction` seam. dshline neither implements compaction nor calls it: it
- * PROJECTS the durable `compaction/*` events and dispatches the registered
- * `/compact` command. So the probe mounts a real `CompactionEngine` subclass —
- * the real abstract class, over a real `SessionStore` — appends the events a
- * backend appends, and asserts dshline's presentation reads them.
- *
- * A real backend (`dsh-compaction-basic`) is deliberately not mounted: it needs
- * an LLM route and an idle agent to summarize with, and none of that is part of
- * the contract dshline consumes. What dshline depends on is the event shape and
- * the command registration, which is what is exercised here.
+ * dshline neither implements compaction nor calls `ctx.compaction`: it projects
+ * durable `compaction/*` events, while the `/compact` command owns dispatch
+ * through `ctx.commands`. This probe uses a real `Session` and the package's
+ * event declarations, appends replacement-shaped records, and asserts the
+ * dshline presentation fold. The local event builder is evidence for the
+ * consumed event shape, not a concrete compaction backend or command run.
  */
 
 import { describe, expect, it } from 'vitest'
 import { Context } from '@deepseek-ai/cordis'
 import SessionStore from '@deepseek-ai/dsh-session'
 import type { Session, SessionSeq } from '@deepseek-ai/dsh-session'
-import { CompactionEngine, CompactionId } from '@deepseek-ai/dsh-compaction'
-import type { CompactionResult } from '@deepseek-ai/dsh-compaction'
+import { CommandId } from '@deepseek-ai/dsh-commands/brand'
+import { CompactionId } from '@deepseek-ai/dsh-compaction'
+import type {} from '@deepseek-ai/dsh-compaction'
 import { stripAnsi } from '@dshline/renderer'
 import { compactionNote } from '../../src/context/compaction.ts'
-
-/** A real subclass of the real abstract service, appending real events. */
-class ProbeCompaction extends CompactionEngine {
-  /**
-   * Automatic policy is not exercised here.
-   * @returns null: nothing to compact.
-   */
-  async compactIfNeeded(): Promise<CompactionResult | null> {
-    return null
-  }
-
-  /**
-   * Explicit compaction is not exercised here.
-   * @returns null: nothing to compact.
-   */
-  async compactNow(): Promise<CompactionResult | null> {
-    return null
-  }
-
-  /**
-   * Range compaction is not exercised here: dshline deliberately exposes no
-   * range-selection control (observation and control are separate contracts).
-   * @throws always.
-   */
-  async compactRegion(): Promise<CompactionResult> {
-    throw new Error('not exercised')
-  }
-}
 
 /** Append the exact event trio a manual or automatic compaction commits. */
 function compact(session: Session, options: { manual: boolean }): {
@@ -58,7 +26,7 @@ function compact(session: Session, options: { manual: boolean }): {
   readonly endSeq: SessionSeq
 } {
   const compactionId = CompactionId('probe-1')
-  const owner = options.manual ? { sourceCommandId: 'cmd-1' as never } : {}
+  const owner = options.manual ? { sourceCommandId: CommandId('cmd-1') } : {}
   const first = session.append('user/message', {
     id: 'm-1', role: 'user', content: [{ type: 'text', text: 'a'.repeat(200) }], source: { kind: 'user' },
   } as never, { surfaceOp: 'append' })
@@ -87,24 +55,14 @@ function compact(session: Session, options: { manual: boolean }): {
   return { startSeq: start.seq, summarySeq: summary.seq, endSeq: end.seq }
 }
 
-/** Mount the real store and a real engine subclass. */
+/** Mount the real session store used by the event fold. */
 async function harness(): Promise<{ ctx: Context; session: Session }> {
   const ctx = new Context()
   await ctx.plugin(SessionStore)
-  await ctx.plugin(ProbeCompaction)
   return { ctx, session: ctx.sessions.create() }
 }
 
 describe('capability: compaction', () => {
-  it('publishes the abstract service under the generic name dshline never calls', async () => {
-    const { ctx } = await harness()
-    // Present, and deliberately unused: dshline dispatches `/compact` through
-    // `ctx.commands` so the command owns validation, the idle lock, the
-    // lifecycle, and persistence. The seam is asserted to exist only so the
-    // probe fails loudly if the contract this decision rests on moves.
-    expect(ctx.get('compaction')).toBeInstanceOf(CompactionEngine)
-  })
-
   it('presents a manual compaction from its summary event, not from command prose', async () => {
     const { session } = await harness()
     const seqs = compact(session, { manual: true })
@@ -148,7 +106,7 @@ describe('capability: compaction', () => {
     // the backend's own classified reason.
     const manual = session.append('compaction/end', {
       compactionId: CompactionId('probe-3'),
-      sourceCommandId: 'cmd-9' as never,
+      sourceCommandId: CommandId('cmd-9'),
       turn: null,
       error: 'summary was not smaller',
     })

--- a/packages/dshline/tests/capability/credentials.probe.spec.ts
+++ b/packages/dshline/tests/capability/credentials.probe.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * Capability probe: `ctx.credentials`, against the abstract contract.
+ *
+ * `CredentialProvider` is intentionally abstract: a deployment supplies the
+ * storage and policy, while dshline consumes the reference/record views and
+ * notification shapes. This probe mounts the real abstract base with a local
+ * in-memory implementation and checks Cordis mounting plus the exact calls
+ * production makes. It does not claim evidence for how a production backend
+ * stores, deletes, or derives `configured`.
+ *
+ * The authorization probe independently exercises AuthorizationService's record
+ * orchestration over its own local credential fixture. Together they cover the
+ * seam and dshline's calls without pretending the fixture is a backend.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import CredentialProvider, { credentialKey } from '@deepseek-ai/dsh-credentials'
+import type { CredentialInfo, CredentialKey, CredentialRecord, CredentialRecordEntry, CredentialRecordInfo, CredentialRef, ResolvedCredential } from '@deepseek-ai/dsh-credentials'
+import { describe, expect, it } from 'vitest'
+
+/** Minimal in-memory provider satisfying the real abstract contract, nothing more. */
+class MemoryCredentialProvider extends CredentialProvider {
+  // TS-private, not `#`-private: cordis serves consumers through a traced
+  // proxy whose `this` carries no private-field brand.
+  /** Values behind environment-shaped references, by reference name. */
+  private readonly refs = new Map<string, string>()
+  /** Plugin-owned records, by `<scope>/<id>` key. */
+  private readonly records = new Map<string, CredentialRecord>()
+
+  override async resolve(ref: CredentialRef): Promise<ResolvedCredential | undefined> {
+    const value = this.refs.get(ref)
+    return value === undefined || value === '' ? undefined : { value, source: 'provider-store' }
+  }
+
+  override async describe(ref: CredentialRef): Promise<CredentialInfo> {
+    const value = this.refs.get(ref)
+    return {
+      configured: value !== undefined && value !== '',
+      source: 'provider-store',
+      writable: true,
+    }
+  }
+
+  override async set(ref: CredentialRef, value: string): Promise<void> {
+    this.refs.set(ref, value)
+  }
+
+  override async unset(ref: CredentialRef): Promise<void> {
+    this.refs.delete(ref)
+  }
+
+  override async readRecord(key: CredentialKey): Promise<CredentialRecord | undefined> {
+    return this.records.get(key)
+  }
+
+  override async describeRecord(key: CredentialKey): Promise<CredentialRecordInfo> {
+    return { configured: this.records.has(key), kind: 'grant', writable: true }
+  }
+
+  override async listRecords(): Promise<readonly CredentialRecordEntry[]> {
+    return [...this.records.keys()].map(key => ({ key, kind: 'grant' as const }))
+  }
+
+  override async modifyRecord(
+    key: CredentialKey,
+    mutate: (current: CredentialRecord | undefined) => Promise<CredentialRecord | undefined>,
+  ): Promise<CredentialRecord | undefined> {
+    const next = await mutate(this.records.get(key))
+    if (next !== undefined) this.records.set(key, next)
+    return next ?? this.records.get(key)
+  }
+
+  override async deleteRecord(key: CredentialKey): Promise<void> {
+    this.records.delete(key)
+  }
+}
+
+/** The one reference the probe's route names, in the env-shaped vocabulary. */
+const REF = 'PROBE_API_KEY'
+
+/** The record address shape authorization entries hand Connect. */
+const OPENAI = credentialKey('llm-pi-ai', 'openai')
+
+/** Mount the real provider base as `ctx.credentials`. */
+async function mounted(): Promise<Context> {
+  const ctx = new Context()
+  await ctx.plugin(MemoryCredentialProvider)
+  return ctx
+}
+
+describe('capability: credentials', () => {
+  it('describes a reference as configured, sourced, and writable — never a value', async () => {
+    const ctx = await mounted()
+    try {
+      const before = await ctx.credentials.describe(REF)
+      expect(before.configured).toBe(false)
+      await ctx.credentials.set(REF, 'probe-secret')
+      const after = await ctx.credentials.describe(REF)
+      expect(after).toEqual({ configured: true, source: 'provider-store', writable: true })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('forgets a reference through unset, which Connect reports as sign-out', async () => {
+    const ctx = await mounted()
+    try {
+      await ctx.credentials.set(REF, 'probe-secret')
+      await ctx.credentials.unset(REF)
+      expect((await ctx.credentials.describe(REF)).configured).toBe(false)
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('describes a record by its scoped key and deletes an absent one as a no-op', async () => {
+    const ctx = await mounted()
+    try {
+      expect((await ctx.credentials.describeRecord(OPENAI)).configured).toBe(false)
+      await ctx.credentials.modifyRecord(OPENAI, async () => ({ kind: 'grant', payload: { token: 't' } }))
+      expect((await ctx.credentials.describeRecord(OPENAI)).configured).toBe(true)
+      await ctx.credentials.deleteRecord(OPENAI)
+      expect((await ctx.credentials.describeRecord(OPENAI)).configured).toBe(false)
+      // A record already gone must not fail the forget action.
+      await expect(ctx.credentials.deleteRecord(OPENAI)).resolves.toBeUndefined()
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+})

--- a/packages/dshline/tests/capability/fs.probe.spec.ts
+++ b/packages/dshline/tests/capability/fs.probe.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Capability probe: `ctx.fs`, against the abstract contract and dshline use.
+ *
+ * dshline reads exactly two operations off the active filesystem:
+ * `resolve(path, { cwd, signal })` to turn a draft into a stable target, and
+ * `readBytes(target, signal, maxBytes)` for the bounded read
+ * `readImageDrafts` performs. `image-drafts.spec.ts` proves dshline's own
+ * guard logic over hand-typed objects; this probe drives that same function
+ * through the real abstract `FileSystem` base from `@deepseek-ai/dsh-fs`.
+ * The in-memory subclass supplies resolution and byte bounding itself, so the
+ * evidence is the abstract contract plus dshline passing the expected cwd,
+ * signal, and bound—not a production filesystem implementation's policy.
+ *
+ * Everything else the abstract class declares is refused, which documents
+ * that the drafting path consumes nothing more of the seam.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import FileSystem, { FsTargetKey } from '@deepseek-ai/dsh-fs'
+import type { FsDirEntry, FsEditRequest, FsInfo, FsTarget, FsWriteIntent, FsWriteOutcome } from '@deepseek-ai/dsh-fs'
+import { describe, expect, it } from 'vitest'
+import { readImageDrafts } from '../../src/image-drafts.ts'
+import type { ImageDraft } from '../../src/image-drafts.ts'
+
+/** One stored file, bytes keyed by display path. */
+const FILES: ReadonlyMap<string, Uint8Array> = new Map([
+  ['/ws/pictures/probe.png', new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4])],
+])
+
+/** Minimal in-memory backend satisfying the real abstract contract. */
+class MemoryFileSystem extends FileSystem {
+  override async resolve(path: string, opts?: { cwd?: string; signal?: AbortSignal }): Promise<FsTarget> {
+    const absolute = path.startsWith('/') ? path : `${opts?.cwd ?? ''}/${path}`
+    return { targetKey: FsTargetKey(absolute), displayPath: absolute }
+  }
+
+  override processPath(target: FsTarget): string {
+    return target.displayPath
+  }
+
+  override fileUrl(target: FsTarget): string {
+    return `file://${target.displayPath}`
+  }
+
+  override async readBytes(target: FsTarget, signal: AbortSignal | undefined, maxBytes: number): Promise<Uint8Array> {
+    signal?.throwIfAborted()
+    const data = FILES.get(target.displayPath)
+    if (data === undefined) throw new Error(`capability probe: nothing stored at ${target.displayPath}`)
+    if (data.byteLength > maxBytes) throw new Error('capability probe: read exceeded its bound')
+    return data
+  }
+
+  override contains(): never {
+    throw new Error('capability probe: the drafting path consumes no containment check')
+  }
+
+  override async stat(): Promise<FsInfo | undefined> {
+    throw new Error('capability probe: the drafting path consumes no stat')
+  }
+
+  override async lstat(): Promise<never> {
+    throw new Error('capability probe: the drafting path consumes no lstat')
+  }
+
+  override async readText(): Promise<never> {
+    throw new Error('capability probe: the drafting path consumes no text read')
+  }
+
+  override async streamText(): Promise<AsyncIterable<never>> {
+    throw new Error('capability probe: the drafting path consumes no text stream')
+  }
+
+  override async listDir(): Promise<FsDirEntry[]> {
+    throw new Error('capability probe: the drafting path consumes no listing')
+  }
+
+  override async writeText(_target: FsTarget, _content: string, _expected?: FsWriteIntent): Promise<FsWriteOutcome> {
+    throw new Error('capability probe: the drafting path never writes')
+  }
+
+  override async editText(_target: FsTarget, _edit: FsEditRequest): Promise<never> {
+    throw new Error('capability probe: the drafting path never edits')
+  }
+}
+
+describe('capability: fs', () => {
+  it('passes cwd and a read bound through the real FileSystem contract', async () => {
+    const drafts: readonly ImageDraft[] = [
+      { path: '/ws/pictures/probe.png', mediaType: 'image/png', name: 'probe.png' },
+    ]
+    const inputs = await readImageDrafts(drafts, new MemoryFileSystem(new Context()), '/ws', 1 << 20)
+    expect(inputs).toEqual([
+      { data: FILES.get('/ws/pictures/probe.png'), mediaType: 'image/png', name: 'probe.png' },
+    ])
+  })
+
+  it('reads a relative draft against the session workspace', async () => {
+    const drafts: readonly ImageDraft[] = [
+      { path: 'pictures/probe.png', mediaType: 'image/png', name: 'probe.png' },
+    ]
+    const inputs = await readImageDrafts(drafts, new MemoryFileSystem(new Context()), '/ws', 1 << 20)
+    expect(inputs).toHaveLength(1)
+  })
+})

--- a/packages/dshline/tests/capability/jobs.probe.spec.ts
+++ b/packages/dshline/tests/capability/jobs.probe.spec.ts
@@ -9,11 +9,11 @@
  * change fails this file at compile time, by capability name, instead of only
  * surfacing as an unrelated typecheck error somewhere else in the graph.
  *
- * The fake registry implements only what `HarnessWork` is documented to use
+ * The local registry implements only what `HarnessWork` is documented to use
  * (`list`, `onJobsChanged`, `attachController`, `start`) and makes every method
- * `HarnessWork` must NOT call (`read`, `kill`, `wait`, `onJobDone`) throw, the
- * same contract `work.spec.ts` already asserts — now backed by the real base
- * class instead of a structural cast.
+ * `HarnessWork` must NOT call (`read`, `kill`, `wait`, `onJobDone`) throw. The
+ * evidence is the real abstract base contract plus Work observation; it is not
+ * concrete provider, controller, or authorization behavior.
  * @module
  */
 

--- a/packages/dshline/tests/capability/llm.probe.spec.ts
+++ b/packages/dshline/tests/capability/llm.probe.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Capability probe: `ctx.llm`, against the real runtime.
+ *
+ * The compatibility evidence `tools/capability-probes.mjs` names for the `llm`
+ * seam. `model.spec.ts` and `connect-catalog.spec.ts` cast hand-typed objects
+ * through `as unknown as Context`, which proves dshline's own logic but never
+ * asks the real `@deepseek-ai/dsh-llm` runtime for the fields those callers
+ * read. This probe mounts the real `LlmRuntime` and a real abstract
+ * `LlmAdapter` subclass — the same package `ctx.llm` publishes — and asserts
+ * exactly the reads production code makes, nothing more:
+ *
+ * - `listProviders()` detaches `{ id, name }`, the route key `discover()` joins
+ *   into every `/model` label and passes to `listModels`;
+ * - `listModels()` returns the catalog `discover()` folds (`model.id`,
+ *   `model.name`);
+ * - `resolveModelInfo()` carries `context.contextWindow`,
+ *   `reasoning.efforts[].id`, and `inputModalities` — the metadata shape
+ *   dshline reads and the window may cache per selection;
+ * - `listConfigurableProviders()` returns the directory fields
+ *   `connect/catalog.ts` reads (`provider`, `displayName`, `settingsNs`,
+ *   `settingsPath`, `declared`);
+ * - `discoverModels()` answers a draft interrogation with the candidate fields
+ *   `connect/model-editor.ts` folds (`id`, `name`, `contextWindow`,
+ *   `maxTokens`).
+ *
+ * The adapter streams nothing: no dshline code path dispatches a model call —
+ * the agent loop owns that — so `stream` is refused like the methods
+ * `HarnessWork` must not call are in the jobs probe.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import LlmRuntime, { LlmAdapter, ReasoningEffortId } from '@deepseek-ai/dsh-llm'
+import type {
+  LlmConfigurableProvider,
+  LlmDiscoveredModel,
+  LlmModelDiscoveryRequest,
+  LlmModelInfo,
+  LlmProviderInfo,
+  LlmResolvedModelInfo,
+  GenerateOptions,
+} from '@deepseek-ai/dsh-llm'
+import { describe, expect, it } from 'vitest'
+
+/** The one provider route this probe's adapter serves. */
+const PROVIDER = 'probe-llm'
+
+/** The settings namespace the probe's configurable-provider entry declares. */
+const SETTINGS_NS = 'llm-pi-ai'
+
+/** An adapter over the real abstract base, answering everything EXCEPT a call. */
+class ProbeAdapter extends LlmAdapter {
+  override providerInfo(provider: string): LlmProviderInfo {
+    return { id: provider, name: 'Probe Provider' }
+  }
+
+  override async listModels(provider: string): Promise<readonly LlmModelInfo[]> {
+    return [{ provider, id: 'probe-model', name: 'Probe Model', inputModalities: ['text'] }]
+  }
+
+  override async resolveModel(provider: string, model: string): Promise<LlmResolvedModelInfo> {
+    return {
+      provider, id: model, name: 'Probe Model', inputModalities: ['text'],
+      context: { contextWindow: 65_536 },
+      reasoning: { efforts: [{ id: ReasoningEffortId('low'), name: 'Low' }, { id: ReasoningEffortId('high'), name: 'High' }] },
+    }
+  }
+
+  override async *stream(_options: GenerateOptions): AsyncIterable<never> {
+    throw new Error('capability probe: dshline never dispatches a model call')
+  }
+}
+
+/** Mount the real runtime and register the probe adapter's route. */
+async function mounted(): Promise<Context> {
+  const ctx = new Context()
+  await ctx.plugin(LlmRuntime)
+  ctx.llm.registerAdapter([PROVIDER], new ProbeAdapter())
+  return ctx
+}
+
+describe('capability: llm', () => {
+  it('lists registered routes as detached { id, name } metadata', async () => {
+    const ctx = await mounted()
+    try {
+      expect(ctx.llm.listProviders()).toEqual([{ id: PROVIDER, name: 'Probe Provider' }])
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('lists one route\'s catalog with the id and name /model folds', async () => {
+    const ctx = await mounted()
+    try {
+      const models = await ctx.llm.listModels(PROVIDER)
+      expect(models).toEqual([
+        { provider: PROVIDER, id: 'probe-model', name: 'Probe Model', inputModalities: ['text'] },
+      ])
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('resolves exact model metadata the window and /model read', async () => {
+    const ctx = await mounted()
+    try {
+      const info = await ctx.llm.resolveModelInfo(PROVIDER, 'probe-model')
+      // The status line's context window, the carried-effort check, and the
+      // modality gate for image I/O each read a different corner of this shape.
+      expect(info.context?.contextWindow).toBe(65_536)
+      expect(info.reasoning?.efforts.map(effort => effort.id)).toEqual(['low', 'high'])
+      expect(info.inputModalities).toEqual(['text'])
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('declares configurable providers /connect can list, registered or dormant', async () => {
+    const ctx = await mounted()
+    try {
+      const entry: LlmConfigurableProvider = {
+        provider: PROVIDER,
+        displayName: 'Probe Provider',
+        settingsNs: SETTINGS_NS,
+        settingsPath: ['providers', PROVIDER],
+        declared: false,
+      }
+      const handle = ctx.llm.registerConfigurableProviders([entry])
+      try {
+        expect(ctx.llm.listConfigurableProviders()).toEqual([entry])
+      } finally {
+        handle()
+      }
+      // Withdrawal is part of the contract /connect's watchers ride.
+      expect(ctx.llm.listConfigurableProviders()).toEqual([])
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('interrogates a draft endpoint through a registered discovery', async () => {
+    const ctx = await mounted()
+    try {
+      ctx.llm.registerModelDiscovery(SETTINGS_NS, async (request: LlmModelDiscoveryRequest) => {
+        expect(request.baseURL).toBe('http://localhost:9/probe')
+        return [
+          { id: 'gw-small', name: 'Gateway Small', contextWindow: 32_768, maxTokens: 8_192 },
+          { id: 'gw-large', name: 'Gateway Large', contextWindow: 131_072, maxTokens: 32_768 },
+        ] satisfies LlmDiscoveredModel[]
+      })
+      const discovered = await ctx.llm.discoverModels(SETTINGS_NS, { baseURL: 'http://localhost:9/probe' })
+      // The draft fold reads exactly these four fields; nothing more is claimed.
+      expect(discovered).toEqual([
+        { id: 'gw-small', name: 'Gateway Small', contextWindow: 32_768, maxTokens: 8_192 },
+        { id: 'gw-large', name: 'Gateway Large', contextWindow: 131_072, maxTokens: 32_768 },
+      ])
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+})

--- a/packages/dshline/tests/capability/plan-mode.probe.spec.ts
+++ b/packages/dshline/tests/capability/plan-mode.probe.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Capability probe: plan mode's logged Harness seam.
+ *
+ * Production dshline does not read a live `ctx.planMode` mirror; it folds the
+ * committed `plan/mode` session events with `planModeAfter`. The real
+ * `PlanModeController` registers the `plan` projection that reads those events,
+ * while this probe appends typed event records and verifies dshline's consumer
+ * over the resulting Session log. Model-loop selection and terminal
+ * presentation are outside the probe.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import PlanModeController from '@deepseek-ai/dsh-plan-mode'
+import SessionStore, { SessionId } from '@deepseek-ai/dsh-session'
+import SessionProjectionRegistry from '@deepseek-ai/dsh-session-projection'
+import SystemPrompt from '@deepseek-ai/dsh-system-prompt'
+import ToolRuntime from '@deepseek-ai/dsh-tools'
+import { describe, expect, it } from 'vitest'
+import { planModeAfter } from '../../src/modes.ts'
+
+/** Mount the concrete controller and the real services it injects. */
+async function mounted(): Promise<{ ctx: Context; agent: Agent }> {
+  const ctx = new Context()
+  await ctx.plugin(SessionStore)
+  await ctx.plugin(SessionProjectionRegistry)
+  await ctx.plugin(SystemPrompt)
+  await ctx.plugin(ToolRuntime)
+  await ctx.plugin(PlanModeController, { section: 'Probe plan guidance' })
+  const session = ctx.sessions.create(SessionId('plan-mode-probe'))
+  const agent = { id: session.id, session, ctx } as unknown as Agent
+  return { ctx, agent }
+}
+
+describe('capability: planMode', () => {
+  it('folds typed plan/mode events through the real controller projection and dshline', async () => {
+    const { ctx, agent } = await mounted()
+    try {
+      expect(ctx.planMode.get(agent)).toEqual({ active: false })
+      agent.session.append('plan/mode', { active: true })
+      expect(ctx.planMode.get(agent)).toEqual({ active: true })
+      expect(sessionPlan(agent)).toBe(true)
+      expect(ctx.sessionProjections.snapshot(agent.session).values.plan).toMatchObject({ active: true, pending: false })
+
+      agent.session.append('plan/mode', { active: false })
+      expect(ctx.planMode.get(agent)).toEqual({ active: false })
+      expect(sessionPlan(agent)).toBe(false)
+      expect(ctx.sessionProjections.snapshot(agent.session).values.plan).toMatchObject({ active: false, pending: false })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+})
+
+/** Fold the session's typed plan/mode stream through dshline's adapter. */
+function sessionPlan(agent: Agent): boolean {
+  return agent.session.snapshotEvents().reduce(planModeAfter, false)
+}

--- a/packages/dshline/tests/capability/session-stats.probe.spec.ts
+++ b/packages/dshline/tests/capability/session-stats.probe.spec.ts
@@ -4,7 +4,7 @@
  * This is the compatibility evidence `tools/capability-probes.mjs` names for the
  * `sessionStats` seam, so it mounts the REAL `@deepseek-ai/dsh-session-stats`
  * over a real `SessionStore` and a real projection registry — never a
- * dshline-shaped fake. Four contracts are asserted, because `/usage`'s
+ * dshline-shaped fake. Five contracts are asserted, because `/usage`'s
  * performance section is built on exactly these and nothing else:
  *
  * 1. the unit registers a `sessionStats` key that dshline's own generic observer
@@ -17,11 +17,11 @@
  * 4. a step Harness counted but did not time yields no averages at all, rather
  *    than zero ones;
  * 5. a zero summed wall time is the ABSENCE of a contribution and not a
- *    measurement of zero — real streaming and a real tool call can both elapse
- *    and leave the total at zero, which is why `/usage` refuses to print it.
+ *    measurement of zero, which is why `/usage` refuses to print it.
  *
- * The fold itself is upstream's contract and upstream's test. What is under
- * test here is dshline's dependency on it.
+ * The fold itself is upstream's contract and upstream's test. The event stream
+ * here is synthetic but passed through real `Session` and projection objects;
+ * provider logging and actual streaming/tool execution are not claimed.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'

--- a/packages/dshline/tests/capability/settings.probe.spec.ts
+++ b/packages/dshline/tests/capability/settings.probe.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Capability probe: `ctx.settings`, against the real base contract.
+ *
+ * `settings.spec.ts` already mounts the real `SettingsProvider`, but only for
+ * dshline's own namespace via the owner scope (`get`/`update`). This probe
+ * exercises the real base `describe()`/`mutate()` path-op and revision logic
+ * over a local in-memory load/persist implementation—the storage and watcher
+ * behavior of a concrete deployment remain outside its claim. Those are the
+ * operations Connect and `/plugins` rely on:
+ *
+ * - `describe()` publishes one descriptor per namespace with the `revision`
+ *   Connect carries into every write, plus `value`/`user` for the overridden
+ *   marking the catalog reads;
+ * - `mutate()` applies `{ op: 'set', path }` edits while preserving the
+ *   current section — the path-op merge contract those consumers rely on;
+ * - `unset` removes exactly one path;
+ * - a write naming a stale `expectedRevision` rejects with
+ *   `SettingsConflictError` — the conflict check that stops a stale browser
+ *   snapshot from overwriting something configured in the meantime.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import Schema from '@deepseek-ai/schemastery'
+import SettingsProvider, { SettingsConflictError } from '@deepseek-ai/dsh-settings'
+import type { SettingsNamespace } from '@deepseek-ai/dsh-settings'
+import { describe, expect, it } from 'vitest'
+
+/** The namespace this probe registers, standing in for a provider profile. */
+const NS = 'probe-llm' as SettingsNamespace
+
+/** A settings provider holding its document in memory, like a real file provider. */
+class MemorySettings extends SettingsProvider {
+  /** Raw document, namespace to raw section. */
+  static seed: Record<string, unknown> = {}
+
+  readonly writable = true
+
+  /**
+   * @returns the seeded raw document.
+   */
+  protected async load(): Promise<Record<string, unknown>> {
+    return structuredClone(MemorySettings.seed)
+  }
+
+  /**
+   * @param _ns - the namespace being written.
+   * @param section - the merged user section.
+   */
+  protected async persist(_ns: SettingsNamespace, section: Record<string, unknown>): Promise<void> {
+    MemorySettings.seed = { ...MemorySettings.seed, [_ns as string]: structuredClone(section) }
+  }
+}
+
+/**
+ * Mount the real provider and register one profile-shaped namespace.
+ * @returns the mounted context.
+ */
+async function mounted(): Promise<Context> {
+  MemorySettings.seed = {
+    [NS]: { displayName: 'Shipped', baseURL: 'http://shipped.example', apiKeyEnv: 'SHIPPED_KEY' },
+  }
+  const ctx = new Context()
+  await ctx.plugin(MemorySettings)
+  ctx.settings.register(NS, Schema.object({
+    displayName: Schema.string().default(''),
+    baseURL: Schema.string().default(''),
+    apiKeyEnv: Schema.string().role('credential-ref'),
+  }))
+  // The registration rides an effect, which settles asynchronously.
+  await new Promise(resolve => setTimeout(resolve, 0))
+  return ctx
+}
+
+describe('capability: settings', () => {
+  it('describes a namespace with the revision a write is checked against', async () => {
+    const ctx = await mounted()
+    try {
+      const [descriptor] = ctx.settings.describe()
+      expect(descriptor.ns).toBe(NS)
+      expect(descriptor.revision).toBe(0)
+      expect(descriptor.value).toMatchObject({ displayName: 'Shipped', baseURL: 'http://shipped.example' })
+      // Presence in `user` is what marks a field user-overridden.
+      expect(descriptor.user).toMatchObject({ displayName: 'Shipped' })
+      // The revision advances when the RAW section changes, which is what a
+      // conflict-checked write compares against.
+      await ctx.settings.mutate(NS, [{ op: 'set', path: ['displayName'], value: 'Moved' }])
+      expect(ctx.settings.describe().find(d => d.ns === NS)?.revision).toBe(1)
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('applies path ops without deleting fields the caller never saw', async () => {
+    const ctx = await mounted()
+    const [descriptor] = ctx.settings.describe()
+    try {
+      // A caller writes one nested path while the base preserves the section.
+      await ctx.settings.mutate(NS, [
+        { op: 'set', path: ['providers', 'gw', 'baseURL'], value: 'http://localhost:9' },
+      ], descriptor.revision)
+      const after = ctx.settings.describe().find(d => d.ns === NS)
+      expect(after?.user).toMatchObject({
+        displayName: 'Shipped',
+        baseURL: 'http://shipped.example',
+        providers: { gw: { baseURL: 'http://localhost:9' } },
+      })
+      expect(after?.value).toMatchObject({ apiKeyEnv: 'SHIPPED_KEY' })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('unsets exactly one path', async () => {
+    const ctx = await mounted()
+    try {
+      await ctx.settings.mutate(NS, [
+        { op: 'set', path: ['providers', 'gw', 'baseURL'], value: 'http://localhost:9' },
+        { op: 'unset', path: ['baseURL'] },
+      ])
+      const after = ctx.settings.describe().find(d => d.ns === NS)
+      expect(after?.user).toMatchObject({ displayName: 'Shipped' })
+      expect((after?.user as Record<string, unknown>).baseURL).toBeUndefined()
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('rejects a write naming a stale revision with SettingsConflictError', async () => {
+    const ctx = await mounted()
+    const [descriptor] = ctx.settings.describe()
+    try {
+      // Something else writes between this caller's read...
+      await ctx.settings.mutate(NS, [{ op: 'set', path: ['displayName'], value: 'Moved' }])
+      // ...so the checked write must refuse rather than clobber it.
+      await expect(ctx.settings.mutate(NS, [
+        { op: 'set', path: ['displayName'], value: 'Stale' },
+      ], descriptor.revision)).rejects.toBeInstanceOf(SettingsConflictError)
+      expect(ctx.settings.get(NS)).toMatchObject({ displayName: 'Moved' })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+})

--- a/packages/dshline/tests/capability/subagent-telemetry.probe.spec.ts
+++ b/packages/dshline/tests/capability/subagent-telemetry.probe.spec.ts
@@ -6,7 +6,8 @@
  * `@deepseek-ai/dsh-subagent` and `@deepseek-ai/dsh-token-meter` over a real
  * `SessionStore` and a real projection registry, and drives them with real
  * `Session.append` calls rather than with a dshline-shaped fake. What is
- * asserted is exactly what the row claims:
+ * asserted is exactly what the row claims; it does not exercise a concrete
+ * `ctx.subagents` provider lifecycle or discovery backend:
  *
  * 1. both units are registered under the keys `HarnessWork` narrows its
  *    snapshot to, and reachable for a CHILD session through the generic
@@ -15,7 +16,7 @@
  *    turns, and a descriptor replayed from a fork seed does not contribute;
  * 3. the four token buckets are disjoint, so the row's total is their sum;
  * 4. `tokenUsage` has NO such descriptor reset — it folds the complete log, so
- *    a really-seeded child's projection carries its parent's usage too, and the
+ *    a fork-seeded child's projection carries its parent's usage too, and the
  *    row must refuse to attribute that to the child;
  * 5. a live child's route comes from its own logged request envelope.
  *
@@ -210,8 +211,9 @@ describe('capability: subagent telemetry projections', () => {
     vi.setSystemTime(ORIGIN)
     const { ctx } = await harness()
     try {
-      // A REAL parent log with a real completed turn and real provider usage,
-      // taken as the seed rather than a hand-made `inheritedEventCount`: the
+      // A real parent Session log with a completed turn and replacement-shaped
+      // usage event, taken as the seed rather than a hand-made
+      // `inheritedEventCount`: the
       // fork backend seeds a child with exactly this — a balanced
       // completed-turn prefix of its parent — and sets the inherited cut to its
       // length (dsh-subagent's `inheritedEventCount = seed.length`).

--- a/packages/dshline/tests/capability/token-meter.probe.spec.ts
+++ b/packages/dshline/tests/capability/token-meter.probe.spec.ts
@@ -13,6 +13,10 @@
  * 3. a surface REPLACEMENT removes the shadowed nodes from that node set —
  *    which is what makes the entry list a picture of the model's current
  *    context rather than of the session's history.
+ *
+ * The projection and registry are real; the session events are compact,
+ * replacement-shaped fixtures, so producer-side logging and payload validation
+ * are not claimed here.
  */
 
 import { describe, expect, it } from 'vitest'

--- a/packages/dshline/tests/capability/tools.probe.spec.ts
+++ b/packages/dshline/tests/capability/tools.probe.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Capability probe: `ctx.tools`, against the real registry.
+ *
+ * `cards.spec.ts` proves dshline's card rendering with hand-typed definitions,
+ * and nothing anywhere instantiates the real `@deepseek-ai/dsh-tools` runtime
+ * that `attachment.ts`'s `ctx.tools.get(name, agent)` publishes. This probe
+ * follows the seam from a real `ToolDefinition` built by the package's own
+ * `defineTool`, through the real `ToolRuntime` lookup, to dshline's `ToolCards`.
+ * The call/result inputs are hand-built because execution, Session events, and
+ * attachment wiring are outside this probe; a change to the presentation views
+ * (`presentCall`/`presentResult`) or lookup contract still fails by capability
+ * name.
+ *
+ * The card assertions are deliberately narrow: dshline's rendering details are
+ * `cards.spec.ts`'s business. What is under probe here is registry lookup to
+ * ToolCards rendering over the appropriate real contract.
+ * @module
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import { createScope } from '@deepseek-ai/dsh-scope'
+import SystemPrompt from '@deepseek-ai/dsh-system-prompt'
+import ToolRuntime, { defineTool } from '@deepseek-ai/dsh-tools'
+import type { ToolResultView, ToolCallView } from '@deepseek-ai/dsh-tools'
+import { describe, expect, it } from 'vitest'
+import { stripAnsi } from '@dshline/renderer'
+import { ToolCards } from '../../src/cards.ts'
+import type { ResultInput } from '../../src/cards.ts'
+
+/** Terminal width the cards draw at; wide enough to keep rows unwrapped. */
+const COLUMNS = 80
+
+/** A real definition whose render intents the probe's cards exercise. */
+const PROBE_TOOL = defineTool({
+  name: 'probe-tool',
+  description: 'Compatibility probe for the tool presentation registry.',
+  parameters: { path: { type: 'string', required: true, description: 'what to inspect' } },
+  output: {
+    schema: { type: 'object', additionalProperties: true },
+    render: () => [{ type: 'text', text: 'probe' }],
+  },
+  execute: async () => ({ ok: true }),
+  // The presenters are the half ToolCards consumes; the generic card would
+  // render a definition without them, so they must survive the real registry.
+  presentCall: (args: { path?: string }): ToolCallView => ({
+    card: 'generic', title: `inspect ${String(args.path)}`, kind: 'read',
+  }),
+  presentResult: (): ToolResultView => ({
+    card: 'generic', title: 'inspected', content: [{ type: 'text', text: 'probe result' }],
+  }),
+})
+
+describe('capability: tools', () => {
+  it('publishes a registered definition through the scoped get the cards call', async () => {
+    const ctx = new Context()
+    await ctx.plugin(SystemPrompt)
+    await ctx.plugin(ToolRuntime)
+    try {
+      const dispose = ctx.tools.register(PROBE_TOOL)
+      const agent = {}
+      // This global registration exercises the lookup contract that an agent
+      // scope receives; shadowing/restriction policy is outside this probe.
+      expect(ctx.tools.get('probe-tool', agent)?.name).toBe('probe-tool')
+      expect(ctx.tools.get('missing', agent)).toBeUndefined()
+      dispose()
+      expect(ctx.tools.get('probe-tool', agent)).toBeUndefined()
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('renders a real definition’s presentation views through dshline’s ToolCards', async () => {
+    const ctx = new Context()
+    await ctx.plugin(SystemPrompt)
+    await ctx.plugin(ToolRuntime)
+    try {
+      ctx.tools.register(PROBE_TOOL)
+      const agent = {}
+      // createScope supplies a real scope key for the registry lookup; this is
+      // not a live Agent or an execution path.
+      await ctx.plugin(Object.assign((inner: Context) => {
+        createScope(inner, agent)
+      }, { inject: ['tools'] }))
+      const cards = new ToolCards(name => ctx.tools.get(name, agent), '/ws')
+      // The event shape the attachment threads in: the harness result content
+      // plus the callId that matches it to its pending card.
+      const rows = [
+        ...cards.call({ callId: 'c1', name: 'probe-tool', arguments: '{"path":"/ws/x"}' }, COLUMNS),
+        ...cards.result(
+          { callId: 'c1', content: [{ type: 'text', text: 'raw' }], isError: false } satisfies ResultInput,
+          COLUMNS,
+        ),
+      ]
+      const drawn = rows.map(stripAnsi)
+      // The pending card shows the tool's OWN presentCall title, not the
+      // generic fallback of the raw tool name.
+      expect(drawn.join('\n')).toContain('inspect /ws/x')
+      // The completed card renders the presentResult replacement content —
+      // the presenter ran, through the real registry's lookup.
+      expect(drawn.join('\n')).toContain('probe result')
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+})

--- a/packages/dshline/tests/capability/user-questions.probe.spec.ts
+++ b/packages/dshline/tests/capability/user-questions.probe.spec.ts
@@ -2,9 +2,10 @@
  * Capability probe: `ctx.userQuestions`.
  *
  * Exercises the exact seam `installQuestionProvider` consumes against the
- * real `@deepseek-ai/dsh-user-questions` service — not a dshline-shaped fake
- * — through a real `TuiSlots` overlay stack, so a real request reaches a real
- * terminal-provider boundary and a real structured answer comes back.
+ * real `@deepseek-ai/dsh-user-questions` service through dshline's local
+ * `TuiSlots` overlay provider boundary. A real Harness request reaches the
+ * provider and a structured answer comes back; a terminal, ask-user tool, and
+ * agent-scoped model wiring are outside this probe.
  * dshline registers on the one registration the adopted Harness generation
  * publishes — the Agent-scoped `user-questions/request` waterfall — so what
  * this proves is that the real service's own dispatch reaches it and that its
@@ -22,7 +23,7 @@ import { installQuestionProvider } from '../../src/questions.ts'
 import { TuiSlots } from '../../src/slots.ts'
 
 describe('capability: userQuestions', () => {
-  it('carries a real Harness question request to a real terminal answer', async () => {
+  it('carries a real Harness question request to the dshline overlay answerer', async () => {
     const ctx = new Context()
     await ctx.plugin(TuiSlots)
     await ctx.plugin(UserQuestionService)
@@ -45,7 +46,7 @@ describe('capability: userQuestions', () => {
     }
   })
 
-  it('carries a real multiSelect request and its custom supplement through the real service', async () => {
+  it('carries a real multiSelect request and custom supplement through the service', async () => {
     const ctx = new Context()
     await ctx.plugin(TuiSlots)
     await ctx.plugin(UserQuestionService)

--- a/packages/dshline/tests/capability/workflow.probe.spec.ts
+++ b/packages/dshline/tests/capability/workflow.probe.spec.ts
@@ -1,17 +1,15 @@
 /**
  * Capability probe: `ctx.workflowEngine` and the durable workflow records.
  *
- * Exercises the exact contracts Work consumes, against the real packages:
- * the abstract `@deepseek-ai/dsh-workflow` `WorkflowEngine` and its
- * `emitWorkflowEvent` dispatch, the real `workflow/*` event declarations, a
- * real `@deepseek-ai/dsh-session` `Session` from the real `SessionStore`, and
- * the `tool-workflow/*` `SessionEventMap` merge that `@deepseek-ai/dsh-tool-workflow`
- * publishes. An upstream rename or payload change fails this file by capability
- * name instead of surfacing as an unrelated typecheck error.
+ * Exercises the contracts Work consumes over the real packages: the abstract
+ * `@deepseek-ai/dsh-workflow` `WorkflowEngine` dispatch, the real
+ * `workflow/*` event names, a real `Session` from `SessionStore`, and the
+ * `tool-workflow/*` event vocabulary. The local engine and hand-appended
+ * records provide the provider-neutral fixtures; no concrete workflow backend,
+ * script, child agent, or tool execution is claimed here.
  *
- * The engine here runs no script and starts no child: the point is the
- * observation seam, and specifically that a run only becomes visible through
- * the durable record the tool writes into the parent Session.
+ * The observation seam is the point: a run becomes visible only through the
+ * durable record the tool writes into the parent Session.
  * @module
  */
 
@@ -25,15 +23,15 @@ import type {} from '@deepseek-ai/dsh-tool-workflow/types'
 import { describe, expect, it } from 'vitest'
 import { createHarnessWork } from '../../src/work/index.ts'
 
-/** The validated meta a real run carries on every one of its events. */
+/** Metadata shaped like the records a workflow provider would publish. */
 const META = { name: 'capability-probe', description: 'Probe the workflow observation seam' }
 
 /**
- * An engine that publishes the real lifecycle events and runs no script.
+ * A local engine that calls the real abstract dispatch and runs no script.
  *
- * Subclassing the real abstract Service is the point: `emitWorkflowEvent` is
- * the protected dispatch every provider uses, so the event names and payload
- * shapes below are the upstream ones, checked by the compiler.
+ * Subclassing the real abstract service supplies interface compatibility; the
+ * payload objects below are local fixtures, not evidence for a concrete
+ * workflow provider.
  */
 class ProbeWorkflowEngine extends WorkflowEngine {
   override start(request: WorkflowStartRequest): WorkflowRun {
@@ -49,7 +47,7 @@ class ProbeWorkflowEngine extends WorkflowEngine {
     }
   }
 
-  /** Publish one phase narration exactly as a real run would. */
+  /** Publish a local phase fixture through the real event dispatcher. */
   narrate(id: string, title: string): void {
     this.emitWorkflowEvent('workflow/phase', { id: WorkflowRunId(id), meta: META }, title)
   }
@@ -59,21 +57,21 @@ class ProbeWorkflowEngine extends WorkflowEngine {
     this.emitWorkflowEvent('workflow/start', { id: WorkflowRunId(id), meta: META })
   }
 
-  /** Publish one member's start edge exactly as a real run would. */
+  /** Publish a local member-start fixture through the real dispatcher. */
   memberStart(id: string, childId: string): void {
     this.emitWorkflowEvent('workflow/agent-start', { id: WorkflowRunId(id), meta: META }, {
       seq: 1, label: 'probe member', phase: 'Review', childId: SessionId(childId),
     })
   }
 
-  /** Publish one member's settlement exactly as a real run would. */
+  /** Publish a local member-end fixture through the real dispatcher. */
   memberEnd(id: string, childId: string): void {
     this.emitWorkflowEvent('workflow/agent-end', { id: WorkflowRunId(id), meta: META }, {
       seq: 1, label: 'probe member', phase: 'Review', childId: SessionId(childId), outcome: 'completed',
     })
   }
 
-  /** Publish one member settlement exactly as a real run would. */
+  /** Publish a local run-end fixture through the real dispatcher. */
   settle(id: string, agentsStarted: number): void {
     this.emitWorkflowEvent(
       'workflow/end',
@@ -171,7 +169,7 @@ describe('capability: workflows', () => {
     }
   })
 
-  it('starts a real run through the seam without observing it as this session\'s', async () => {
+  it('starts a run through the local engine seam without observing it as this session\'s', async () => {
     const ctx = new Context()
     try {
       await ctx.plugin(SessionStore)

--- a/packages/dshline/tests/goals.spec.ts
+++ b/packages/dshline/tests/goals.spec.ts
@@ -203,7 +203,7 @@ describe('the Goal authority split', () => {
     // only field this frontend consumes from the goal service anywhere.
     //
     // Asserted against the source because neither is expressible in the type
-    // system: alpha.5 publishes no activation-only accessor, so `get()` hands
+    // system: the adopted Harness generation publishes no activation-only accessor, so `get()` hands
     // back a whole `GoalView` and nothing but this stops a durable field being
     // read off it. That call does resolve its own durable half through
     // `sessionProjections.stateOf()` internally — a service-side read, not a
@@ -235,13 +235,12 @@ async function harness(): Promise<{ ctx: Context; agent: Agent; observer: Sessio
   return { ctx, agent, observer }
 }
 
-describe('the real Alpha.5 Goal service and session projection', () => {
+describe('the real Goal service and session projection', () => {
   it('reads the durable goal from the registry and activation from the service', async () => {
     const { ctx, agent, observer } = await harness()
     const created = ctx.goals.create(agent, { objective: 'ship the release', maxGoalRounds: 8 })
-    // One admitted continuation round, recorded the way the real goal round
-    // driver records it: a `user/message` attributed to the goal, folded into
-    // `roundsStarted` by the real projection unit.
+    // One continuation-shaped `user/message` attributed to the goal, folded
+    // into `roundsStarted` by the real projection unit.
     agent.session.append('user/message', createUserMessage({
       content: [{ type: 'text', text: 'continue' }],
       source: { kind: 'goal', goalId: created.id, revision: created.revision, round: 1 },

--- a/tools/capability-probes.mjs
+++ b/tools/capability-probes.mjs
@@ -38,6 +38,11 @@ export const CAPABILITY_PROBES = [
     note: 'real query service/store list, filter, title, and trace paths; full-text search uses local abstract-contract fixtures rather than a production search backend',
   },
   {
+    name: 'agents',
+    files: ['packages/dshline/tests/capability/agents.probe.spec.ts'],
+    note: 'real AgentRegistry get/create/resume dispatch over entered agents and the published AgentFactory seam; local factory behavior does not prove AgentLoop creation, persistence, setup, or lifecycle policy',
+  },
+  {
     name: 'jobs',
     files: ['packages/dshline/tests/capability/jobs.probe.spec.ts'],
     note: 'real abstract JobRegistry contract plus HarnessWork observation over a local registry; concrete provider/controller policy is host-owned',

--- a/tools/capability-probes.mjs
+++ b/tools/capability-probes.mjs
@@ -3,12 +3,12 @@
  * compatibility evidence already lives.
  *
  * This is a POINTER table, not a second copy of the contract: every entry
- * names an existing or purpose-built test file that exercises the real
- * `@deepseek-ai/*` class for that seam (a real `SessionQueryEngine`, a real
- * `SubagentRuntime`, a real abstract `JobRegistry` subclass, …), never a
- * dshline-shaped fake. If a seam's real contract changes upstream, the file
- * named here fails — by capability name — before anything has to fall back to
- * a generic `pnpm typecheck failed`.
+ * names at least one existing or purpose-built test that reaches the relevant
+ * Harness class, base contract, or dshline integration. Some files use local
+ * subclasses or fixtures because a seam is intentionally abstract; those local
+ * implementations are not evidence for a concrete deployment policy. If a
+ * named seam's consumed contract changes upstream, its file fails by capability
+ * name before anything has to fall back to a generic `pnpm typecheck failed`.
  *
  * Adding a capability dshline newly depends on means adding one line here that
  * names an already-real test, or a small new probe under
@@ -23,8 +23,8 @@
  * @typedef {object} CapabilityProbe
  * @property {string} name - the seam's name, matching `docs/architecture.md`'s
  *   capability-surface vocabulary (`sessionQuery`, `jobs`, `subagents`, …).
- * @property {string[]} files - repository-relative test files whose pass/fail
- *   IS this capability's verdict.
+ * @property {string[]} files - repository-relative test files containing this
+ *   capability's named evidence and runtime verdict.
  * @property {string} [note] - shown beside the capability name in the report,
  *   for coverage that rides on an existing acceptance test rather than a
  *   dedicated probe.
@@ -35,10 +35,12 @@ export const CAPABILITY_PROBES = [
   {
     name: 'sessionQuery',
     files: ['packages/dshline/tests/sessions-query.integration.spec.ts'],
+    note: 'real query service/store list, filter, title, and trace paths; full-text search uses local abstract-contract fixtures rather than a production search backend',
   },
   {
     name: 'jobs',
     files: ['packages/dshline/tests/capability/jobs.probe.spec.ts'],
+    note: 'real abstract JobRegistry contract plus HarnessWork observation over a local registry; concrete provider/controller policy is host-owned',
   },
   {
     name: 'subagents',
@@ -46,7 +48,7 @@ export const CAPABILITY_PROBES = [
       'packages/dshline/tests/capability/subagents.probe.spec.ts',
       'packages/dshline/tests/capability/subagent-telemetry.probe.spec.ts',
     ],
-    note: 'lifecycle seam, plus the subagentTiming/tokenUsage projections a Work row reads',
+    note: 'real runtime lifecycle over a provider-neutral local backend, plus real subagentTiming/tokenUsage projections over synthetic Session events; no provider backend or discovery is claimed',
   },
   {
     name: 'sessionProjections',
@@ -55,42 +57,117 @@ export const CAPABILITY_PROBES = [
       'packages/dshline/tests/goals.spec.ts',
       'packages/dshline/tests/permission.spec.ts',
     ],
-    note: 'Todo, Goal, and permission projection acceptance tests',
+    note: 'real projection/service assertions layered with dshline acceptance fixtures for Todo, Goal, and permission',
   },
   {
     name: 'sessionStats',
     files: ['packages/dshline/tests/capability/session-stats.probe.spec.ts'],
-    note: 'the optional whole-log turn/step and wall-time unit `/usage` reports',
+    note: 'real sessionStats projection and dshline performance fold over synthetic Session events; provider streaming/tool logging is outside the probe',
   },
   {
     name: 'workflows',
     files: ['packages/dshline/tests/capability/workflow.probe.spec.ts'],
+    note: 'real abstract WorkflowEngine dispatch and dshline Work observation over local event fixtures; no concrete backend, script, or child run',
   },
   {
     name: 'userQuestions',
     files: ['packages/dshline/tests/capability/user-questions.probe.spec.ts'],
+    note: 'real UserQuestionService dispatch through dshline’s local overlay provider; terminal, ask-user tool, and agent-scoped wiring are outside the probe',
   },
   {
     name: 'tokenMeter',
     files: ['packages/dshline/tests/capability/token-meter.probe.spec.ts'],
+    note: 'real TokenMeter/projection registry and dshline context fold over replacement-shaped event fixtures; producer logging is not claimed',
   },
   {
     name: 'compaction',
     files: ['packages/dshline/tests/capability/compaction.probe.spec.ts'],
+    note: 'durable compaction/* event contract and dshline presentation fold over a real Session; ctx.compaction backend and /compact command execution are host-owned',
+  },
+  {
+    name: 'planMode',
+    files: ['packages/dshline/tests/capability/plan-mode.probe.spec.ts'],
+    note: 'real PlanModeController/projection reads typed plan/mode events, then dshline folds the real Session log; model-loop selection and terminal presentation are outside the probe',
   },
   {
     name: 'skills',
     files: ['packages/dshline/tests/capability/skills.probe.spec.ts'],
+    note: 'real SkillRegistry and dsh-tool-skill pre-step boundary over local provider/Agent fixtures; live agent submission and filesystem discovery are outside the probe',
   },
   {
     name: 'authorization',
     files: ['packages/dshline/tests/capability/authorization.probe.spec.ts'],
-    note: 'the sign-in seam `/connect` runs and this bundle now composes as a host row',
+    note: 'real AuthorizationService begin/list/cancel and route-key helper over a local credential fixture; bundle patch and browser `/connect` presentation are not covered',
   },
   {
     name: 'requestHeader',
     files: ['packages/dshline/tests/cache-inspector.spec.ts'],
-    note: 'the `Session.requestHeader()` fold `/cache` reads the latest recorded route, system prompt, and tool count from',
+    note: 'real `Session.requestHeader()` fold consumed by `/cache`; header events are fixture-appended, so loop logging policy is not covered',
+  },
+  {
+    name: 'llm',
+    files: ['packages/dshline/tests/capability/llm.probe.spec.ts'],
+    note: 'real LlmRuntime over a minimal abstract-contract adapter: route/catalog, metadata shapes dshline reads, configurable-provider directory, and discovery callback',
+  },
+  {
+    name: 'agentDefaultModel',
+    files: ['packages/dshline/tests/capability/agent-default-model.probe.spec.ts'],
+    note: 'concrete default-model service currentSelection/saveSelection over optional real SettingsProvider base; persistence is local in-memory evidence',
+  },
+  {
+    name: 'settings',
+    files: ['packages/dshline/tests/capability/settings.probe.spec.ts'],
+    note: 'real SettingsProvider base path-op/revision behavior over local load/persist; the contract Connect and `/plugins` rely on, not those consumers themselves',
+  },
+  {
+    name: 'credentials',
+    files: ['packages/dshline/tests/capability/credentials.probe.spec.ts'],
+    note: 'real abstract CredentialProvider contract with a local reference/record implementation; backend storage policy is not proved, and AuthorizationService covers record orchestration separately',
+  },
+  {
+    name: 'commands',
+    files: ['packages/dshline/tests/permission.spec.ts'],
+    note: 'real CommandRuntime execute/lifecycle for `/permission review`; local dispatch/list decoration and other fixtures are not discovery evidence',
+  },
+  {
+    name: 'tools',
+    files: ['packages/dshline/tests/capability/tools.probe.spec.ts'],
+    note: 'real ToolRuntime/defineTool lookup to dshline ToolCards rendering over hand-built call/result inputs; execution, Session events, and attachment wiring are out of scope',
+  },
+  {
+    name: 'attachments',
+    files: ['packages/dshline/tests/capability/attachments.probe.spec.ts'],
+    note: 'real AttachmentStore.saveImages base ordering/admission used by `/image`, over local limits/validation/storage; context mounting and deployment policy are not claimed',
+  },
+  {
+    name: 'fs',
+    files: ['packages/dshline/tests/capability/fs.probe.spec.ts'],
+    note: 'real abstract FileSystem contract plus readImageDrafts passing cwd/signal/bound to a local backend; backend bounding policy is not claimed',
+  },
+  {
+    name: 'agentPresets',
+    files: ['packages/dshline/tests/capability/agent-presets.probe.spec.ts'],
+    note: 'real AgentPresets list/resolve/read/copy and structural AgentPresetsSeam assignment, plus the creation-header projection read; mount/recompose/select and selected events are outside the probe',
+  },
+  {
+    name: 'goals',
+    files: ['packages/dshline/tests/goals.spec.ts'],
+    note: 'real GoalService/projection plus dshline `goalReading` adapter path and source rule; no mounted status line is exercised',
+  },
+  {
+    name: 'approval',
+    files: ['packages/dshline/tests/capability/approval.probe.spec.ts'],
+    note: 'real ApprovalService waterfall through dshline answerer, SessionStore audit pair, different-agent fail-closed result, and cancellation over minimal agent-shaped fixtures',
+  },
+  {
+    name: 'subprocess',
+    files: ['packages/dshline/tests/profiles-actions.spec.ts'],
+    note: 'real LocalSubprocessRuntime child/env/timeout behavior plus unit-tested argv forwarding with an injected runner; no real dsh launcher/profile invocation',
+  },
+  {
+    name: 'sessionTitle',
+    files: ['packages/dshline/tests/sessions-query.integration.spec.ts'],
+    note: 'real SessionTitleService.rename and live-store membership; browser action/overlay wiring is not exercised',
   },
 ]
 

--- a/tools/capability-probes.spec.mjs
+++ b/tools/capability-probes.spec.mjs
@@ -1,0 +1,67 @@
+/**
+ * Invariants of the probe table itself.
+ *
+ * `capability-report.mjs` already reports a probe whose file produced no
+ * result as MISSING, but only after spending a vitest run. These checks are
+ * the cheap, structural half of the same honesty: a table entry that names a
+ * file which does not exist, a duplicated name or file, and a purpose-built
+ * probe under `tests/capability/` that the table forgot all fail here, at a
+ * glance, instead of waiting for a lane to run.
+ * @module tools/capability-probes.spec
+ */
+
+import { existsSync, readdirSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { CAPABILITY_PROBES } from './capability-probes.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** Where purpose-built probes live, and the only place new ones may be added. */
+const PROBE_DIR = join(repoRoot, 'packages/dshline/tests/capability')
+
+describe('the capability probe table', () => {
+  it('names each capability exactly once', () => {
+    const names = CAPABILITY_PROBES.map(probe => probe.name)
+    expect(names).toEqual([...new Set(names)])
+  })
+
+  it('uses capability names shaped like the doc vocabulary', () => {
+    for (const probe of CAPABILITY_PROBES) {
+      expect(probe.name).toMatch(/^[a-z][A-Za-z0-9]*$/)
+    }
+  })
+
+  it('names only existing test files, once each per capability', () => {
+    for (const probe of CAPABILITY_PROBES) {
+      expect(probe.files.length, `${probe.name} names no file`).toBeGreaterThan(0)
+      for (const file of probe.files) {
+        expect(file, `${probe.name}: ${file} is not a test file`).toMatch(/\.spec\.tsx?$/)
+        expect(existsSync(join(repoRoot, file)), `${probe.name} names a missing file: ${file}`).toBe(true)
+      }
+      expect(probe.files, `${probe.name} names a file twice`).toEqual([...new Set(probe.files)])
+    }
+  })
+
+  it('keeps named evidence in the dshline package test tree', () => {
+    // This is only a cheap repository-structure check. The capability report,
+    // not this test, is the authority that a named file actually produced a
+    // Vitest result in the active project configuration.
+    for (const probe of CAPABILITY_PROBES) {
+      for (const file of probe.files) {
+        expect(file, `${file} is outside the package test tree`).toMatch(/^packages\/dshline\/tests\/.*\.spec\.ts$/u)
+      }
+    }
+  })
+
+  it('leaves no purpose-built probe behind the table', () => {
+    const named = new Set(CAPABILITY_PROBES.flatMap(probe => probe.files))
+    const onDisk = readdirSync(PROBE_DIR)
+      .filter(file => file.endsWith('.spec.ts'))
+      .map(file => `packages/dshline/tests/capability/${file}`)
+    for (const file of onDisk) {
+      expect(named.has(file), `${file} exists but no capability names it — add it to CAPABILITY_PROBES or delete it`).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## What this does

Final small correctness pass on the rebased capability-evidence work for current `main` (`40a6683c7d1b2f14dca4b7b08a6bf3723fde5808`). The pointer table now names 27 Harness seams that production dshline consumes and that can be exercised deterministically in-process. It remains a pointer table: each row points at evidence; it does not copy a contract or claim that a local fixture is a concrete deployment.

Evidence is scoped to the strongest deterministic layer available:

- concrete Harness service/runtime behavior;
- Harness base-class or orchestration behavior when that is the contract;
- minimal subclasses for intentionally abstract seams;
- dshline integration over a Harness seam where the frontend consumes it.

## Final capability inventory

`sessionQuery`, `agents`, `jobs`, `subagents`, `sessionProjections`, `sessionStats`, `workflows`, `userQuestions`, `tokenMeter`, `compaction`, `planMode`, `skills`, `authorization`, `requestHeader`, `llm`, `agentDefaultModel`, `settings`, `credentials`, `commands`, `tools`, `attachments`, `fs`, `agentPresets`, `goals`, `approval`, `subprocess`, `sessionTitle`.

The table deliberately excludes launcher/Host-plane inputs `appExit`, `loader`, `cmdlineArgs`, `dshHomePath`, and `baseUrl`; TUI-owned surfaces are not capability rows. The published consumer lane proves real install/boot integration at that boundary, while focused tests cover dshline's local forwarding and policy without claiming to exercise every `/profiles` or Host accessor behavior.

## Final correctness pass

`agents` now has a purpose-built probe over the real `AgentRegistry`: it verifies entered/announced `get()` lookup and `create()`/`resume()` forwarding through the published `AgentFactory` seam. Its local factory does not claim concrete AgentLoop creation, persistence, setup, announcements, or lifecycle policy.

The plan-mode documentation now states that committed `plan/mode` events are the presentation authority; Harness's `plan` projection is contract evidence, while dshline folds the events with `planModeAfter()` and does not read `ctx.planMode` as a presentation mirror. The bilingual architecture docs and generated translation hashes are aligned.

## Scope

No production behavior or dependencies changed. `HARNESS_TARGET` is unchanged. No compatibility layer, feature detection, provider-specific code, Claude acceptance, changeset, or unrelated cleanup was added.

## Verification

- `node tools/capability-report.mjs "local (0.1.2-rc.1)"` — 27/27 PASS
- focused capability/goal probes — 23 files, 95 tests passed
- `pnpm typecheck` — clean
- `pnpm build` — clean
- `pnpm test` — 3134 passed, 22 skipped, 158 files (1 skipped)
- `pnpm run verify-docs` — 9 bilingual pairs consistent; two pre-existing documents await Chinese counterparts
- `node tools/harness-target.mjs` — exact `0.1.2-rc.1` pins verified
