### PR TITLE
fix(release): make npm publication and recovery rerunnable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,31 +5,26 @@ name: publish
 # tarball to this repository, this commit, and this workflow. Anyone installing
 # the package can then check that what they got was built from the source they can
 # read, which is not a claim a local `npm publish` can make at all.
-# Tags are the only trigger that can PUBLISH. The manual entry point performs
-# only the two OIDC token exchanges, so trusted-publisher configuration can be
-# checked without creating an irreversible package version.
+# Tags are the only trigger that can PUBLISH. The ordinary manual entry point
+# performs only the two OIDC token exchanges, so trusted-publisher configuration
+# can be checked without creating an irreversible package version. Its separate
+# existing-tag mode is read-only until the contents-scoped Release job.
 on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      recovery-tag:
+        description: existing immutable v* tag whose missing GitHub Release should be recovered
+        required: false
+        type: string
 
-# One release at a time, across every tag. The group is deliberately CONSTANT: a
-# ref-scoped group gives each tag its own lane, so two tags pushed close together
-# would publish concurrently, and if the older run finished last it would drag
-# npm's `latest` back to the older version and could leave the two packages on
-# different `latest` versions. Nothing in flight is cancelled either — a
-# half-cancelled publish has already put a version on the registry.
-#
-# The limit of this primitive, stated because it is not obvious: GitHub keeps at
-# most ONE pending run per group and cancels the pending one when another is
-# queued, `cancel-in-progress: false` notwithstanding. So pushing a THIRD tag
-# while a release is still running discards the middle tag's run, and that run
-# never executes, so nothing inside it can report the loss. The version workflow
-# therefore refuses to create another tag while a publisher is active, leaving
-# the next tag absent and safely retryable. A manually pushed tag bypasses that
-# guard, so the operational rule remains: never push release tags by hand.
+# Serialize irreversible tag publishers together, but keep manual verification and
+# existing-tag recovery out of that queue. GitHub keeps only one pending run per
+# group even with cancel-in-progress false; sharing a group would let a harmless
+# manual check evict the next tag handoff before npm ever sees it.
 concurrency:
-  group: publish
+  group: publish-${{ github.event_name == 'push' && 'tag' || (inputs.recovery-tag != '' && 'recovery' || 'trusted') }}
   cancel-in-progress: false
 
 permissions:
@@ -38,7 +33,9 @@ permissions:
 jobs:
   trusted-publisher:
     name: verify npm trusted publishers
-    if: github.event_name == 'workflow_dispatch'
+    # OIDC is exposed only to the reviewed main workflow, never to a dispatch from
+    # an arbitrary branch whose script could spend the identity unexpectedly.
+    if: github.event_name == 'workflow_dispatch' && inputs.recovery-tag == '' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read # check out the verification script
@@ -47,6 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Use the exact reviewed dispatch commit, not a branch that can move.
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -56,30 +55,32 @@ jobs:
 
       - run: node tools/check-trusted-publishers.mjs
 
-  publish:
-    name: publish to npm
+  release-preflight:
+    name: validate and pack release
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
+    # This job intentionally has no OIDC permission. Build, tests, package
+    # lifecycle hooks, and dependency audit all run before any npm identity exists.
     permissions:
-      contents: read # read the tagged tree
-      id-token: write # authenticate to npm and sign provenance with this job identity
+      contents: read
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 11.22.0
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           # No dependency cache on a release, deliberately. An Actions cache is
           # writable from any branch and restorable here, so a release that used one
-          # would be built partly from whatever a pull request last wrote into it —
-          # which is precisely the guarantee the attestation below is supposed to be
-          # making. Twenty seconds of download is the right price.
+          # would be built partly from whatever a pull request last wrote into it.
           package-manager-cache: false
 
       - run: pnpm install --frozen-lockfile --ignore-scripts
@@ -93,75 +94,225 @@ jobs:
         run: node tools/check-release-tag.mjs
 
       # Defense in depth for the release channel: `@deepseek-ai/dsh@latest` can
-      # move between the green Version Packages check, the tag, and this run,
-      # and a manually pushed or recovered tag skips both earlier gates. Placed
-      # before the first irreversible npm write, so a moved pointer costs a red
-      # release rather than a `latest` that resolves an unsupported pair.
+      # move between the green Version Packages check, the tag, and this run.
       - name: the default Harness install must be the adopted generation
         run: node tools/check-release-harness.mjs
 
-      # Exchange both package identities before either package is published. A
-      # recursive publish authenticates one at a time, so discovering that only
-      # the second package was configured after the renderer went out would leave
-      # an irreversible half-release.
+      - run: pnpm run build
+      - run: pnpm run typecheck
+      - run: pnpm run test
+      - run: pnpm run audit
+
+      # The OIDC job publishes these immutable tarballs with --ignore-scripts.
+      # No package prepare/prepublish code runs after a publish identity exists.
+      - name: pack validated npm artifacts
+        run: |
+          set -euo pipefail
+          ARTIFACT_ROOT="$RUNNER_TEMP/dshline-npm-packages"
+          mkdir -p "$ARTIFACT_ROOT"
+          pnpm --dir packages/renderer pack --config.ignore-scripts=true --pack-destination "$ARTIFACT_ROOT"
+          mv "$ARTIFACT_ROOT"/dshline-renderer-*.tgz "$ARTIFACT_ROOT/renderer.tgz"
+          pnpm --dir packages/dshline pack --config.ignore-scripts=true --pack-destination "$ARTIFACT_ROOT"
+          mv "$ARTIFACT_ROOT"/dshline-dshline-*.tgz "$ARTIFACT_ROOT/dshline.tgz"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dshline-npm-packages
+          path: ${{ runner.temp }}/dshline-npm-packages
+          overwrite: true
+          if-no-files-found: error
+
+  publish-to-npm:
+    name: publish accepted npm operations
+    if: github.event_name == 'push'
+    needs: release-preflight
+    runs-on: ubuntu-latest
+
+    # This is the smallest job that can hold OIDC: checkout, artifact download,
+    # trusted-publisher exchange, and the no-script tarball publisher only.
+    permissions:
+      contents: read
+      id-token: write # exchange trusted-publisher identity for npm's short-lived token
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 11.22.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dshline-npm-packages
+          path: ${{ runner.temp }}/dshline-npm-packages
+
       - name: npm must trust this workflow for both packages
         run: node tools/check-trusted-publishers.mjs
 
-      # A release is the one build that cannot be taken back, so it gates on
-      # everything: types, tests, and advisories. Re-running them here costs a
-      # minute and removes the assumption that whoever tagged had checked.
-      - run: pnpm run build
+      - name: create an isolated npm configuration
+        run: |
+          : > "$RUNNER_TEMP/empty-npmrc"
 
-      - run: pnpm run typecheck
+      - name: publish validated tarballs
+        env:
+          PUBLISH_ARTIFACT_ROOT: ${{ runner.temp }}/dshline-npm-packages
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/empty-npmrc
+          npm_config_userconfig: ${{ runner.temp }}/empty-npmrc
+          NPM_TOKEN: ''
+          NODE_AUTH_TOKEN: ''
+        run: node tools/publish-packages.mjs
 
-      - run: pnpm run test
+  # This is deliberately a different job from publish-to-npm. npm accepted
+  # publication is not the same moment npm serves the package publicly. If this
+  # bounded, scanning-aware read fails, GitHub can rerun only this job without
+  # crossing the irreversible npm publication boundary a second time.
+  verify-registry:
+    name: verify npm registry visibility
+    if: github.event_name == 'push'
+    needs: publish-to-npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
-      - run: pnpm run audit
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
-      # Trusted publishing exchanges the job's OIDC identity for short-lived,
-      # package-scoped credentials. --provenance remains explicit as defense in
-      # depth even though npm now enables it automatically for trusted publishers.
-      # Order is topological: the renderer publishes before the bundle that
-      # depends on it, and pnpm rewrites `workspace:^` to the real version as it goes.
-      # The repository's minimum release age remains in force for install;
-      # publishing alone disables it so an immediate retry can see and skip the
-      # first package if a prior run failed after only half the workspace landed.
-      - name: publish
-        run: pnpm -r publish --access public --provenance --no-git-checks --config.minimum-release-age=0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
 
-      # A workspace publish is not atomic: the renderer goes out before the bundle
-      # that depends on it, so a failure in between leaves one package published and
-      # the other not, and a published version cannot be replaced. This turns that
-      # into a red release rather than something found later by someone whose
-      # install half-resolves.
-      - name: the registry must now serve what was tagged
+      - name: wait for a coherent public registry release
         run: node tools/verify-published.mjs
 
-# Release creation is separate from publishing so the npm job never receives a
-# token that can write to the repository. That keeps a compromised publish step
-# from being able to create releases or modify repository state.
+  # Release creation is separate from both publishing and registry reads. It is the
+  # only ordinary job with contents: write; a compromised npm or registry-read step
+  # cannot create a release or modify repository state.
   github-release:
     name: create GitHub Release
+    if: github.event_name == 'push'
+    needs: verify-registry
     runs-on: ubuntu-latest
-    needs: publish
-
-    # Only this job gets write access; creating the GitHub Release needs it while
-    # the publish job keeps contents: read so a compromised publish step still
-    # cannot write to the repo.
     permissions:
       contents: write # create the GitHub Release after npm verification
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
-      # --generate-notes builds the body from commits between the previous tag
-      # and this one, grouped by conventional-commit prefix. --verify-tag aborts
-      # if the tag does not exist, which would mean publishing ran from something
-      # other than a tag push.
-      - name: create release from tag
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: create or reuse the release for this tag
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
-        run: gh release create "$RELEASE_TAG" --generate-notes --verify-tag
+        run: node tools/ensure-github-release.mjs
+
+  # Manual recovery never checks out or executes a mutable main tree as the release
+  # subject. The workflow code stays at the reviewed dispatch ref; an exact-tag
+  # worktree is validated through RELEASE_ROOT. No install, build, OIDC exchange,
+  # npm publish, tag creation, or tag mutation occurs in this path.
+  recover-existing-tag:
+    name: verify existing tag recovery
+    if: github.event_name == 'workflow_dispatch' && inputs.recovery-tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Keep validation tools on the exact reviewed dispatch commit while the
+          # tagged worktree remains the release subject.
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: validate and check out the exact existing tag
+        env:
+          RECOVERY_TAG: ${{ inputs.recovery-tag }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [ "$WORKFLOW_REF" != 'refs/heads/main' ]; then
+            printf '%s\n' 'Existing-tag recovery must be dispatched from reviewed main.' >&2
+            exit 1
+          fi
+          if ! RELEASE_TAG="$RECOVERY_TAG" node tools/release-version.mjs; then
+            printf 'recovery-tag must be an explicit stable release tag, got %s\n' "$RECOVERY_TAG" >&2
+            exit 1
+          fi
+          if ! git ls-remote --exit-code origin "refs/tags/$RECOVERY_TAG" >/dev/null; then
+            printf 'recovery-tag %s does not exist on origin; no tag will be created.\n' "$RECOVERY_TAG" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin "refs/tags/$RECOVERY_TAG:refs/tags/$RECOVERY_TAG" main:refs/remotes/origin/main
+          TAG_ROOT="$RUNNER_TEMP/dshline-release-tag"
+          git worktree add --detach "$TAG_ROOT" "refs/tags/$RECOVERY_TAG"
+          TAG_COMMIT="$(git -C "$TAG_ROOT" rev-parse HEAD)"
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" refs/remotes/origin/main; then
+            printf 'recovery-tag %s is not reachable from origin/main; refusing recovery.\n' "$RECOVERY_TAG" >&2
+            exit 1
+          fi
+          printf 'tag=%s\ncommit=%s\nroot=%s\n' "$RECOVERY_TAG" "$TAG_COMMIT" "$TAG_ROOT"
+          printf 'TAG_ROOT=%s\n' "$TAG_ROOT" >> "$GITHUB_ENV"
+
+      - name: the tagged tree must match the recovery tag
+        env:
+          RELEASE_TAG: ${{ inputs.recovery-tag }}
+        run: RELEASE_ROOT="$TAG_ROOT" node tools/check-release-tag.mjs
+
+      - name: the tagged tree must use one immutable Harness generation
+        run: RELEASE_ROOT="$TAG_ROOT" node tools/harness-target.mjs
+
+      - name: both exact npm versions and the coherent release must be visible
+        env:
+          RELEASE_RECOVERY: 'true'
+        run: RELEASE_ROOT="$TAG_ROOT" node tools/verify-published.mjs
+
+  recover-github-release:
+    name: create recovered GitHub Release
+    if: github.event_name == 'workflow_dispatch' && inputs.recovery-tag != '' && github.ref == 'refs/heads/main'
+    needs: recover-existing-tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # the only permission needed to create the missing Release
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Keep the writer on the exact reviewed workflow commit selected by
+          # dispatch; `main` can advance while the read-only preflight runs.
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: create or reuse the Release for the existing tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.recovery-tag }}
+        run: node tools/ensure-github-release.mjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,6 +154,9 @@ jobs:
           name: dshline-npm-packages
           path: ${{ runner.temp }}/dshline-npm-packages
 
+      - name: the default Harness install must still be the adopted generation
+        run: node tools/check-release-harness.mjs
+
       - name: npm must trust this workflow for both packages
         run: node tools/check-trusted-publishers.mjs
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -28,7 +28,10 @@ concurrency:
 jobs:
   version:
     name: open version PR
-    if: github.event_name != 'pull_request'
+    # A manual run is an operator action, not permission to execute a branch's
+    # changesets or create-pull-request code. Recovery is tag-only, and normal
+    # versioning is accepted only from the reviewed main workflow.
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.recovery-commit == '')
     runs-on: ubuntu-latest
     # VERSION_TOKEN supplies the two write scopes needed for the generated
     # branch and PR. The built-in token stays read-only, so a compromised
@@ -41,6 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Use the exact reviewed event commit, not a branch that can move.
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       # README.md documents Changesets; it is not a release record. Looking for
@@ -84,6 +89,8 @@ jobs:
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: steps.check-changesets.outputs.has-changesets == 'true'
+        with:
+          version: 11.22.0
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: steps.check-changesets.outputs.has-changesets == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,10 +333,19 @@ GitHub Release. Configure both tokens before the first version run.
 The tag handoff refuses to create a second tag while a publish run is queued or
 running. Finish that release first; GitHub keeps only one pending run in a
 concurrency group and would otherwise silently discard an intermediate version.
-If a publish fails after only one package lands, correct the missing package's
-trusted-publisher mapping and rerun that same tagged workflow. Its publish-only
-release-age override lets pnpm see and skip the package already on npm; never create
-a replacement tag for a half-release.
+The publish job only crosses npm's irreversible boundary; a separate registry job
+waits for npm to serve the accepted versions, so rerunning failed verification never
+runs `npm publish` again. If publication fails after only one package lands, correct
+the missing package's trusted-publisher mapping and rerun that same tagged workflow:
+its per-package preflight skips a visible exact version and treats only npm's exact
+accepted/staged conflict as already accepted. Never create a replacement tag for a
+half-release.
+
+To recover a missing GitHub Release after both exact npm versions are visible, open
+**Actions → publish → Run workflow** from `main`, leave trusted-publisher mode
+empty, and enter the existing tag in **recovery-tag**. Recovery checks out that tag
+and performs read-only release checks before the contents-scoped job creates or
+reuses its generated-notes Release; it never publishes npm packages or moves a tag.
 
 If the Version Packages PR was merged but its tag job was skipped or failed before
 creating a tag, open **Actions → version → Run workflow**, select `main`, and enter

--- a/tools/check-release-harness.mjs
+++ b/tools/check-release-harness.mjs
@@ -167,7 +167,7 @@ export function formatChannelStatus(result) {
 }
 
 if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], 'file:').href) {
-  const target = await readTarget()
+  const target = await readTarget(process.env.RELEASE_ROOT)
   const { code, text } = formatChannelStatus(releaseChannelStatus(target.version))
   process[code === 0 ? 'stdout' : 'stderr'].write(text)
   process.exit(code)

--- a/tools/check-release-harness.spec.mjs
+++ b/tools/check-release-harness.spec.mjs
@@ -290,17 +290,19 @@ describe('boundary B: the gate precedes the immutable tag', () => {
 })
 
 describe('boundary C: the gate precedes the first irreversible npm write', () => {
-  it('runs before anything is published', async () => {
-    const job = extractJob(await readWorkflow('publish.yml'), 'release-preflight')
-    const publisher = extractJob(await readWorkflow('publish.yml'), 'publish-to-npm')
-    const gate = stepIndex(job, GUARD)
+  it('checks the release channel in both jobs and immediately before publishing', async () => {
+    const workflow = await readWorkflow('publish.yml')
+    const preflight = extractJob(workflow, 'release-preflight')
+    const publisher = extractJob(workflow, 'publish-to-npm')
+    const preflightGate = stepIndex(preflight, GUARD)
+    const publisherGate = stepIndex(publisher, GUARD)
     const publishing = stepIndex(publisher, 'node tools/publish-packages.mjs')
-    expect(gate, 'the preflight job must run the release gate').toBeGreaterThanOrEqual(0)
-    expect(publishing, 'the publish job must still publish').toBeGreaterThanOrEqual(0)
+    expect(preflightGate, 'the preflight job must run the release gate').toBeGreaterThanOrEqual(0)
+    expect(publisherGate, 'the publish job must re-check the release channel').toBeGreaterThanOrEqual(0)
+    expect(publishing, 'the publish job must still publish').toBeGreaterThan(publisherGate)
     expect(publisher).toContain('needs: release-preflight')
-    expect(publisher).not.toContain(GUARD)
-    // The job dependency is the cross-job ordering; step indexes from different
-    // jobs are not comparable.
+    const beforePublisherGate = jobSteps(publisher).slice(0, publisherGate).join('\n')
+    expect(beforePublisherGate).not.toMatch(/publish-packages|pnpm publish|npm publish/u)
   })
 })
 

--- a/tools/check-release-harness.spec.mjs
+++ b/tools/check-release-harness.spec.mjs
@@ -291,14 +291,16 @@ describe('boundary B: the gate precedes the immutable tag', () => {
 
 describe('boundary C: the gate precedes the first irreversible npm write', () => {
   it('runs before anything is published', async () => {
-    const job = extractJob(await readWorkflow('publish.yml'), 'publish')
+    const job = extractJob(await readWorkflow('publish.yml'), 'release-preflight')
+    const publisher = extractJob(await readWorkflow('publish.yml'), 'publish-to-npm')
     const gate = stepIndex(job, GUARD)
-    const publishing = stepIndex(job, 'pnpm -r publish')
-    expect(gate, 'the publish job must run the release gate').toBeGreaterThanOrEqual(0)
+    const publishing = stepIndex(publisher, 'node tools/publish-packages.mjs')
+    expect(gate, 'the preflight job must run the release gate').toBeGreaterThanOrEqual(0)
     expect(publishing, 'the publish job must still publish').toBeGreaterThanOrEqual(0)
-    // Defense in depth: `latest` can move between the green Version Packages
-    // PR, the tag, and this run.
-    expect(gate).toBeLessThan(publishing)
+    expect(publisher).toContain('needs: release-preflight')
+    expect(publisher).not.toContain(GUARD)
+    // The job dependency is the cross-job ordering; step indexes from different
+    // jobs are not comparable.
   })
 })
 

--- a/tools/check-release-tag.mjs
+++ b/tools/check-release-tag.mjs
@@ -13,9 +13,19 @@
  */
 
 import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 
-/** Workspace packages that get published, in dependency order. */
-const PACKAGES = ['packages/renderer', 'packages/dshline']
+import { NPM_REGISTRY, PUBLISHED_PACKAGES } from './verify-published.mjs'
+import { VERSION_SHAPE, versionFromReleaseTag } from './release-version.mjs'
+
+export { versionFromReleaseTag }
+
+/**
+ * Root of the tree being checked. Recovery uses the workflow checkout plus an
+ * exact-tag worktree, so new validation code can inspect the immutable tag
+ * without pretending that the tag already contains this recovery workflow.
+ */
+const root = resolve(process.env.RELEASE_ROOT ?? process.cwd())
 
 /**
  * A version the SOURCE embeds rather than reads from its manifest.
@@ -27,37 +37,64 @@ const PACKAGES = ['packages/renderer', 'packages/dshline']
  */
 const EMBEDDED = {
   path: 'packages/dshline/src/index.ts',
-  pattern: /^const VERSION = '(?<version>[^']+)'$/mu,
+  pattern: /^const VERSION = '(?<version>[^']+)'$/mgu,
 }
 
-const tag = process.env.RELEASE_TAG ?? ''
-const expected = tag.replace(/^v/u, '')
-if (expected === '') {
-  process.stderr.write('check-release-tag: RELEASE_TAG is empty; expected something like v0.1.0\n')
-  process.exit(2)
-}
+if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  const tag = process.env.RELEASE_TAG ?? ''
+  let expected
+  try {
+    expected = versionFromReleaseTag(tag)
+  } catch (error) {
+    process.stderr.write(`check-release-tag: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(2)
+  }
 
-const mismatched = []
-for (const directory of PACKAGES) {
-  const manifest = JSON.parse(readFileSync(`${directory}/package.json`, 'utf8'))
-  if (manifest.version !== expected) mismatched.push(`${manifest.name} is ${manifest.version}`)
-}
+  const mismatched = []
+  for (const definition of PUBLISHED_PACKAGES) {
+    const manifest = JSON.parse(readFileSync(join(root, definition.directory, 'package.json'), 'utf8'))
+    if (manifest.name !== definition.name) mismatched.push(`${definition.directory} is ${manifest.name}, expected ${definition.name}`)
+    if (typeof manifest.version !== 'string' || !VERSION_SHAPE.test(manifest.version) || manifest.version !== expected) {
+      mismatched.push(`${definition.name} is ${manifest.version}`)
+    }
+    if (manifest.publishConfig !== undefined && (manifest.publishConfig === null || typeof manifest.publishConfig !== 'object' || Array.isArray(manifest.publishConfig))) {
+      mismatched.push(`${definition.name} has an invalid publishConfig`)
+    }
+    if (manifest.publishConfig?.name !== undefined && manifest.publishConfig.name !== definition.name) {
+      mismatched.push(`${definition.name} has mismatched publishConfig.name`)
+    }
+    if (manifest.publishConfig?.registry !== undefined && manifest.publishConfig.registry !== NPM_REGISTRY) {
+      mismatched.push(`${definition.name} overrides the npm registry`)
+    }
+    if (manifest.publishConfig?.tag !== undefined && manifest.publishConfig.tag !== 'latest') {
+      mismatched.push(`${definition.name} overrides the latest dist-tag`)
+    }
+    if (manifest.publishConfig?.provenance === false) {
+      mismatched.push(`${definition.name} disables provenance`)
+    }
+    if (manifest.publishConfig?.directory !== undefined || manifest.publishConfig?.linkDirectory !== undefined) {
+      mismatched.push(`${definition.name} overrides the packed directory`)
+    }
+  }
 
-const embedded = EMBEDDED.pattern.exec(readFileSync(EMBEDDED.path, 'utf8'))
-if (embedded?.groups?.version === undefined) {
-  process.stderr.write(`check-release-tag: no VERSION constant found in ${EMBEDDED.path}\n`)
-  process.exit(2)
-}
-if (embedded.groups.version !== expected) {
-  mismatched.push(`the banner in ${EMBEDDED.path} says ${embedded.groups.version}`)
-}
+  const source = readFileSync(join(root, EMBEDDED.path), 'utf8')
+  const embeddedMatches = [...source.matchAll(EMBEDDED.pattern)]
+  if (embeddedMatches.length !== 1 || embeddedMatches[0]?.groups?.version === undefined) {
+    process.stderr.write(`check-release-tag: expected exactly one VERSION constant in ${EMBEDDED.path}\n`)
+    process.exit(2)
+  }
+  const embedded = embeddedMatches[0]
+  if (embedded.groups.version !== expected) {
+    mismatched.push(`the banner in ${EMBEDDED.path} says ${embedded.groups.version}`)
+  }
 
-if (mismatched.length > 0) {
-  process.stderr.write(
-    `check-release-tag: tag ${tag} expects version ${expected}, but ${mismatched.join(', ')}.\n`
-    + 'Bump the manifests and re-tag; a published version cannot be taken back.\n',
-  )
-  process.exit(1)
-}
+  if (mismatched.length > 0) {
+    process.stderr.write(
+      `check-release-tag: tag ${tag} expects version ${expected}, but ${mismatched.join(', ')}.\n`
+      + 'Bump the manifests and re-tag; a published version cannot be taken back.\n',
+    )
+    process.exit(1)
+  }
 
-process.stdout.write(`check-release-tag: ${tag} matches ${expected} in ${String(PACKAGES.length)} packages\n`)
+  process.stdout.write(`check-release-tag: ${tag} matches ${expected} in ${String(PUBLISHED_PACKAGES.length)} packages\n`)
+}

--- a/tools/check-release-tag.spec.mjs
+++ b/tools/check-release-tag.spec.mjs
@@ -1,0 +1,26 @@
+import { execFileSync } from 'node:child_process'
+
+import { describe, expect, it } from 'vitest'
+import { versionFromReleaseTag } from './check-release-tag.mjs'
+
+describe('versionFromReleaseTag()', () => {
+  it('accepts immutable stable tags and rejects prereleases/build metadata', () => {
+    expect(versionFromReleaseTag('v0.20.0')).toBe('0.20.0')
+    expect(() => versionFromReleaseTag('v1.2.3-rc.1')).toThrow()
+    expect(() => versionFromReleaseTag('v1.2.3+build.1')).toThrow()
+  })
+
+  it('rejects a branch, empty input, or shell-shaped tag', () => {
+    for (const value of ['', 'main', 'v0.20.0/../../main', 'v0.20.0\n--flag']) {
+      expect(() => versionFromReleaseTag(value)).toThrow()
+    }
+  })
+
+  it('runs the coherent tagged-tree CLI success path', () => {
+    const output = execFileSync(process.execPath, ['tools/check-release-tag.mjs'], {
+      env: { ...process.env, RELEASE_TAG: 'v0.20.0' },
+      encoding: 'utf8',
+    })
+    expect(output).toContain('matches 0.20.0 in 2 packages')
+  })
+})

--- a/tools/check-trusted-publishers.mjs
+++ b/tools/check-trusted-publishers.mjs
@@ -9,11 +9,10 @@
  * @module tools/check-trusted-publishers
  */
 
-/** Published workspace packages, in dependency order. */
-export const PUBLISHED_PACKAGES = [
-  '@dshline/renderer',
-  '@dshline/dshline',
-]
+import { PUBLISHED_PACKAGES as RELEASE_PACKAGES } from './verify-published.mjs'
+
+/** Published workspace package names, shared with registry and publish gates. */
+export const PUBLISHED_PACKAGES = Object.freeze(RELEASE_PACKAGES.map(item => item.name))
 
 /** npm's expected audience for a GitHub-issued identity token. */
 const NPM_AUDIENCE = 'npm:registry.npmjs.org'
@@ -47,11 +46,19 @@ async function fetchJson(fetchImpl, url, init, label) {
 export async function checkTrustedPublishers({ env = process.env, fetchImpl = fetch } = {}) {
   const requestUrl = env.ACTIONS_ID_TOKEN_REQUEST_URL
   const requestToken = env.ACTIONS_ID_TOKEN_REQUEST_TOKEN
-  if (requestUrl === undefined || requestToken === undefined) {
+  if (typeof requestUrl !== 'string' || requestUrl === '' || typeof requestToken !== 'string' || requestToken === '') {
     throw new Error('GitHub OIDC is unavailable; the job needs id-token: write')
   }
 
-  const identityUrl = new URL(requestUrl)
+  let identityUrl
+  try {
+    identityUrl = new URL(requestUrl)
+  } catch {
+    throw new Error('GitHub OIDC request URL is invalid')
+  }
+  if (identityUrl.protocol !== 'https:' || !identityUrl.hostname.endsWith('.actions.githubusercontent.com')) {
+    throw new Error('GitHub OIDC request URL must use the GitHub Actions HTTPS issuer')
+  }
   identityUrl.searchParams.set('audience', NPM_AUDIENCE)
   const identity = await fetchJson(fetchImpl, identityUrl, {
     headers: {

--- a/tools/check-trusted-publishers.spec.mjs
+++ b/tools/check-trusted-publishers.spec.mjs
@@ -11,7 +11,7 @@ function response(value, status = 200) {
 }
 
 const ENV = {
-  ACTIONS_ID_TOKEN_REQUEST_URL: 'https://actions.example.test/id-token?api-version=1',
+  ACTIONS_ID_TOKEN_REQUEST_URL: 'https://pipelines.actions.githubusercontent.com/id-token?api-version=1',
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-request-token',
 }
 
@@ -52,5 +52,13 @@ describe('checkTrustedPublishers()', () => {
   it('requires the workflow OIDC permission', async () => {
     await expect(checkTrustedPublishers({ env: {}, fetchImpl: vi.fn() }))
       .rejects.toThrow('the job needs id-token: write')
+    await expect(checkTrustedPublishers({
+      env: { ...ENV, ACTIONS_ID_TOKEN_REQUEST_TOKEN: '' },
+      fetchImpl: vi.fn(),
+    })).rejects.toThrow('the job needs id-token: write')
+    await expect(checkTrustedPublishers({
+      env: { ...ENV, ACTIONS_ID_TOKEN_REQUEST_URL: 'https://evil.example.test/token' },
+      fetchImpl: vi.fn(),
+    })).rejects.toThrow('GitHub Actions HTTPS issuer')
   })
 })

--- a/tools/ensure-github-release.mjs
+++ b/tools/ensure-github-release.mjs
@@ -1,0 +1,314 @@
+/**
+ * Create a GitHub Release for an immutable tag, or safely reuse the existing one.
+ *
+ * The read is explicit rather than `gh release view || gh release create`: an
+ * authentication or GitHub outage must never be mistaken for an absent release.
+ * A create race is re-read and accepted only when the resulting object names the
+ * exact requested tag. Existing releases are never deleted or rewritten. Creation
+ * uses GitHub CLI's `--verify-tag`, which refuses to create a tag when the immutable
+ * reference is absent instead of relying on the Releases API's tag auto-creation.
+ *
+ * @module tools/ensure-github-release
+ */
+
+import { execFileSync } from 'node:child_process'
+
+import { validateReleaseTag, versionFromReleaseTag } from './release-version.mjs'
+
+export { validateReleaseTag }
+
+/** GitHub's default API origin when Actions does not override it. */
+const DEFAULT_API_URL = 'https://api.github.com'
+
+/**
+ * Read one release object from GitHub.
+ * @param options - API access and injected fetch.
+ * @param options.apiUrl - GitHub API origin.
+ * @param options.repository - owner/name repository.
+ * @param options.tag - immutable release tag.
+ * @param options.token - GitHub token.
+ * @param options.fetchImpl - fetch implementation.
+ * @returns whether the release is absent or an existing published release.
+ */
+export async function readGithubRelease({
+  apiUrl = DEFAULT_API_URL,
+  repository,
+  tag,
+  token,
+  fetchImpl = fetch,
+}) {
+  validateReleaseTag(tag)
+  if (typeof repository !== 'string' || !/^[^/]+\/[^/]+$/u.test(repository)) {
+    throw new Error('GITHUB_REPOSITORY must be owner/name')
+  }
+  if (typeof token !== 'string' || token === '') throw new Error('GH_TOKEN is required to create or inspect a GitHub Release')
+  let response
+  try {
+    response = await fetchImpl(
+      `${apiUrl.replace(/\/$/u, '')}/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    )
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(`GitHub Release lookup failed before a response: ${reason}`)
+  }
+  if (response.status === 404) return { kind: 'absent' }
+  if (!response.ok) throw new Error(`GitHub Release lookup returned HTTP ${String(response.status)}`)
+  let release
+  try {
+    release = await response.json()
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(`GitHub Release lookup returned invalid JSON: ${reason}`)
+  }
+  if (release === null || typeof release !== 'object' || release.tag_name !== tag) {
+    throw new Error(`GitHub returned a Release that does not point at ${tag}`)
+  }
+  if (release.draft !== false) {
+    throw new Error(`GitHub Release ${tag} does not have the required published state`)
+  }
+  versionFromReleaseTag(tag)
+  const expectedPrerelease = false
+  if (release.prerelease !== expectedPrerelease) {
+    throw new Error(`GitHub Release ${tag} has the wrong prerelease state`)
+  }
+  return { kind: 'existing', release }
+}
+
+/**
+ * Confirm the tag exists before asking GitHub to create a Release. The API would
+ * otherwise create a new tag at its default target, which is forbidden here.
+ * @param options - API access and injected fetch.
+ * @param options.apiUrl - GitHub API origin.
+ * @param options.repository - owner/name repository.
+ * @param options.tag - immutable release tag.
+ * @param options.token - GitHub token.
+ * @param options.fetchImpl - fetch implementation.
+ * @returns nothing when the exact tag reference exists.
+ */
+export async function requireGithubTag({
+  apiUrl = DEFAULT_API_URL,
+  repository,
+  tag,
+  token,
+  fetchImpl = fetch,
+}) {
+  validateReleaseTag(tag)
+  if (typeof repository !== 'string' || !/^[^/]+\/[^/]+$/u.test(repository)) {
+    throw new Error('GITHUB_REPOSITORY must be owner/name')
+  }
+  if (typeof token !== 'string' || token === '') throw new Error('GH_TOKEN is required to inspect a GitHub tag')
+  let response
+  try {
+    response = await fetchImpl(
+      `${apiUrl.replace(/\/$/u, '')}/repos/${repository}/git/ref/tags/${encodeURIComponent(tag)}`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    )
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(`GitHub tag lookup failed before a response: ${reason}`)
+  }
+  if (response.status === 404) throw new Error(`GitHub tag ${tag} does not exist; refusing to create it`)
+  if (!response.ok) throw new Error(`GitHub tag lookup returned HTTP ${String(response.status)}`)
+  let reference
+  try {
+    reference = await response.json()
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    throw new Error(`GitHub tag lookup returned invalid JSON: ${reason}`)
+  }
+  if (
+    reference === null
+    || typeof reference !== 'object'
+    || reference.ref !== `refs/tags/${tag}`
+    || reference.object === null
+    || typeof reference.object !== 'object'
+    || typeof reference.object.sha !== 'string'
+    || !['commit', 'tag'].includes(reference.object.type)
+  ) {
+    throw new Error(`GitHub returned a tag reference that does not point at ${tag}`)
+  }
+  return reference
+}
+
+/**
+ * Error for the one create response that may be caused by a concurrent creator.
+ */
+export class ReleaseCreateError extends Error {
+  /**
+   * @param kind - whether a second read can safely resolve the outcome.
+   * @param message - safe diagnostic.
+   */
+  constructor(kind, message) {
+    super(message)
+    this.name = 'ReleaseCreateError'
+    this.kind = kind
+  }
+}
+
+/**
+ * Create a release with the existing generated-notes and immutable-tag semantics.
+ * @param options - release tag and GitHub token.
+ * @param options.apiUrl - GitHub API origin.
+ * @param options.repository - owner/name repository.
+ * @param options.tag - immutable release tag.
+ * @param options.token - GitHub token.
+ * @param options.exec - command runner, injectable for tests.
+ * @returns a placeholder release object after gh succeeds.
+ * @throws {ReleaseCreateError} when gh reports a create race.
+ */
+export function createGithubRelease({
+  apiUrl = DEFAULT_API_URL,
+  repository,
+  tag,
+  token,
+  exec = execFileSync,
+}) {
+  versionFromReleaseTag(tag)
+  if (typeof repository !== 'string' || !/^[^/]+\/[^/]+$/u.test(repository)) {
+    throw new Error('GITHUB_REPOSITORY must be owner/name')
+  }
+  if (typeof token !== 'string' || token === '') throw new Error('GH_TOKEN is required to create a GitHub Release')
+  const args = ['release', 'create', tag, '--repo', repository, '--generate-notes', '--verify-tag']
+  const apiHost = new URL(apiUrl).hostname
+  const env = { ...process.env, GH_TOKEN: token }
+  if (apiHost !== 'api.github.com') env.GH_HOST = apiHost
+  else delete env.GH_HOST
+  try {
+    exec('gh', args, {
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (error) {
+    const output = [error?.stdout, error?.stderr, error?.message]
+      .filter(value => value !== undefined)
+      .map(String)
+      .join('\n')
+    const duplicateRelease = /(?:\b409\b|\b422\b)[\s\S]*(?:already_exists[\s\S]*tag_name|tag_name[\s\S]*already_exists|release[\s\S]*already exists[\s\S]*tag|tag[\s\S]*already exists)/iu
+    const mixedFatal = /\b(?:401|403|5\d\d)\b|authentication|permission denied|forbidden/iu.test(output)
+    if (duplicateRelease.test(output) && !mixedFatal) {
+      throw new ReleaseCreateError('conflict', 'GitHub Release creation raced another creator')
+    }
+    throw error
+  }
+  return {
+    tag_name: tag,
+    draft: false,
+    prerelease: false,
+  }
+}
+
+/**
+ * Ensure one valid GitHub Release exists without rewriting an existing object.
+ * @param options - tag, repository, token, API, and injectable operations.
+ * @param options.apiUrl - GitHub API origin.
+ * @param options.repository - owner/name repository.
+ * @param options.tag - immutable release tag.
+ * @param options.token - GitHub token.
+ * @param options.fetchImpl - fetch implementation.
+ * @param options.createRelease - release creator, injected for tests.
+ * @param options.write - status logger.
+ * @returns whether the object was reused or newly created.
+ */
+export async function ensureGithubRelease({
+  apiUrl = process.env.GITHUB_API_URL ?? DEFAULT_API_URL,
+  repository = process.env.GITHUB_REPOSITORY,
+  tag = process.env.RELEASE_TAG,
+  token = process.env.GH_TOKEN,
+  fetchImpl = fetch,
+  createRelease = createGithubRelease,
+  sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)),
+  readbackAttempts = 3,
+  readbackDelayMs = 1000,
+  write = text => process.stdout.write(text),
+} = {}) {
+  if (repository === undefined || tag === undefined || token === undefined) {
+    throw new Error('GITHUB_REPOSITORY, RELEASE_TAG, and GH_TOKEN are required')
+  }
+  if (!Number.isSafeInteger(readbackAttempts) || readbackAttempts < 1 || !Number.isSafeInteger(readbackDelayMs) || readbackDelayMs < 0) {
+    throw new Error('GitHub Release readback bounds are invalid')
+  }
+  const request = { apiUrl, repository, tag, token, fetchImpl }
+  const readbackRelease = async () => {
+    let result
+    for (let attempt = 0; attempt < readbackAttempts; attempt += 1) {
+      result = await readGithubRelease(request)
+      if (result.kind === 'existing' || attempt + 1 === readbackAttempts) return result
+      await sleep(readbackDelayMs)
+    }
+    return result
+  }
+  const tagReference = await requireGithubTag(request)
+  const existing = await readGithubRelease(request)
+  if (existing.kind === 'existing') {
+    write(`ensure-github-release: ${tag} already has a valid GitHub Release; leaving it unchanged\n`)
+    return { kind: 'existing', release: existing.release }
+  }
+
+  try {
+    const beforeCreateTag = await requireGithubTag(request)
+    if (
+      beforeCreateTag.object.sha !== tagReference.object.sha
+      || beforeCreateTag.object.type !== tagReference.object.type
+    ) {
+      throw new Error(`GitHub tag ${tag} changed during release creation; refusing to create a Release`)
+    }
+    const release = await createRelease(request)
+    const expectedPrerelease = false
+    if (
+      release === null
+      || typeof release !== 'object'
+      || release.tag_name !== tag
+      || release.draft === true
+      || (release.prerelease !== undefined && release.prerelease !== expectedPrerelease)
+    ) {
+      throw new Error(`release creation did not return a valid ${tag} release`)
+    }
+    const afterCreateTag = await requireGithubTag(request)
+    if (
+      afterCreateTag.object.sha !== tagReference.object.sha
+      || afterCreateTag.object.type !== tagReference.object.type
+    ) {
+      throw new Error(`GitHub tag ${tag} changed during Release creation; refusing to continue`)
+    }
+    const afterCreate = await readbackRelease()
+    if (afterCreate.kind !== 'existing') {
+      throw new Error(`GitHub did not return the created Release for ${tag}`)
+    }
+    write(`ensure-github-release: created the GitHub Release for ${tag}\n`)
+    return { kind: 'created', release: afterCreate.release }
+  } catch (createError) {
+    // Only a documented create conflict is a race. Re-read and accept the result
+    // only if GitHub now serves this exact tag; auth and other failures stay red.
+    if (!(createError instanceof ReleaseCreateError) || createError.kind !== 'conflict') throw createError
+    const afterRace = await readbackRelease()
+    if (afterRace.kind === 'existing') {
+      write(`ensure-github-release: ${tag} was created concurrently; leaving it unchanged\n`)
+      return { kind: 'existing', release: afterRace.release }
+    }
+    throw createError
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  try {
+    await ensureGithubRelease()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`ensure-github-release: ${message}\n`)
+    process.exit(1)
+  }
+}

--- a/tools/ensure-github-release.spec.mjs
+++ b/tools/ensure-github-release.spec.mjs
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createGithubRelease,
+  ensureGithubRelease,
+  readGithubRelease,
+  ReleaseCreateError,
+  validateReleaseTag,
+} from './ensure-github-release.mjs'
+
+const OPTIONS = {
+  apiUrl: 'https://api.github.test',
+  repository: 'riesbri/dshline',
+  tag: 'v0.20.0',
+  token: 'github-token',
+}
+
+/** Minimal GitHub API response for the release helper tests. */
+function response(body, status) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }
+}
+
+describe('validateReleaseTag()', () => {
+  it('accepts only stable release tags', () => {
+    expect(validateReleaseTag('v0.20.0')).toBe('v0.20.0')
+    expect(() => validateReleaseTag('v1.2.3-rc.1')).toThrow()
+  })
+
+  it('rejects unsafe or non-version input', () => {
+    for (const tag of ['', 'main', 'v0.20.0/../../main', 'v0.20.0\n--repo']) {
+      expect(() => validateReleaseTag(tag)).toThrow()
+    }
+  })
+})
+
+describe('ensureGithubRelease()', () => {
+  it('does not POST or rewrite an existing release for the exact tag', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+      .mockResolvedValueOnce(response({ tag_name: OPTIONS.tag, draft: false, prerelease: false }, 200))
+    const createRelease = vi.fn()
+
+    await expect(ensureGithubRelease({ ...OPTIONS, fetchImpl, createRelease, write: () => {} }))
+      .resolves.toMatchObject({ kind: 'existing' })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(createRelease).not.toHaveBeenCalled()
+  })
+
+  it('creates only after an explicit release 404 and existing tag response', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+      .mockResolvedValueOnce(response({ message: 'Not Found' }, 404))
+      .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+      .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+      .mockResolvedValueOnce(response({ tag_name: OPTIONS.tag, draft: false, prerelease: false }, 200))
+    const createRelease = vi.fn(async request => ({ tag_name: request.tag, draft: false, prerelease: false }))
+
+    await expect(ensureGithubRelease({ ...OPTIONS, fetchImpl, createRelease, write: () => {} }))
+      .resolves.toMatchObject({ kind: 'created' })
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining(OPTIONS))
+  })
+
+  it('bounds post-create readback while tolerating GitHub Release propagation', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+      .mockResolvedValueOnce(response({ message: 'Not Found' }, 404))
+      .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+      .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+      .mockResolvedValueOnce(response({ message: 'Not Found' }, 404))
+      .mockResolvedValueOnce(response({ tag_name: OPTIONS.tag, draft: false, prerelease: false }, 200))
+    const sleep = vi.fn(async () => {})
+    await expect(ensureGithubRelease({
+      ...OPTIONS,
+      fetchImpl,
+      createRelease: async request => ({ tag_name: request.tag, draft: false, prerelease: false }),
+      sleep,
+      readbackAttempts: 2,
+      write: () => {},
+    })).resolves.toMatchObject({ kind: 'created' })
+    expect(sleep).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles a create race by accepting the exact release that appeared', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+      .mockResolvedValueOnce(response({ message: 'Not Found' }, 404))
+      .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+      .mockResolvedValueOnce(response({ tag_name: OPTIONS.tag, draft: false, prerelease: false }, 200))
+    const createRelease = vi.fn(async () => {
+      throw new ReleaseCreateError('conflict', 'GitHub Release creation raced another creator')
+    })
+
+    await expect(ensureGithubRelease({ ...OPTIONS, fetchImpl, createRelease, write: () => {} }))
+      .resolves.toMatchObject({ kind: 'existing' })
+    expect(fetchImpl).toHaveBeenCalledTimes(4)
+  })
+
+  it('uses generated notes, an explicit repository, and verify-tag without creating a tag', () => {
+    const exec = vi.fn()
+    const release = createGithubRelease({ ...OPTIONS, exec })
+    expect(release).toMatchObject({ tag_name: OPTIONS.tag, draft: false, prerelease: false })
+    expect(exec).toHaveBeenCalledWith('gh', [
+      'release', 'create', OPTIONS.tag,
+      '--repo', OPTIONS.repository,
+      '--generate-notes', '--verify-tag',
+    ], expect.objectContaining({ encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }))
+    vi.stubEnv('GH_HOST', 'evil.example.test')
+    const isolatedExec = vi.fn()
+    createGithubRelease({ ...OPTIONS, apiUrl: 'https://api.github.com', exec: isolatedExec })
+    expect(isolatedExec.mock.calls[0][2].env.GH_HOST).toBeUndefined()
+    vi.unstubAllEnvs()
+  })
+
+  it('classifies only the exact duplicate-release create response as a race', () => {
+    const duplicate = () => {
+      const error = new Error('gh failed')
+      error.stderr = "HTTP 422: Validation Failed {resource:'Release', code:'already_exists', field:'tag_name'}"
+      throw error
+    }
+    expect(() => createGithubRelease({ ...OPTIONS, exec: duplicate })).toThrow(ReleaseCreateError)
+    const unrelated = () => {
+      const error = new Error('gh failed')
+      error.stderr = 'HTTP 422: Validation Failed {resource:"Release", code:"invalid", field:"tag_name"}'
+      throw error
+    }
+    expect(() => createGithubRelease({ ...OPTIONS, exec: unrelated })).toThrow('gh failed')
+  })
+
+  it('fails closed on a lookup outage or malformed release', async () => {
+    await expect(ensureGithubRelease({
+      ...OPTIONS,
+      fetchImpl: async () => response({}, 500),
+      createRelease: vi.fn(),
+    })).rejects.toThrow('HTTP 500')
+    await expect(ensureGithubRelease({
+      ...OPTIONS,
+      fetchImpl: vi.fn()
+        .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+        .mockResolvedValueOnce(response({ tag_name: 'v0.19.0', draft: false, prerelease: false }, 200)),
+      createRelease: vi.fn(),
+    })).rejects.toThrow('does not point at v0.20.0')
+    await expect(ensureGithubRelease({
+      ...OPTIONS,
+      fetchImpl: vi.fn()
+        .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200))
+        .mockResolvedValueOnce(response({}, 404))
+        .mockResolvedValueOnce(response({ ref: `refs/tags/${OPTIONS.tag}`, object: { sha: 'tag-sha', type: 'tag' } }, 200)),
+      createRelease: vi.fn(async () => ({ tag_name: 'v0.19.0', draft: false, prerelease: false })),
+    })).rejects.toThrow('did not return a valid v0.20.0 release')
+    await expect(ensureGithubRelease({
+      ...OPTIONS,
+      fetchImpl: vi.fn()
+        .mockResolvedValueOnce(response({}, 404)),
+      createRelease: vi.fn(),
+    })).rejects.toThrow('does not exist; refusing to create it')
+  })
+
+  it('does not accept an existing draft as a completed public release', async () => {
+    await expect(readGithubRelease({
+      ...OPTIONS,
+      fetchImpl: async () => response({ tag_name: OPTIONS.tag, draft: true }, 200),
+    })).rejects.toThrow('published state')
+  })
+})

--- a/tools/harness-target.mjs
+++ b/tools/harness-target.mjs
@@ -39,10 +39,6 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const TARGET_FILE = join(repoRoot, 'HARNESS_TARGET')
-const BUNDLE_MANIFEST = join(repoRoot, 'packages', 'dshline', 'package.json')
-const WORKSPACE_MANIFEST = join(repoRoot, 'package.json')
-const MANIFESTS = [BUNDLE_MANIFEST, WORKSPACE_MANIFEST]
-
 /**
  * The same two manifests as path SEGMENTS, so a caller can resolve them
  * against a root other than this repository's. Only `pinTargetVersion` needs
@@ -51,6 +47,12 @@ const MANIFESTS = [BUNDLE_MANIFEST, WORKSPACE_MANIFEST]
  */
 const MANIFEST_PATHS = [['packages', 'dshline', 'package.json'], ['package.json']]
 const REGISTRY_HOST = 'https://registry.npmjs.org'
+const HARNESS_NUMERIC = '(?:0|[1-9][0-9]*)'
+const HARNESS_PRERELEASE = `(?:${HARNESS_NUMERIC}|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)`
+const HARNESS_VERSION = new RegExp(
+  `^${HARNESS_NUMERIC}\\.${HARNESS_NUMERIC}\\.${HARNESS_NUMERIC}(?:-${HARNESS_PRERELEASE}(?:\\.${HARNESS_PRERELEASE})*)?(?![\\s\\S])`,
+  'u',
+)
 
 /**
  * The package a consumer installs, and therefore the one whose publication
@@ -131,7 +133,7 @@ export function parseTarget(text) {
   // A shape check, not a semver engine: nothing here ever orders or compares
   // two versions, so this only rejects a typo that could never match a real
   // published version.
-  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(fields.version)) {
+  if (!HARNESS_VERSION.test(fields.version)) {
     throw new Error(`HARNESS_TARGET: version must look like 1.2.3 or 1.2.3-tag.4, got: ${fields.version}`)
   }
   return { revision: fields.revision, version: fields.version }
@@ -139,10 +141,11 @@ export function parseTarget(text) {
 
 /**
  * Read the adopted target from disk.
+ * @param root - repository root whose target file should be read.
  * @returns the adopted target.
  */
-export async function readTarget() {
-  return parseTarget(await readFile(TARGET_FILE, 'utf8'))
+export async function readTarget(root = repoRoot) {
+  return parseTarget(await readFile(join(root, 'HARNESS_TARGET'), 'utf8'))
 }
 
 /**
@@ -178,9 +181,12 @@ export function targetUpdates(dependencies, version) {
  * @throws when the manifest carries no version, which means the checkout is not what we think it is.
  */
 export function sourceVersion(manifest) {
+  if (manifest === null || typeof manifest !== 'object' || Array.isArray(manifest) || manifest.name !== '@deepseek-ai/dsh-root') {
+    throw new Error(`harness checkout root manifest must be @deepseek-ai/dsh-root (found ${JSON.stringify(manifest?.name ?? null)})`)
+  }
   const version = manifest.version
   if (typeof version !== 'string' || version === '') {
-    throw new Error(`harness checkout root manifest declares no version (found ${JSON.stringify(manifest.name ?? null)})`)
+    throw new Error(`harness checkout root manifest declares no version (found ${JSON.stringify(manifest.name)})`)
   }
   return version
 }
@@ -200,7 +206,13 @@ export function sourceVersion(manifest) {
  */
 export async function isPublished(name, version, fetchPackument = defaultFetchPackument) {
   const packument = await fetchPackument(name)
-  return Object.hasOwn(packument.versions ?? {}, version)
+  if (packument === null || typeof packument !== 'object' || Array.isArray(packument)) {
+    throw new Error(`registry returned an invalid packument for ${name}`)
+  }
+  if (packument.versions === null || typeof packument.versions !== 'object' || Array.isArray(packument.versions)) {
+    throw new Error(`registry returned an invalid versions map for ${name}`)
+  }
+  return Object.hasOwn(packument.versions, version)
 }
 
 /**
@@ -285,28 +297,21 @@ export function formatReport(target, problems) {
 /**
  * Collect every checked spec that is not literally the target version.
  * @param target - the adopted target.
+ * @param root - repository root whose manifests should be checked.
  * @returns one entry per disagreeing spec, with the manifest and field it came from.
  */
-async function collectProblems(target) {
+async function collectProblems(target, root = repoRoot) {
   const problems = []
-  for (const manifestPath of MANIFESTS) {
+  for (const relative of MANIFEST_PATHS) {
+    const manifestPath = join(root, ...relative)
     const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
     for (const field of CHECKED_FIELDS) {
       for (const update of targetUpdates(manifest[field] ?? {}, target.version)) {
-        problems.push({ manifest: relativeManifest(manifestPath), field, name: update.name, from: update.from })
+        problems.push({ manifest: relative.join('/'), field, name: update.name, from: update.from })
       }
     }
   }
   return problems
-}
-
-/**
- * A manifest path as it reads in a report, relative to the repository root.
- * @param manifestPath - the absolute path.
- * @returns the repository-relative path.
- */
-function relativeManifest(manifestPath) {
-  return manifestPath.slice(repoRoot.length + 1)
 }
 
 // Entry point: vitest imports the pure functions above, so the side-effecting
@@ -318,7 +323,8 @@ if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(
     process.stderr.write(usage)
     process.exit(2)
   }
-  const target = await readTarget()
+  const targetRoot = process.env.RELEASE_ROOT ?? repoRoot
+  const target = await readTarget(targetRoot)
 
   if (flag === '--revision') {
     process.stdout.write(`${target.revision}\n`)
@@ -353,7 +359,7 @@ if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(
       ? `dependencies already pinned to ${target.version}\n`
       : `pinned ${String(applied.length)} package(s) to ${target.version}; run \`pnpm install\` to refresh the lockfile\n`)
   } else if (flag === undefined) {
-    const problems = await collectProblems(target)
+    const problems = await collectProblems(target, targetRoot)
     process.stdout.write(formatReport(target, problems))
     process.exit(problems.length > 0 ? 1 : 0)
   } else {

--- a/tools/harness-target.spec.mjs
+++ b/tools/harness-target.spec.mjs
@@ -48,6 +48,10 @@ describe('parseTarget()', () => {
     expect(() => parseTarget(`version ${TARGET.version}\nversion 0.1.2\n`)).toThrow(/declared twice/)
     expect(() => parseTarget('channel alpha\n')).toThrow(/unknown field: channel/)
     expect(() => parseTarget(`revision ${TARGET.revision}\nversion not-a-version\n`)).toThrow(/must look like/)
+    for (const version of ['01.1.1', '0.01.1', '0.1.01', '0.1.1-', '0.1.1..rc']) {
+      expect(() => parseTarget(`revision ${TARGET.revision}\nversion ${version}\n`), version).toThrow(/must look like/)
+    }
+    expect(() => parseTarget(`revision ${TARGET.revision}\nversion 0.1.1-rc.2\n\n`)).not.toThrow()
   })
 })
 
@@ -128,11 +132,12 @@ describe('sourceVersion()', () => {
     expect(sourceVersion({ name: '@deepseek-ai/dsh-root', version: '0.1.1-rc.2' })).toBe('0.1.1-rc.2')
   })
 
-  it('refuses a manifest with no version rather than comparing against undefined', () => {
+  it('refuses a non-Harness root or a manifest with no version', () => {
     // Silently reading `undefined` here would make the coherence guard pass
     // for any checkout that is not a Harness workspace at all.
     expect(() => sourceVersion({ name: '@deepseek-ai/dsh-root' })).toThrow(/declares no version/)
-    expect(() => sourceVersion({})).toThrow(/declares no version/)
+    expect(() => sourceVersion({})).toThrow(/must be @deepseek-ai\/dsh-root/)
+    expect(() => sourceVersion({ name: 'other', version: '0.1.1-rc.2' })).toThrow(/must be @deepseek-ai\/dsh-root/)
   })
 })
 
@@ -173,7 +178,10 @@ describe('isPublished()', () => {
     await expect(isPublished('@deepseek-ai/dsh', '0.1.3-alpha.1', fetchPackument)).resolves.toBe(false)
   })
 
-  it('reports a package with no versions at all as unpublished rather than throwing', async () => {
-    await expect(isPublished('@deepseek-ai/dsh', '0.1.1-rc.2', () => Promise.resolve({}))).resolves.toBe(false)
+  it('rejects a malformed packument rather than treating it as unpublished', async () => {
+    await expect(isPublished('@deepseek-ai/dsh', '0.1.1-rc.2', () => Promise.resolve({})))
+      .rejects.toThrow('invalid versions map')
+    await expect(isPublished('@deepseek-ai/dsh', '0.1.1-rc.2', () => Promise.resolve({ versions: [] })))
+      .rejects.toThrow('invalid versions map')
   })
 })

--- a/tools/publish-packages.mjs
+++ b/tools/publish-packages.mjs
@@ -1,0 +1,336 @@
+/**
+ * Publish each validated package artifact without repeating an accepted immutable version.
+ *
+ * The registry preflight is deliberately per package because a workspace publish
+ * is not atomic. A visible exact version is skipped, an absent version is sent to
+ * npm once, and the registry-verification job remains the authority for an
+ * accepted version that npm has not exposed yet.
+ *
+ * The OIDC job publishes prebuilt tarballs with `--ignore-scripts`, not workspace
+ * directories. That keeps package prepare/prepublish code in the no-identity
+ * preflight and binds the publish target to an artifact whose name and version
+ * are checked before the irreversible command.
+ *
+ * @module tools/publish-packages
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { isAbsolute, resolve } from 'node:path'
+
+import {
+  NPM_REGISTRY,
+  PUBLISHED_PACKAGES,
+  readExactPackage,
+} from './verify-published.mjs'
+import { isPrereleaseVersion, VERSION_SHAPE } from './release-version.mjs'
+
+/** Arguments shared by every individual trusted publication. */
+export const PUBLISH_ARGUMENTS = [
+  '--access', 'public',
+  '--provenance',
+  '--no-git-checks',
+  '--ignore-scripts',
+  '--registry', NPM_REGISTRY,
+  '--tag', 'latest',
+  '--dry-run=false',
+  '--config.minimum-release-age=0',
+]
+
+/** A hung npm operation is ambiguous and must fail rather than be retried. */
+export const PUBLISH_TIMEOUT_MS = 120_000
+
+/** Exact registry wording npm uses for an accepted staged version. */
+function stagedMessage(version) {
+  return `Cannot publish over previously staged version "${version}"`
+}
+
+/**
+ * Classify one publish process result without turning arbitrary failures green.
+ * @param result - process result with captured output.
+ * @param result.status - process exit status.
+ * @param result.stdout - standard output.
+ * @param result.stderr - standard error.
+ * @param packageName - package being published.
+ * @param version - immutable version being published.
+ * @returns the safe publication outcome.
+ */
+export function classifyPublishResult(result, packageName, version) {
+  if (result.status === 0) return { kind: 'published' }
+  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`
+  const conflictLines = output.split(/\r?\n/u).filter(line => line.includes('[E409] 409 Conflict'))
+  const expectedLine = conflictLines.length === 1 ? conflictLines[0].match(
+    /\[E409\] 409 Conflict - PUT (\S+) - (.+)$/u,
+  ) : null
+  let exactStagedConflict = false
+  if (expectedLine !== null) {
+    try {
+      const endpoint = new URL(expectedLine[1])
+      const message = expectedLine[2].trim().replace(/\.$/u, '')
+      exactStagedConflict = endpoint.origin === NPM_REGISTRY
+        && decodeURIComponent(endpoint.pathname) === `/${packageName}`
+        && message === stagedMessage(version)
+    } catch {
+      exactStagedConflict = false
+    }
+  }
+  const mixedFatalOutput = /\bE(?:401|403|409|5\d\d)\b|authentication|permission denied|forbidden/iu.test(
+    output.replace(conflictLines[0] ?? '', ''),
+  )
+  if (result.status === 1 && exactStagedConflict && !mixedFatalOutput) {
+    return { kind: 'accepted-staged', packageName, version }
+  }
+  return {
+    kind: 'failed',
+    packageName,
+    version,
+    status: result.status,
+  }
+}
+
+/**
+ * Read and validate a workspace package identity before registry lookup.
+ * @param definition - fixed directory/name/artifact identity.
+ * @returns package name, version, directory, and artifact filename.
+ */
+function validatePublishConfig(manifest, item, source) {
+  const publishConfig = manifest.publishConfig
+  if (publishConfig !== undefined && (publishConfig === null || typeof publishConfig !== 'object' || Array.isArray(publishConfig))) {
+    throw new Error(`publish-packages: ${source} has an invalid publishConfig`)
+  }
+  if (publishConfig?.name !== undefined && publishConfig.name !== item.name) {
+    throw new Error(`publish-packages: ${source} has a mismatched publishConfig.name`)
+  }
+  if (publishConfig?.registry !== undefined && publishConfig.registry !== NPM_REGISTRY) {
+    throw new Error(`publish-packages: ${source} overrides the trusted registry`)
+  }
+  if (publishConfig?.tag !== undefined && publishConfig.tag !== 'latest') {
+    throw new Error(`publish-packages: ${source} overrides the stable latest tag`)
+  }
+  if (publishConfig?.provenance === false) {
+    throw new Error(`publish-packages: ${source} disables provenance`)
+  }
+  if (publishConfig?.directory !== undefined || publishConfig?.linkDirectory !== undefined) {
+    throw new Error(`publish-packages: ${source} overrides the packed directory`)
+  }
+}
+
+/** @param definition - fixed package identity. @returns validated package item. */
+function readPackage(definition) {
+  const manifest = JSON.parse(readFileSync(resolve(definition.directory, 'package.json'), 'utf8'))
+  if (manifest.name !== definition.name) {
+    throw new Error(`publish-packages: ${definition.directory} must be ${definition.name}, got ${String(manifest.name)}`)
+  }
+  if (
+    typeof manifest.version !== 'string'
+    || !VERSION_SHAPE.test(manifest.version)
+    || manifest.version.includes('+')
+    || isPrereleaseVersion(manifest.version)
+  ) {
+    throw new Error(`publish-packages: ${definition.name} has invalid publish version ${JSON.stringify(manifest.version)}`)
+  }
+  validatePublishConfig(manifest, definition, definition.directory)
+  return {
+    ...definition,
+    version: manifest.version,
+    dependencies: manifest.dependencies,
+    publishConfig: manifest.publishConfig,
+  }
+}
+
+/**
+ * Validate the identity embedded in a prebuilt npm tarball.
+ * @param item - expected package identity.
+ * @param artifact - tarball path.
+ * @returns nothing when the tarball manifest is exact.
+ */
+function validateArtifact(item, artifact) {
+  let manifest
+  try {
+    manifest = JSON.parse(execFileSync('tar', ['-xOf', artifact, 'package/package.json'], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      maxBuffer: 128 * 1024,
+    }))
+  } catch (error) {
+    throw new Error(`publish-packages: could not inspect ${artifact}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  if (manifest === null || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new Error(`publish-packages: artifact ${artifact} has no object package manifest`)
+  }
+  if (manifest.name !== item.name || manifest.version !== item.version) {
+    throw new Error(
+      `publish-packages: artifact ${artifact} is ${String(manifest.name)}@${String(manifest.version)}, `
+      + `expected ${item.name}@${item.version}`,
+    )
+  }
+  if (item.name === '@dshline/dshline' && manifest.dependencies?.['@dshline/renderer'] !== `^${item.rendererVersion}`) {
+    throw new Error(`publish-packages: artifact ${artifact} has the wrong renderer dependency`)
+  }
+  validatePublishConfig(manifest, item, artifact)
+}
+
+/**
+ * Publish one package artifact with captured output and status.
+ * @param item - package identity.
+ * @param target - workspace directory or prebuilt tarball.
+ * @returns captured process output and status.
+ */
+function safeLog(text) {
+  return String(text).replaceAll('::', '%3A%3A')
+}
+
+function runPublish(item, target) {
+  const result = spawnSync('pnpm', ['publish', target, ...PUBLISH_ARGUMENTS], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: PUBLISH_TIMEOUT_MS,
+    killSignal: 'SIGTERM',
+  })
+  if (result.stdout !== undefined) process.stdout.write(safeLog(result.stdout))
+  if (result.stderr !== undefined) process.stderr.write(safeLog(result.stderr))
+  if (result.error !== undefined) {
+    return {
+      status: null,
+      stdout: result.stdout ?? '',
+      stderr: `${result.stderr ?? ''}\n${result.error.message}`,
+    }
+  }
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+/**
+ * Normalize the registry reader for tests that use a boolean answer.
+ * @param value - exact registry observation.
+ * @returns a visible/absent observation.
+ */
+function normalizeObservation(value, item, allowLegacyBoolean = false) {
+  if (typeof value === 'boolean') {
+    if (!allowLegacyBoolean) throw new Error(`publish-packages: registry returned a legacy boolean for ${item.name}@${item.version}`)
+    return { kind: value ? 'visible' : 'absent' }
+  }
+  if (value?.kind === 'visible') {
+    if (
+      value.manifest !== undefined
+      && (value.manifest === null || typeof value.manifest !== 'object'
+        || value.manifest.name !== item.name || value.manifest.version !== item.version)
+    ) {
+      throw new Error(`publish-packages: registry returned the wrong manifest for ${item.name}@${item.version}`)
+    }
+    return value
+  }
+  if (value?.kind === 'absent') return value
+  return { kind: 'unexpected' }
+}
+
+/**
+ * Publish every workspace package once, in dependency order.
+ * @param options - injectable registry reader, publisher, and logger.
+ * @param options.readManifest - workspace manifest reader for tests.
+ * @param options.readPublished - exact-version registry reader.
+ * @param options.runPublish - publication process.
+ * @param options.write - status logger.
+ * @param options.artifactRoot - downloaded prebuilt tarball directory.
+ * @param options.allowSourceDirectory - test-only escape hatch; CLI never enables it.
+ * @returns one outcome per package.
+ */
+export async function publishWorkspacePackages({
+  readManifest = readPackage,
+  readPublished,
+  readPackage: legacyReadPublished,
+  runPublish: publish = runPublish,
+  write = text => process.stdout.write(text),
+  artifactRoot = process.env.PUBLISH_ARTIFACT_ROOT,
+  allowSourceDirectory = false,
+} = {}) {
+  const usingLegacyReader = readPublished === undefined && legacyReadPublished !== undefined
+  const registryReader = readPublished ?? legacyReadPublished ?? readExactPackage
+  if (allowSourceDirectory && process.env.VITEST !== 'true' && process.env.NODE_ENV !== 'test') {
+    throw new Error('publish-packages: source-directory publishing is test-only')
+  }
+  if (!allowSourceDirectory && (typeof artifactRoot !== 'string' || artifactRoot === '' || !isAbsolute(artifactRoot))) {
+    throw new Error('publish-packages: PUBLISH_ARTIFACT_ROOT must be a non-empty absolute directory')
+  }
+  const outcomes = []
+  const rawManifests = PUBLISHED_PACKAGES.map(definition => readManifest(definition))
+  const manifests = rawManifests.map((manifest, index) => {
+    const definition = PUBLISHED_PACKAGES[index]
+    if (
+      manifest === null
+      || typeof manifest !== 'object'
+      || manifest.name !== definition.name
+      || manifest.directory !== definition.directory
+      || manifest.artifact !== definition.artifact
+    ) {
+      throw new Error(`publish-packages: manifest identity for ${definition.name} is not the fixed release identity`)
+    }
+    const item = { ...definition, ...manifest }
+    if (typeof item.version !== 'string' || !VERSION_SHAPE.test(item.version) || item.version.includes('+') || isPrereleaseVersion(item.version)) {
+      throw new Error(`publish-packages: ${item.name} has invalid stable publish version ${JSON.stringify(item.version)}`)
+    }
+    validatePublishConfig(item, definition, definition.directory)
+    return item
+  })
+  const rendererVersion = manifests.find(item => item.name === '@dshline/renderer')?.version
+  if (rendererVersion === undefined || manifests.some(item => item.version !== rendererVersion)) {
+    throw new Error('publish-packages: both packages must share one stable version')
+  }
+  for (const item of manifests) item.rendererVersion = rendererVersion
+
+  const decisions = []
+  for (const item of manifests) {
+    const existing = normalizeObservation(
+      await registryReader(item.name, item.version, { registry: NPM_REGISTRY }),
+      item,
+      usingLegacyReader,
+    )
+    if (existing.kind !== 'visible' && existing.kind !== 'absent') {
+      throw new Error(`publish-packages: registry did not provide a safe publish decision for ${item.name}@${item.version}`)
+    }
+    decisions.push({ item, existing })
+  }
+  const needsArtifacts = decisions.some(({ existing }) => existing.kind === 'absent')
+  if (needsArtifacts && !allowSourceDirectory) {
+    for (const { item, existing } of decisions) {
+      if (existing.kind === 'absent') validateArtifact(item, resolve(artifactRoot, item.artifact))
+    }
+  }
+
+  for (const { item, existing } of decisions) {
+    if (existing.kind === 'visible') {
+      write(`publish-packages: skipping ${item.name}@${item.version}; exact version is already visible\n`)
+      outcomes.push({ ...item, kind: 'already-visible' })
+      continue
+    }
+    const target = allowSourceDirectory ? item.directory : resolve(artifactRoot, item.artifact)
+    const result = publish(item, target)
+    const outcome = classifyPublishResult(result, item.name, item.version)
+    if (outcome.kind === 'failed') {
+      throw new Error(`publish-packages: publishing ${item.name}@${item.version} failed with exit ${String(outcome.status)}`)
+    }
+    if (outcome.kind === 'accepted-staged') {
+      write(
+        `publish-packages: npm accepted ${item.name}@${item.version} in its staged/validation state; `
+        + 'registry verification remains authoritative\n',
+      )
+    } else {
+      write(`publish-packages: npm accepted ${item.name}@${item.version}\n`)
+    }
+    outcomes.push({ ...item, kind: outcome.kind })
+  }
+  return outcomes
+}
+
+if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  try {
+    await publishWorkspacePackages()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`publish-packages: ${message}\n`)
+    process.exit(1)
+  }
+}

--- a/tools/publish-packages.spec.mjs
+++ b/tools/publish-packages.spec.mjs
@@ -105,7 +105,7 @@ describe('publishWorkspacePackages()', () => {
     const runPublish = vi.fn(item => ({
       status: 1,
       stdout: '',
-      stderr: `[E409] 409 Conflict - PUT https://registry.npmjs.org/${item.name.replace('/', '%2f')} - Cannot publish over previously staged version "${item.version}"`,
+      stderr: `[E409] 409 Conflict - PUT https://registry.npmjs.org/${encodeURIComponent(item.name)} - Cannot publish over previously staged version "${item.version}"`,
     }))
     const readPublished = vi.fn(async () => ({ kind: 'absent' }))
 

--- a/tools/publish-packages.spec.mjs
+++ b/tools/publish-packages.spec.mjs
@@ -1,0 +1,191 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+import { RegistryReadError } from './verify-published.mjs'
+import { classifyPublishResult, PUBLISH_ARGUMENTS, publishWorkspacePackages } from './publish-packages.mjs'
+
+const PACKAGES = [
+  { name: '@dshline/renderer', version: '0.20.0' },
+  { name: '@dshline/dshline', version: '0.20.0' },
+]
+
+function makeArtifacts(rendererDependency = '^0.20.0') {
+  const root = mkdtempSync(join(tmpdir(), 'dshline-release-artifacts-'))
+  const definitions = [
+    { file: 'renderer.tgz', name: '@dshline/renderer', dependencies: {} },
+    { file: 'dshline.tgz', name: '@dshline/dshline', dependencies: { '@dshline/renderer': rendererDependency } },
+  ]
+  for (const definition of definitions) {
+    const source = join(root, `${definition.file}.src`)
+    mkdirSync(join(source, 'package'), { recursive: true })
+    writeFileSync(join(source, 'package', 'package.json'), JSON.stringify({
+      name: definition.name,
+      version: '0.20.0',
+      dependencies: definition.dependencies,
+    }))
+    execFileSync('tar', ['-czf', join(root, definition.file), '-C', source, 'package'])
+    rmSync(source, { recursive: true, force: true })
+  }
+  return root
+}
+
+describe('classifyPublishResult()', () => {
+  it('pins the irreversible publish to npm latest with scripts disabled', () => {
+    expect(PUBLISH_ARGUMENTS).toEqual(expect.arrayContaining([
+      '--ignore-scripts', '--registry', 'https://registry.npmjs.org', '--tag', 'latest', '--dry-run=false',
+    ]))
+  })
+
+  it('accepts a successful publish', () => {
+    expect(classifyPublishResult({ status: 0, stdout: '', stderr: '' }, PACKAGES[0].name, PACKAGES[0].version))
+      .toEqual({ kind: 'published' })
+  })
+
+  it('recognizes only npm’s exact accepted/staged conflict', () => {
+    expect(classifyPublishResult({
+      status: 1,
+      stdout: '',
+      stderr: '[E409] 409 Conflict - PUT https://registry.npmjs.org/@dshline%2frenderer - Cannot publish over previously staged version "0.20.0".',
+    }, PACKAGES[0].name, PACKAGES[0].version)).toMatchObject({
+      kind: 'accepted-staged',
+      packageName: PACKAGES[0].name,
+      version: PACKAGES[0].version,
+    })
+  })
+
+  it('rejects wrong hosts, mixed errors, extra conflicts, and timeouts', () => {
+    for (const result of [
+      { status: 1, stdout: '', stderr: '[E409] 409 Conflict - PUT https://evilregistry.npmjs.org/@dshline%2frenderer - Cannot publish over previously staged version "0.20.0".' },
+      { status: 1, stdout: '', stderr: '[E409] 409 Conflict - PUT https://registry.npmjs.org/@dshline%2frenderer - Cannot publish over previously staged version "0.20.0". E401 auth failure' },
+      { status: 1, stdout: '', stderr: '[E409] 409 Conflict - PUT https://registry.npmjs.org/@dshline%2frenderer - Cannot publish over previously staged version "0.20.0".\n[E409] 409 Conflict - another operation' },
+      { status: 2, stdout: '', stderr: '[E409] 409 Conflict - PUT https://registry.npmjs.org/@dshline%2frenderer - Cannot publish over previously staged version "0.20.0".' },
+    ]) {
+      expect(classifyPublishResult(result, PACKAGES[0].name, PACKAGES[0].version).kind).toBe('failed')
+    }
+  })
+
+  it('does not suppress auth, unrelated conflict, or server failures', () => {
+    for (const result of [
+      { status: 1, stdout: '', stderr: 'E401 Unable to authenticate' },
+      { status: 1, stdout: '', stderr: '[E409] 409 Conflict - version is immutable for another reason' },
+      { status: 1, stdout: '', stderr: '[E503] 503 Service Unavailable' },
+      { status: null, stdout: '', stderr: 'spawn pnpm ENOENT' },
+    ]) {
+      expect(classifyPublishResult(result, PACKAGES[0].name, PACKAGES[0].version).kind).toBe('failed')
+    }
+  })
+})
+
+describe('publishWorkspacePackages()', () => {
+  it('skips an exact version already visible without invoking publish', async () => {
+    const runPublish = vi.fn()
+    const readPublished = vi.fn(async (name, version) => ({ kind: 'visible', manifest: { name, version } }))
+
+    const outcomes = await publishWorkspacePackages({ readPackage: readPublished, runPublish, write: () => {}, allowSourceDirectory: true })
+
+    expect(runPublish).not.toHaveBeenCalled()
+    expect(outcomes.map(outcome => outcome.kind)).toEqual(['already-visible', 'already-visible'])
+    expect(readPublished).toHaveBeenCalledTimes(2)
+  })
+
+  it('publishes an absent package and continues after npm accepts it', async () => {
+    const runPublish = vi.fn(() => ({ status: 0, stdout: '', stderr: '' }))
+    const readPublished = vi.fn(async () => ({ kind: 'absent' }))
+
+    const outcomes = await publishWorkspacePackages({ readPackage: readPublished, runPublish, write: () => {}, allowSourceDirectory: true })
+
+    expect(runPublish).toHaveBeenCalledTimes(2)
+    expect(outcomes.map(outcome => outcome.kind)).toEqual(['published', 'published'])
+  })
+
+  it('continues narrowly after the exact accepted/staged condition', async () => {
+    const runPublish = vi.fn(item => ({
+      status: 1,
+      stdout: '',
+      stderr: `[E409] 409 Conflict - PUT https://registry.npmjs.org/${item.name.replace('/', '%2f')} - Cannot publish over previously staged version "${item.version}"`,
+    }))
+    const readPublished = vi.fn(async () => ({ kind: 'absent' }))
+
+    await expect(publishWorkspacePackages({ readPackage: readPublished, runPublish, write: () => {}, allowSourceDirectory: true }))
+      .resolves.toHaveLength(2)
+  })
+
+  it('fails before publishing when the registry cannot establish absence', async () => {
+    const runPublish = vi.fn()
+    const readPublished = vi.fn(async () => { throw new RegistryReadError('transient', 'registry returned HTTP 503') })
+
+    await expect(publishWorkspacePackages({ readPackage: readPublished, runPublish, write: () => {}, allowSourceDirectory: true }))
+      .rejects.toThrow('registry returned HTTP 503')
+    expect(runPublish).not.toHaveBeenCalled()
+  })
+
+  it('fails on an auth or unrelated publish error', async () => {
+    const readPublished = vi.fn(async () => ({ kind: 'absent' }))
+    const runPublish = vi.fn(() => ({ status: 1, stdout: '', stderr: 'E401 auth failure' }))
+
+    await expect(publishWorkspacePackages({ readPackage: readPublished, runPublish, write: () => {}, allowSourceDirectory: true }))
+      .rejects.toThrow('@dshline/renderer@0.20.0')
+  })
+
+  it('requires an absolute artifact root outside explicit test mode', async () => {
+    await expect(publishWorkspacePackages({ readPublished: async () => ({ kind: 'visible' }) }))
+      .rejects.toThrow('PUBLISH_ARTIFACT_ROOT')
+    await expect(publishWorkspacePackages({ artifactRoot: 'relative', readPublished: async () => ({ kind: 'visible' }) }))
+      .rejects.toThrow('PUBLISH_ARTIFACT_ROOT')
+  })
+
+  it('publishes only validated downloaded tarballs and binds the dependency generation', async () => {
+    const artifactRoot = makeArtifacts()
+    const runPublish = vi.fn(() => ({ status: 0, stdout: '', stderr: '' }))
+    try {
+      await expect(publishWorkspacePackages({
+        artifactRoot,
+        readPublished: async () => ({ kind: 'absent' }),
+        runPublish,
+        write: () => {},
+      })).resolves.toHaveLength(2)
+      expect(runPublish.mock.calls.map(call => call[1])).toEqual([
+        join(artifactRoot, 'renderer.tgz'),
+        join(artifactRoot, 'dshline.tgz'),
+      ])
+    } finally {
+      rmSync(artifactRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an artifact with a mismatched renderer dependency before publishing', async () => {
+    const artifactRoot = makeArtifacts('^0.19.0')
+    const runPublish = vi.fn(() => ({ status: 0, stdout: '', stderr: '' }))
+    try {
+      await expect(publishWorkspacePackages({
+        artifactRoot,
+        readPublished: async () => ({ kind: 'absent' }),
+        runPublish,
+        write: () => {},
+      })).rejects.toThrow('wrong renderer dependency')
+      expect(runPublish).not.toHaveBeenCalled()
+    } finally {
+      rmSync(artifactRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('collects every registry decision before publishing any package', async () => {
+    const runPublish = vi.fn(() => ({ status: 0, stdout: '', stderr: '' }))
+    let calls = 0
+    await expect(publishWorkspacePackages({
+      readPackage: async () => ({ kind: 'absent' }),
+      readPublished: async () => {
+        calls += 1
+        if (calls === 2) throw new RegistryReadError('transient', 'second package unavailable')
+        return { kind: 'absent' }
+      },
+      runPublish,
+      write: () => {},
+      allowSourceDirectory: true,
+    })).rejects.toThrow('second package unavailable')
+    expect(runPublish).not.toHaveBeenCalled()
+  })
+})

--- a/tools/release-version.mjs
+++ b/tools/release-version.mjs
@@ -1,0 +1,75 @@
+/**
+ * Strict semver shapes shared by release tag and registry validation.
+ *
+ * Release automation must reject malformed versions before an immutable tag or
+ * package publication can be attempted. This is grammar validation only; it does
+ * not compare versions or replace a semver library where ordering is needed.
+ * Build metadata is intentionally excluded because pnpm strips it while packing.
+ *
+ * @module tools/release-version
+ */
+
+/** Semver numeric identifiers cannot have leading zeroes. */
+const NUMERIC = '(?:0|[1-9][0-9]*)'
+
+/** A prerelease identifier is numeric or contains at least one non-digit. */
+const PRERELEASE_IDENTIFIER = `(?:${NUMERIC}|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)`
+
+/** Shared semver grammar without anchors or a leading tag marker. */
+const VERSION_PATTERN = `${NUMERIC}\\.${NUMERIC}\\.${NUMERIC}`
+  + `(?:-${PRERELEASE_IDENTIFIER}(?:\\.${PRERELEASE_IDENTIFIER})*)?`
+
+/** A published package version accepted by the release tools. */
+export const VERSION_SHAPE = new RegExp(`^${VERSION_PATTERN}(?![\\s\\S])`, 'u')
+
+/** An immutable release tag carrying one accepted package version. */
+export const RELEASE_TAG = new RegExp(`^v${VERSION_PATTERN}(?![\\s\\S])`, 'u')
+
+/**
+ * Return the version claimed by a release tag.
+ * @param tag - immutable release tag.
+ * @returns the package version without its leading `v`.
+ * @throws when the tag is not a strict semver release tag.
+ */
+export function versionFromReleaseTag(tag) {
+  // pnpm strips build metadata while packing, so it cannot remain an exact
+  // immutable package identity in this release pipeline.
+  if (
+    typeof tag !== 'string'
+    || !RELEASE_TAG.test(tag)
+    || tag.includes('+')
+    || isPrereleaseVersion(tag.slice(1))
+  ) {
+    throw new Error(`expected a release tag like v1.2.3, got ${JSON.stringify(tag)}`)
+  }
+  return tag.slice(1)
+}
+
+/**
+ * Validate an immutable release tag before it reaches a registry or API path.
+ * @param tag - requested release tag.
+ * @returns the same validated tag.
+ * @throws when the tag is not a strict semver release tag.
+ */
+export function validateReleaseTag(tag) {
+  versionFromReleaseTag(tag)
+  return tag
+}
+
+/**
+ * Determine whether a version is a prerelease, ignoring build metadata.
+ * @param version - strict semver version without a leading tag marker.
+ * @returns whether the prerelease component is present.
+ */
+export function isPrereleaseVersion(version) {
+  return version.split('+', 1)[0].includes('-')
+}
+
+if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], 'file:').href) {
+  try {
+    validateReleaseTag(process.env.RELEASE_TAG ?? '')
+  } catch (error) {
+    process.stderr.write(`release-version: ${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(2)
+  }
+}

--- a/tools/release-version.spec.mjs
+++ b/tools/release-version.spec.mjs
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { RELEASE_TAG, VERSION_SHAPE, versionFromReleaseTag } from './release-version.mjs'
+
+describe('strict release version grammar', () => {
+  it('accepts ordinary semver and prerelease Harness versions, but not build metadata', () => {
+    expect(VERSION_SHAPE.test('0.20.0')).toBe(true)
+    expect(VERSION_SHAPE.test('0.1.1-rc.2')).toBe(true)
+    expect(VERSION_SHAPE.test('1.2.3+build.7')).toBe(false)
+    expect(RELEASE_TAG.test('v0.20.0')).toBe(true)
+  })
+
+  it('rejects leading zeros, empty identifiers, repeated dots, and trailing newlines', () => {
+    for (const value of ['01.2.3', '1.02.3', '1.2.03', '1.2.3-', '1.2.3..1', '1.2.3\n']) {
+      expect(VERSION_SHAPE.test(value), value).toBe(false)
+    }
+    for (const value of ['v01.2.3', 'v1.2.3-rc.1\n', 'v1.2.3+build.1']) {
+      expect(() => versionFromReleaseTag(value), value).toThrow()
+    }
+  })
+})

--- a/tools/release-workflow.spec.mjs
+++ b/tools/release-workflow.spec.mjs
@@ -1,0 +1,147 @@
+import { readFile } from 'node:fs/promises'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Extract a workflow job while ignoring full-line comments, so prose cannot
+ * satisfy a topology assertion.
+ * @param workflow - workflow YAML text.
+ * @param jobName - job key under `jobs:`.
+ * @returns the job's code block.
+ */
+function extractJob(workflow, jobName) {
+  const match = workflow.match(new RegExp(`\\n  ${jobName}:\\n([\\s\\S]*?)(?=\\n  \\S|$)`))
+  if (match === null) throw new Error(`job not found in publish workflow: ${jobName}`)
+  return match[1].split('\n').filter(line => !line.trim().startsWith('#')).join('\n')
+}
+
+/**
+ * Read the publish workflow once per assertion.
+ * @returns the workflow text.
+ */
+async function readWorkflow() {
+  return readFile(new URL('../.github/workflows/publish.yml', import.meta.url), 'utf8')
+}
+
+/** @returns the version workflow text. */
+async function readVersionWorkflow() {
+  return readFile(new URL('../.github/workflows/version.yml', import.meta.url), 'utf8')
+}
+
+describe('version workflow recovery boundaries', () => {
+  it('does not let arbitrary manual dispatches run the Version Packages writer', async () => {
+    const workflow = await readVersionWorkflow()
+    expect(workflow).toContain("github.event_name == 'push'")
+    expect(workflow).toContain("github.ref == 'refs/heads/main'")
+    expect(workflow).toContain("inputs.recovery-commit == ''")
+    expect(workflow).toContain('ref: ${{ github.sha }}')
+  })
+})
+
+describe('publish workflow state machine', () => {
+  it('puts accepted npm publication and registry visibility in different jobs', async () => {
+    const workflow = await readWorkflow()
+    const preflight = extractJob(workflow, 'release-preflight')
+    const publish = extractJob(workflow, 'publish-to-npm')
+    const verify = extractJob(workflow, 'verify-registry')
+    const release = extractJob(workflow, 'github-release')
+
+    expect(preflight).toContain('node tools/check-release-tag.mjs')
+    expect(preflight).toContain('pnpm run build')
+    expect(preflight).toContain('pnpm run typecheck')
+    expect(preflight).toContain('pnpm run test')
+    expect(preflight).toContain('pnpm run audit')
+    expect(preflight).toContain('pack --config.ignore-scripts=true')
+    expect(preflight).toContain('version: 11.22.0')
+    expect(preflight).toContain('dshline-renderer-*.tgz')
+    expect(preflight).not.toContain('id-token: write')
+    expect(publish).toContain('node tools/publish-packages.mjs')
+    expect(publish).toContain('actions/download-artifact@')
+    expect(publish).toContain('id-token: write')
+    expect(publish).toContain('PUBLISH_ARTIFACT_ROOT')
+    expect(publish).toContain('version: 11.22.0')
+    expect(publish).toContain('NPM_CONFIG_USERCONFIG')
+    expect(publish).toContain("NPM_TOKEN: ''")
+    expect(publish).not.toContain('pnpm install')
+    expect(publish).not.toContain('pnpm run test')
+    expect(verify).toContain('needs: publish-to-npm')
+    expect(verify).toContain('node tools/verify-published.mjs')
+    expect(verify).not.toContain('publish-packages')
+    expect(release).toContain('needs: verify-registry')
+    expect(release).toContain('node tools/ensure-github-release.mjs')
+  })
+
+  it('cannot publish on a verification rerun or through manual recovery', async () => {
+    const workflow = await readWorkflow()
+    const publish = extractJob(workflow, 'publish-to-npm')
+    const verify = extractJob(workflow, 'verify-registry')
+    const recovery = extractJob(workflow, 'recover-existing-tag')
+    const recoveryRelease = extractJob(workflow, 'recover-github-release')
+
+    expect(publish).toContain("if: github.event_name == 'push'")
+    expect(verify).toContain("if: github.event_name == 'push'")
+    expect(recovery).not.toMatch(/pnpm|publish-packages|npm publish/u)
+    expect(recoveryRelease).not.toMatch(/pnpm|publish-packages|npm publish/u)
+    expect(workflow).toContain('recovery-tag:')
+    expect(workflow).toContain('git worktree add --detach')
+  })
+
+  it('keeps OIDC and repository-write permissions at their narrow boundaries', async () => {
+    const workflow = await readWorkflow()
+    const publish = extractJob(workflow, 'publish-to-npm')
+    const verify = extractJob(workflow, 'verify-registry')
+    const release = extractJob(workflow, 'github-release')
+    const recovery = extractJob(workflow, 'recover-existing-tag')
+    const recoveryRelease = extractJob(workflow, 'recover-github-release')
+
+    expect(publish).toContain('contents: read')
+    expect(publish).toContain('id-token: write')
+    expect(verify).not.toContain('id-token: write')
+    expect(recovery).not.toContain('id-token: write')
+    expect(recovery).toContain('contents: read')
+    expect(release).toContain('contents: write')
+    expect(release).not.toContain('id-token: write')
+    expect(recoveryRelease).toContain('contents: write')
+    expect(recoveryRelease).not.toContain('id-token: write')
+  })
+
+  it('keeps manual trusted-publisher verification non-publishing and tags as the publish trigger', async () => {
+    const workflow = await readWorkflow()
+    const trusted = extractJob(workflow, 'trusted-publisher')
+    expect(trusted).toContain("github.event_name == 'workflow_dispatch'")
+    expect(trusted).toContain("github.ref == 'refs/heads/main'")
+    expect(trusted).toContain('ref: ${{ github.sha }}')
+    expect(trusted).toContain('node tools/check-trusted-publishers.mjs')
+    expect(trusted).not.toMatch(/pnpm publish|publish-packages/u)
+    expect(workflow).toMatch(/push:\n\s+tags: \['v\*'\]/u)
+    expect(workflow).toContain("NPM_TOKEN: ''")
+    expect(workflow).toContain('NPM_CONFIG_USERCONFIG')
+  })
+
+  it('keeps release serialization and checks the release object idempotently', async () => {
+    const workflow = await readWorkflow()
+    expect(workflow).toContain('group: publish-${{')
+    expect(workflow).toContain('cancel-in-progress: false')
+    expect(workflow).toContain('node tools/ensure-github-release.mjs')
+    expect(workflow).not.toContain('gh release create "$RELEASE_TAG"')
+  })
+
+  it('checks the exact tag tree before recovery can reach the write job', async () => {
+    const workflow = await readWorkflow()
+    const recovery = extractJob(workflow, 'recover-existing-tag')
+    const release = extractJob(workflow, 'recover-github-release')
+    expect(recovery).toContain('WORKFLOW_REF')
+    expect(recovery).toContain('refs/tags/$RECOVERY_TAG')
+    expect(recovery).toContain('RELEASE_ROOT="$TAG_ROOT" node tools/check-release-tag.mjs')
+    expect(recovery).toContain('RELEASE_ROOT="$TAG_ROOT" node tools/harness-target.mjs')
+    expect(recovery).toContain('RELEASE_RECOVERY: \'true\'')
+    expect(recovery).toContain('RELEASE_ROOT="$TAG_ROOT" node tools/verify-published.mjs')
+    expect(recovery).not.toContain('check-release-harness.mjs')
+    expect(recovery).toContain('git merge-base --is-ancestor')
+    expect(recovery).not.toMatch(/git (push|tag|update-ref)|gh api --method POST/u)
+    expect(release).toContain('needs: recover-existing-tag')
+    expect(release).toContain('ref: ${{ github.sha }}')
+    expect(release).not.toContain('ref: main')
+    expect(release).toContain("github.ref == 'refs/heads/main'")
+  })
+})

--- a/tools/release-workflow.spec.mjs
+++ b/tools/release-workflow.spec.mjs
@@ -71,6 +71,24 @@ describe('publish workflow state machine', () => {
     expect(release).toContain('node tools/ensure-github-release.mjs')
   })
 
+  it('keeps the validated artifact handoff outside the OIDC publisher', async () => {
+    const workflow = await readWorkflow()
+    const preflight = extractJob(workflow, 'release-preflight')
+    const publisher = extractJob(workflow, 'publish-to-npm')
+    expect(preflight).toContain('pnpm run build')
+    expect(preflight).toContain('pnpm run typecheck')
+    expect(preflight).toContain('pnpm run test')
+    expect(preflight).toContain('pack --config.ignore-scripts=true')
+    expect(preflight).toContain('actions/upload-artifact@')
+    expect(preflight).toContain('name: dshline-npm-packages')
+    expect(publisher).toContain('needs: release-preflight')
+    expect(publisher).toContain('actions/download-artifact@')
+    expect(publisher).toContain('name: dshline-npm-packages')
+    expect(publisher).toContain('node tools/publish-packages.mjs')
+    expect(publisher).not.toMatch(/pnpm install|pnpm run build|pnpm run typecheck|pnpm run test|pack --/u)
+    expect(publisher).not.toMatch(/prepublish|prepare|postinstall|npm publish/u)
+  })
+
   it('cannot publish on a verification rerun or through manual recovery', async () => {
     const workflow = await readWorkflow()
     const publish = extractJob(workflow, 'publish-to-npm')

--- a/tools/verify-published.mjs
+++ b/tools/verify-published.mjs
@@ -1,52 +1,305 @@
 /**
- * Confirm the registry actually serves what the release tag claimed.
+ * Confirm the public registry serves one coherent release.
  *
- * A publish is not atomic across a workspace: the renderer goes out before the
- * bundle that depends on it, so a failure in between leaves one package published
- * and the other not — and a published version cannot be replaced. Checking
- * afterwards turns that into a red release rather than a discovery made later by
- * someone whose install half-resolves.
+ * npm accepted publication is not the same moment npm serves the package publicly:
+ * trusted publishing and registry validation can leave an accepted version
+ * temporarily absent from the public read API. This verifier is intentionally
+ * separate from the publish job so a delayed read can fail and be rerun without
+ * crossing the irreversible publication boundary again.
  *
- * This checks only the version in the current release tree. It cannot detect a
- * different tagged version whose pending workflow GitHub discarded before it ran;
- * version.yml prevents the automated handoff from creating that second tag while
- * a publisher is active instead.
  * @module tools/verify-published
  */
 
-import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 
-/** Workspace packages that get published, in dependency order. */
-export const PACKAGE_DIRECTORIES = ['packages/renderer', 'packages/dshline']
+import { isPrereleaseVersion, VERSION_SHAPE } from './release-version.mjs'
+
+/** Workspace packages and their immutable public identities, in publish order. */
+export const PUBLISHED_PACKAGES = Object.freeze([
+  Object.freeze({ directory: 'packages/renderer', name: '@dshline/renderer', artifact: 'renderer.tgz' }),
+  Object.freeze({ directory: 'packages/dshline', name: '@dshline/dshline', artifact: 'dshline.tgz' }),
+])
+
+/** Workspace package directories retained as a small compatibility surface. */
+export const PACKAGE_DIRECTORIES = PUBLISHED_PACKAGES.map(item => item.directory)
+
+/** The public npm registry is the authority for externally visible versions. */
+export const NPM_REGISTRY = 'https://registry.npmjs.org'
 
 /**
- * npm's read API can trail a successful publish briefly. One minute distinguishes
- * ordinary propagation from a real half-release without making recovery opaque.
+ * Twenty minutes covers npm's current publish-time validation without polling
+ * forever. The fixed interval is slow enough not to hammer the registry and
+ * simple enough to make the bounded behavior obvious.
  */
-const VERIFY_ATTEMPTS = 12
+export const VERIFY_ATTEMPTS = 60
 
-/** Five seconds avoids hammering npm while keeping a normal release prompt. */
-const VERIFY_DELAY_MS = 5_000
+/** One registry read every twenty seconds after an accepted publication. */
+export const VERIFY_DELAY_MS = 20_000
+
+/** One shared deadline covers exact versions, tags, and coherence checks. */
+export const VERIFY_WINDOW_MS = 20 * 60 * 1000
+
+/** Keep one hung registry connection from extending the bounded window forever. */
+export const REGISTRY_REQUEST_TIMEOUT_MS = 10_000
+
+/** HTTP statuses that describe a temporary registry/network condition. */
+const RETRYABLE_STATUS = new Set([408, 425, 429])
 
 /**
- * Whether the registry serves an exact version of a package.
- * @param name - the package name.
- * @param version - the exact version.
- * @returns whether the registry answered with that version.
+ * A registry lookup failed in a way the caller must not misreport as absence.
+ * @typedef {'transient' | 'unexpected'} RegistryFailureKind
  */
-function published(name, version) {
-  try {
-    const answer = execFileSync('npm', ['view', `${name}@${version}`, 'version'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
-    return answer.trim() === version
-  } catch {
-    // `npm view` exits non-zero for a version that does not exist, which is the
-    // answer rather than a failure to get one.
-    return false
+
+/**
+ * Error from the registry reader, with absence kept separate from failure.
+ */
+export class RegistryReadError extends Error {
+  /**
+   * @param {RegistryFailureKind} kind - whether retrying may help.
+   * @param {string} message - safe diagnostic without credentials.
+   * @param {{retryAfterMs?: number}} details - optional bounded retry hint.
+   */
+  constructor(kind, message, details = {}) {
+    super(message)
+    this.name = 'RegistryReadError'
+    this.kind = kind
+    this.retryAfterMs = details.retryAfterMs ?? 0
   }
+}
+
+/**
+ * A response body that describes a package version.
+ * @typedef {{ kind: 'visible', manifest: Record<string, unknown> } | { kind: 'absent' }} PackageRead
+ */
+
+/**
+ * Convert a package name to the registry endpoint used for an exact version.
+ * @param {string} registry - registry origin.
+ * @param {string} name - package name.
+ * @param {string} version - exact version.
+ * @returns {string} exact package endpoint.
+ */
+function exactEndpoint(registry, name, version) {
+  return `${registry.replace(/\/$/u, '')}/${encodeURIComponent(name)}/${encodeURIComponent(version)}`
+}
+
+/**
+ * Convert a package name to its packument endpoint.
+ * @param {string} registry - registry origin.
+ * @param {string} name - package name.
+ * @returns {string} package metadata endpoint.
+ */
+function packumentEndpoint(registry, name) {
+  return `${registry.replace(/\/$/u, '')}/${encodeURIComponent(name)}`
+}
+
+/**
+ * Return the configured registry origin, rejecting redirects and non-HTTPS sinks.
+ * @param registry - registry origin.
+ * @returns normalized registry origin.
+ */
+function registryOrigin(registry) {
+  let parsed
+  try {
+    parsed = new URL(registry)
+  } catch (error) {
+    throw new RegistryReadError('unexpected', `registry URL is invalid: ${String(error)}`)
+  }
+  if (parsed.protocol !== 'https:' || parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '') {
+    throw new RegistryReadError('unexpected', `registry URL must be an HTTPS origin: ${registry}`)
+  }
+  return parsed.origin
+}
+
+/**
+ * Network errors are retryable; programmer/configuration errors are not.
+ * @param error - thrown fetch error.
+ * @returns whether the error can plausibly be a temporary network failure.
+ */
+function isTransientNetworkError(error) {
+  return error instanceof TypeError
+    || (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError'))
+}
+
+/**
+ * Convert an HTTP Retry-After header into a bounded millisecond hint.
+ * @param response - registry response.
+ * @returns non-negative milliseconds, or zero when absent/malformed.
+ */
+function retryAfterMilliseconds(response) {
+  const raw = typeof response.headers?.get === 'function' ? response.headers.get('retry-after') : undefined
+  if (raw === undefined || raw === null || raw === '') return 0
+  if (/^\d+(?:\.\d+)?$/u.test(raw)) return Math.max(0, Number(raw) * 1000)
+  const timestamp = Date.parse(raw)
+  return Number.isFinite(timestamp) ? Math.max(0, timestamp - Date.now()) : 0
+}
+
+/**
+ * Read JSON from npm while classifying HTTP/network failures explicitly.
+ * @param {typeof fetch} fetchImpl - fetch implementation.
+ * @param {string} url - endpoint to read.
+ * @param {string} label - safe operation name for diagnostics.
+ * @param {number} timeoutMs - maximum time for headers and body.
+ * @returns {Promise<{status: number, body: unknown} | {status: 404, body: undefined}>} response status and body.
+ * @throws {RegistryReadError} for retryable or unexpected registry failures.
+ */
+async function readJson(fetchImpl, url, label, timeoutMs = REGISTRY_REQUEST_TIMEOUT_MS) {
+  const controller = new AbortController()
+  const startedAt = performance.now()
+  let timedOut = false
+  let bodyTimer
+  let timer
+  const requestTimeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      timedOut = true
+      controller.abort()
+      reject(new DOMException('registry request timed out', 'AbortError'))
+    }, Math.max(1, timeoutMs))
+  })
+  let response
+  try {
+    response = await Promise.race([
+      fetchImpl(url, {
+        headers: { Accept: 'application/json', 'Cache-Control': 'no-cache' },
+        redirect: 'manual',
+        signal: controller.signal,
+      }),
+      requestTimeout,
+    ])
+
+    if (response.status >= 300 && response.status < 400) {
+      throw new RegistryReadError('unexpected', `${label} returned an unexpected redirect`)
+    }
+    if (response.url !== undefined && response.url !== '' && new URL(response.url).origin !== new URL(url).origin) {
+      throw new RegistryReadError('unexpected', `${label} returned a cross-origin response`)
+    }
+    if (response.status === 404) return { status: 404, body: undefined }
+    if (RETRYABLE_STATUS.has(response.status) || response.status >= 500) {
+      throw new RegistryReadError(
+        'transient',
+        `${label} returned HTTP ${String(response.status)}`,
+        { retryAfterMs: retryAfterMilliseconds(response) },
+      )
+    }
+    if (response.status !== 200 || !response.ok) {
+      throw new RegistryReadError('unexpected', `${label} returned unexpected HTTP ${String(response.status)}`)
+    }
+
+    let body
+    try {
+      const remainingBodyMs = Math.max(1, timeoutMs - (performance.now() - startedAt))
+      const bodyTimeout = new Promise((_, reject) => {
+        bodyTimer = setTimeout(() => {
+          timedOut = true
+          controller.abort()
+          reject(new DOMException('registry response body timed out', 'AbortError'))
+        }, remainingBodyMs)
+      })
+      body = await Promise.race([response.json(), bodyTimeout])
+    } catch (error) {
+      if (timedOut || isTransientNetworkError(error)) {
+        throw new RegistryReadError('transient', `${label} timed out while reading JSON`)
+      }
+      const reason = error instanceof Error ? error.message : String(error)
+      throw new RegistryReadError('unexpected', `${label} returned invalid JSON: ${reason}`)
+    }
+    return { status: response.status, body }
+  } catch (error) {
+    if (error instanceof RegistryReadError) throw error
+    const reason = error instanceof Error ? error.message : String(error)
+    if (timedOut || isTransientNetworkError(error)) {
+      throw new RegistryReadError('transient', `${label} failed before a response: ${reason}`)
+    }
+    throw new RegistryReadError('unexpected', `${label} failed unexpectedly: ${reason}`)
+  } finally {
+    clearTimeout(timer)
+    if (bodyTimer !== undefined) clearTimeout(bodyTimer)
+  }
+}
+
+/**
+ * Ask the public registry whether one exact version is externally visible.
+ *
+ * A 404 is deliberately the only absence result. DNS failures, timeouts, rate
+ * limits, 5xx responses, malformed JSON, and other statuses remain failures so
+ * a broken registry cannot be reported as a half-release.
+ * @param name - package name.
+ * @param version - exact version.
+ * @param options - injectable registry access for tests.
+ * @param options.fetchImpl - fetch implementation.
+ * @param options.registry - registry origin.
+ * @returns the exact-version observation.
+ */
+export async function readExactPackage(name, version, {
+  fetchImpl = fetch,
+  registry = NPM_REGISTRY,
+  timeoutMs = REGISTRY_REQUEST_TIMEOUT_MS,
+} = {}) {
+  const origin = registryOrigin(registry)
+  const result = await readJson(
+    fetchImpl,
+    exactEndpoint(origin, name, version),
+    `registry lookup for ${name}@${version}`,
+    timeoutMs,
+  )
+  if (result.status === 404) return { kind: 'absent' }
+  if (result.body === null || typeof result.body !== 'object' || Array.isArray(result.body)) {
+    throw new RegistryReadError('unexpected', `registry lookup for ${name}@${version} returned a non-object manifest`)
+  }
+  const manifest = /** @type {Record<string, unknown>} */ (result.body)
+  if (manifest.name !== name) {
+    throw new RegistryReadError(
+      'unexpected',
+      `registry lookup for ${name}@${version} returned package ${JSON.stringify(manifest.name)}`,
+    )
+  }
+  if (manifest.version !== version) {
+    throw new RegistryReadError(
+      'unexpected',
+      `registry lookup for ${name}@${version} returned version ${JSON.stringify(manifest.version)}`,
+    )
+  }
+  return { kind: 'visible', manifest }
+}
+
+/**
+ * Read the public dist-tags for one package.
+ * @param name - package name.
+ * @param options - injectable registry access for tests.
+ * @param options.fetchImpl - fetch implementation.
+ * @param options.registry - registry origin.
+ * @returns the package's dist-tags map.
+ */
+export async function readDistTags(name, {
+  fetchImpl = fetch,
+  registry = NPM_REGISTRY,
+  timeoutMs = REGISTRY_REQUEST_TIMEOUT_MS,
+} = {}) {
+  const origin = registryOrigin(registry)
+  const result = await readJson(
+    fetchImpl,
+    packumentEndpoint(origin, name),
+    `registry packument for ${name}`,
+    timeoutMs,
+  )
+  if (result.status === 404) {
+    throw new RegistryReadError('unexpected', `registry packument for ${name} disappeared after its version was visible`)
+  }
+  if (result.body === null || typeof result.body !== 'object' || Array.isArray(result.body)) {
+    throw new RegistryReadError('unexpected', `registry packument for ${name} returned a non-object document`)
+  }
+  const tags = /** @type {Record<string, unknown>} */ (result.body)['dist-tags']
+  if (tags === null || typeof tags !== 'object' || Array.isArray(tags)) {
+    throw new RegistryReadError('unexpected', `registry packument for ${name} has no dist-tags object`)
+  }
+  if (typeof tags.latest !== 'string' || !VERSION_SHAPE.test(tags.latest)) {
+    throw new RegistryReadError(
+      'unexpected',
+      `registry packument for ${name} has an invalid latest tag ${JSON.stringify(tags.latest)}`,
+    )
+  }
+  return /** @type {Record<string, string>} */ (tags)
 }
 
 /**
@@ -55,60 +308,358 @@ function published(name, version) {
  * @returns a promise settled after the delay.
  */
 function delay(milliseconds) {
-  return new Promise(resolve => setTimeout(resolve, milliseconds))
+  return new Promise(resolvePromise => setTimeout(resolvePromise, milliseconds))
+}
+
+/**
+ * Validate a polling attempt count instead of letting NaN or Infinity escape the bound.
+ * @param attempts - configured maximum attempts.
+ * @returns the validated attempt count.
+ */
+function validAttempts(attempts) {
+  if (!Number.isSafeInteger(attempts) || attempts < 1) {
+    throw new Error(`verify-published: attempts must be a positive safe integer, got ${String(attempts)}`)
+  }
+  return attempts
+}
+
+/**
+ * Sleep without extending a shared verification deadline.
+ * @param sleep - injectable sleep implementation.
+ * @param remainingMs - time remaining in the shared window.
+ * @param retryAfterMs - registry requested backoff, if any.
+ * @returns a promise settled after the bounded delay.
+ */
+async function boundedSleep(sleep, remainingMs, retryAfterMs = 0) {
+  const duration = Math.min(remainingMs, Math.max(VERIFY_DELAY_MS, retryAfterMs))
+  if (duration > 0) await sleep(duration)
 }
 
 /**
  * Wait for every exact package version to become visible on npm.
  *
- * Versions already observed are not queried again. This both shortens retries and
- * makes the log say exactly when each half of the workspace became visible.
+ * Versions already observed are removed from the pending set and never queried
+ * again. A temporary 404 is normal during npm validation; a temporary registry
+ * failure is retried with a diagnostic, while an unexpected response fails closed.
+ * The caller supplies one deadline so exact reads and dist-tag coherence share a
+ * single bounded window.
  * @param packages - package names and exact versions expected from this release.
- * @param options - injectable registry reader, delay and logger for tests.
- * @param options.isPublished - exact-version registry reader.
+ * @param options - injectable registry reader, delay, clock, and logger for tests.
+ * @param options.readPackage - exact-version registry reader.
+ * @param options.isPublished - backwards-compatible boolean reader for small callers.
  * @param options.sleep - delay between attempts.
- * @param options.write - successful-observation logger.
+ * @param options.write - observation and retry logger.
+ * @param options.onVisible - callback invoked once per visible package.
  * @param options.attempts - maximum registry reads per package.
+ * @param options.now - monotonic-clock substitute returning milliseconds.
+ * @param options.deadlineAt - shared absolute deadline.
+ * @param options.windowMs - window used when deadlineAt is omitted.
  * @returns exact `name@version` strings still missing after all attempts.
  */
 export async function waitForPublished(packages, {
-  isPublished = published,
+  readPackage = readExactPackage,
+  isPublished,
   sleep = delay,
   write = text => process.stdout.write(text),
+  onVisible,
   attempts = VERIFY_ATTEMPTS,
+  now = () => performance.now(),
+  deadlineAt,
+  windowMs = VERIFY_WINDOW_MS,
 } = {}) {
+  const reader = isPublished === undefined
+    ? readPackage
+    : async (name, version, readerOptions) => ({
+      kind: (await Promise.resolve(isPublished(name, version, readerOptions))) ? 'visible' : 'absent',
+    })
   let pending = [...packages]
-  const limit = Math.max(1, attempts)
-  for (let attempt = 1; attempt <= limit; attempt += 1) {
+  const limit = validAttempts(attempts)
+  const deadline = Number.isFinite(deadlineAt) ? deadlineAt : now() + windowMs
+  const transientFailures = new Map()
+
+  for (let attempt = 1; attempt <= limit && pending.length > 0; attempt += 1) {
     const missing = []
-    for (const item of pending) {
-      if (isPublished(item.name, item.version)) {
-        write(`verify-published: ${item.name}@${item.version} is on the registry\n`)
-      } else {
+    for (let index = 0; index < pending.length; index += 1) {
+      const item = pending[index]
+      const remainingMs = deadline - now()
+      if (remainingMs <= 0) {
+        missing.push(...pending.slice(index))
+        break
+      }
+      try {
+        const observation = await reader(item.name, item.version, {
+          timeoutMs: Math.min(REGISTRY_REQUEST_TIMEOUT_MS, remainingMs),
+        })
+        const normalized = typeof observation === 'boolean'
+          ? { kind: observation ? 'visible' : 'absent' }
+          : observation
+        if (normalized?.kind === 'visible') {
+          write(`verify-published: ${item.name}@${item.version} is on the registry\n`)
+          onVisible?.(item, normalized.manifest)
+          transientFailures.delete(item.name)
+        } else if (normalized?.kind === 'absent') {
+          missing.push(item)
+          transientFailures.delete(item.name)
+        } else {
+          throw new RegistryReadError('unexpected', `registry lookup for ${item.name}@${item.version} returned an invalid observation`)
+        }
+      } catch (error) {
+        if (!(error instanceof RegistryReadError) || error.kind !== 'transient') throw error
+        transientFailures.set(item.name, error)
         missing.push(item)
+        write(`verify-published: retrying ${item.name}@${item.version}: ${error.message}\n`)
       }
     }
     pending = missing
     if (pending.length === 0) break
-    if (attempt < limit) await sleep(VERIFY_DELAY_MS)
+    const remainingMs = deadline - now()
+    if (attempt < limit && remainingMs > 0) {
+      const retryAfterMs = Math.max(...pending.map(item => transientFailures.get(item.name)?.retryAfterMs ?? 0), 0)
+      await boundedSleep(sleep, remainingMs, retryAfterMs)
+    }
+  }
+
+  const stillUnavailable = pending
+    .filter(item => transientFailures.has(item.name))
+    .map(item => `${item.name}@${item.version}: ${transientFailures.get(item.name).message}`)
+  if (stillUnavailable.length > 0) {
+    throw new RegistryReadError(
+      'transient',
+      `registry remained unavailable while verifying ${stillUnavailable.join(', ')}`,
+    )
   }
   return pending.map(item => `${item.name}@${item.version}`)
 }
 
-/** Read the release tree's package identities once before polling npm. */
-const packages = PACKAGE_DIRECTORIES.map(directory => {
-  const { name, version } = JSON.parse(readFileSync(`${directory}/package.json`, 'utf8'))
-  return { name, version }
-})
+/**
+ * Wait for stable packages' `latest` tags to form one coherent snapshot.
+ * @param packages - stable package names and exact versions.
+ * @param options - injectable tag reader, timing, and logger.
+ * @returns the confirmed dist-tags by package name.
+ */
+async function waitForStableTags(packages, {
+  readTags,
+  sleep,
+  write,
+  attempts,
+  options,
+  now,
+  deadlineAt,
+  latestPolicy = 'exact',
+}) {
+  const limit = validAttempts(attempts)
+  const transientFailures = new Map()
+  let lastTags = new Map()
+
+  for (let attempt = 1; attempt <= limit; attempt += 1) {
+    const remainingMs = deadlineAt - now()
+    if (remainingMs <= 0) break
+    const nextTags = new Map()
+    let mismatch = false
+    for (const item of packages) {
+      const remainingForRead = deadlineAt - now()
+      if (remainingForRead <= 0) {
+        mismatch = true
+        break
+      }
+      try {
+        const tags = await readTags(item.name, {
+          ...options,
+          timeoutMs: Math.min(REGISTRY_REQUEST_TIMEOUT_MS, remainingForRead),
+        })
+        nextTags.set(item.name, tags)
+        const latestIsStable = typeof tags.latest === 'string'
+          && VERSION_SHAPE.test(tags.latest)
+          && !tags.latest.split('+', 1)[0].includes('-')
+        const matches = latestPolicy === 'stable'
+          ? latestIsStable
+          : tags.latest === item.version
+        if (!matches) {
+          mismatch = true
+          write(`verify-published: waiting for ${item.name}@latest to become ${item.version}; currently ${JSON.stringify(tags.latest)}\n`)
+        }
+        transientFailures.delete(item.name)
+      } catch (error) {
+        if (!(error instanceof RegistryReadError) || error.kind !== 'transient') throw error
+        transientFailures.set(item.name, error)
+        mismatch = true
+        write(`verify-published: retrying ${item.name} dist-tags: ${error.message}\n`)
+      }
+    }
+    if (!mismatch && nextTags.size === packages.length) return nextTags
+    lastTags = nextTags
+    const remainingAfterRead = deadlineAt - now()
+    if (attempt < limit && remainingAfterRead > 0) {
+      const retryAfterMs = Math.max(...transientFailures.values().map(error => error.retryAfterMs ?? 0), 0)
+      await boundedSleep(sleep, remainingAfterRead, retryAfterMs)
+    }
+  }
+
+  const unavailable = [...transientFailures.entries()]
+    .map(([name, error]) => `${name}: ${error.message}`)
+  if (unavailable.length > 0) {
+    throw new RegistryReadError('transient', `registry remained unavailable while verifying dist-tags for ${unavailable.join(', ')}`)
+  }
+  const unresolved = packages
+    .filter(item => !lastTags.has(item.name) || (latestPolicy === 'exact' && lastTags.get(item.name).latest !== item.version))
+    .map(item => `${item.name}@${item.version}`)
+  if (unresolved.length > 0) {
+    throw new RegistryReadError('unexpected', `stable latest did not reach the release version for ${unresolved.join(', ')}`)
+  }
+  return lastTags
+}
+
+/**
+ * Verify exact versions, stable dist-tags, and the generated workspace dependency.
+ * @param packages - package names and exact versions expected from this release.
+ * @param options - injectable registry access, timing, and logging.
+ * @param options.readPackage - exact-version registry reader.
+ * @param options.readTags - package dist-tag reader.
+ * @param options.latestPolicy - `exact` for normal releases, `skip` for historical old-tag recovery.
+ * @returns observations and dist-tags for the coherent release.
+ */
+export async function verifyRelease(packages, options = {}) {
+  const expectedNames = new Set(PUBLISHED_PACKAGES.map(item => item.name))
+  const actualNames = packages.map(item => item?.name)
+  const versions = new Set(packages.map(item => item?.version))
+  if (
+    packages.length !== PUBLISHED_PACKAGES.length
+    || actualNames.some(name => !expectedNames.has(name))
+    || new Set(actualNames).size !== packages.length
+    || versions.size !== 1
+    || packages.some(item => typeof item?.version !== 'string' || !VERSION_SHAPE.test(item.version) || item.version.includes('+') || isPrereleaseVersion(item.version))
+  ) {
+    throw new Error('verify-published: release package set must be the two fixed packages at one stable version')
+  }
+  const latestPolicy = options.latestPolicy ?? 'exact'
+  if (!['exact', 'stable', 'skip'].includes(latestPolicy)) {
+    throw new Error(`verify-published: unknown latest policy ${String(latestPolicy)}`)
+  }
+  const readPackage = options.readPackage ?? readExactPackage
+  const readTags = options.readTags ?? readDistTags
+  const now = options.now ?? (() => performance.now())
+  const deadlineAt = options.deadlineAt ?? now() + (options.windowMs ?? VERIFY_WINDOW_MS)
+  const manifests = new Map()
+  const missing = await waitForPublished(packages, {
+    ...options,
+    readPackage: async (name, version, readerOptions = {}) => readPackage(name, version, {
+      ...options,
+      ...readerOptions,
+    }),
+    now,
+    deadlineAt,
+    onVisible: (item, manifest) => {
+      if (manifest !== undefined) manifests.set(item.name, manifest)
+      options.onVisible?.(item, manifest)
+    },
+  })
+  if (missing.length > 0) return { missing, manifests, distTags: new Map() }
+
+  for (const item of packages) {
+    if (manifests.has(item.name)) continue
+    const remainingMs = deadlineAt - now()
+    if (remainingMs <= 0) throw new RegistryReadError('transient', `verification deadline expired before rereading ${item.name}@${item.version}`)
+    const observation = await readPackage(item.name, item.version, {
+      ...options,
+      timeoutMs: Math.min(REGISTRY_REQUEST_TIMEOUT_MS, remainingMs),
+    })
+    if (observation?.kind !== 'visible') {
+      throw new RegistryReadError('unexpected', `${item.name}@${item.version} disappeared after verification`)
+    }
+    manifests.set(item.name, observation.manifest)
+  }
+
+  const renderer = packages.find(item => item.name === '@dshline/renderer')
+  const dshline = packages.find(item => item.name === '@dshline/dshline')
+  if (renderer === undefined || dshline === undefined) {
+    throw new Error('verify-published: release must contain renderer and dshline packages')
+  }
+
+  const dshlineManifest = manifests.get(dshline.name)
+  const rendererDependency = dshlineManifest?.dependencies?.['@dshline/renderer']
+  const expectedRendererDependency = `^${renderer.version}`
+  if (rendererDependency !== expectedRendererDependency) {
+    throw new Error(
+      `verify-published: ${dshline.name}@${dshline.version} refers to `
+      + `${JSON.stringify(rendererDependency)} instead of ${expectedRendererDependency}`,
+    )
+  }
+
+  const stable = packages.every(item => !item.version.split('+', 1)[0].includes('-'))
+  const distTags = stable && latestPolicy !== 'skip'
+    ? await waitForStableTags(packages, {
+      readTags,
+      sleep: options.sleep ?? delay,
+      write: options.write ?? (text => process.stdout.write(text)),
+      attempts: options.attempts ?? VERIFY_ATTEMPTS,
+      options,
+      now,
+      deadlineAt,
+      latestPolicy,
+    })
+    : new Map()
+  return { missing, manifests, distTags }
+}
+
+/**
+ * Read the release tree's package identities once before polling npm.
+ * @param root - repository root whose package manifests should be read.
+ * @returns package names and exact versions in publish order.
+ */
+export function readReleasePackages(root = process.env.RELEASE_ROOT ?? process.cwd()) {
+  return PUBLISHED_PACKAGES.map(definition => {
+    const manifest = JSON.parse(readFileSync(join(resolve(root), definition.directory, 'package.json'), 'utf8'))
+    if (manifest.name !== definition.name) {
+      throw new Error(`verify-published: ${definition.directory} must be ${definition.name}, got ${String(manifest.name)}`)
+    }
+    if (
+      typeof manifest.version !== 'string'
+      || !VERSION_SHAPE.test(manifest.version)
+      || manifest.version.includes('+')
+      || isPrereleaseVersion(manifest.version)
+    ) {
+      throw new Error(`verify-published: ${definition.name} has invalid publish version ${JSON.stringify(manifest.version)}`)
+    }
+    if (manifest.publishConfig !== undefined && (manifest.publishConfig === null || typeof manifest.publishConfig !== 'object' || Array.isArray(manifest.publishConfig))) {
+      throw new Error(`verify-published: ${definition.name} has an invalid publishConfig`)
+    }
+    if (manifest.publishConfig?.name !== undefined && manifest.publishConfig.name !== definition.name) {
+      throw new Error(`verify-published: ${definition.name} has a mismatched publishConfig.name`)
+    }
+    if (manifest.publishConfig?.registry !== undefined && manifest.publishConfig.registry !== NPM_REGISTRY) {
+      throw new Error(`verify-published: ${definition.name} overrides the trusted registry`)
+    }
+    if (manifest.publishConfig?.tag !== undefined && manifest.publishConfig.tag !== 'latest') {
+      throw new Error(`verify-published: ${definition.name} overrides the stable latest tag`)
+    }
+    if (manifest.publishConfig?.provenance === false) {
+      throw new Error(`verify-published: ${definition.name} disables provenance`)
+    }
+    if (manifest.publishConfig?.directory !== undefined || manifest.publishConfig?.linkDirectory !== undefined) {
+      throw new Error(`verify-published: ${definition.name} overrides the packed directory`)
+    }
+    return { name: definition.name, version: manifest.version }
+  })
+}
 
 if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], 'file:').href) {
-  const missing = await waitForPublished(packages)
-  if (missing.length > 0) {
-    process.stderr.write(
-      `verify-published: the registry does not serve ${missing.join(', ')}.\n`
-      + 'The release did not fully land. Correct the missing package trusted-publisher mapping, then rerun\n'
-      + 'this same tagged workflow; do not create another tag until both exact versions verify.\n',
-    )
+  try {
+    const packages = readReleasePackages()
+    const result = await verifyRelease(packages, {
+      latestPolicy: process.env.RELEASE_RECOVERY === 'true' ? 'skip' : 'exact',
+    })
+    if (result.missing.length > 0) {
+      process.stderr.write(
+        `verify-published: the registry did not serve ${result.missing.join(', ')} within the bounded verification window.\n`
+        + 'npm accepted publication is not the same moment npm serves it publicly.\n'
+        + 'Rerun registry verification after a delay; do not publish again or create another tag.\n',
+      )
+      process.exit(1)
+    }
+    process.stdout.write('verify-published: both packages and the stable release generation are coherent\n')
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stderr.write(`verify-published: ${message}\n`)
     process.exit(1)
   }
 }

--- a/tools/verify-published.spec.mjs
+++ b/tools/verify-published.spec.mjs
@@ -1,50 +1,268 @@
 import { describe, expect, it, vi } from 'vitest'
-import { PACKAGE_DIRECTORIES, waitForPublished } from './verify-published.mjs'
+import {
+  NPM_REGISTRY,
+  PACKAGE_DIRECTORIES,
+  RegistryReadError,
+  readDistTags,
+  readExactPackage,
+  verifyRelease,
+  waitForPublished,
+} from './verify-published.mjs'
 
 const PACKAGES = [
-  { name: '@dshline/renderer', version: '0.3.2' },
-  { name: '@dshline/dshline', version: '0.3.2' },
+  { name: '@dshline/renderer', version: '0.20.0' },
+  { name: '@dshline/dshline', version: '0.20.0' },
 ]
+
+/** Minimal fetch response for the registry reader tests. */
+function response(body, status = 200, headers = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: name => headers[name.toLowerCase()] },
+    json: async () => body,
+  }
+}
 
 describe('waitForPublished()', () => {
   it('covers every published workspace package', () => {
     expect(PACKAGE_DIRECTORIES).toEqual(['packages/renderer', 'packages/dshline'])
   })
 
-  it('waits for a package that appears after its publish request returns', async () => {
-    const seen = new Map([
-      [PACKAGES[0].name, 0],
-      [PACKAGES[1].name, 0],
-    ])
-    const isPublished = vi.fn(name => {
+  it('reports one package immediately and waits for the other beyond the old minute', async () => {
+    const seen = new Map(PACKAGES.map(item => [item.name, 0]))
+    const readPackage = vi.fn(async name => {
       const count = (seen.get(name) ?? 0) + 1
       seen.set(name, count)
-      return name === PACKAGES[0].name || count >= 2
+      return name === PACKAGES[0].name || count >= 7
+        ? { kind: 'visible', manifest: { name, version: '0.20.0' } }
+        : { kind: 'absent' }
     })
     const sleep = vi.fn(async () => {})
     const write = vi.fn()
+    const onVisible = vi.fn()
 
-    await expect(waitForPublished(PACKAGES, { isPublished, sleep, write, attempts: 3 }))
-      .resolves.toEqual([])
-    expect(sleep).toHaveBeenCalledTimes(1)
-    expect(isPublished.mock.calls.map(call => call[0])).toEqual([
+    await expect(waitForPublished(PACKAGES, {
+      readPackage,
+      sleep,
+      write,
+      onVisible,
+      attempts: 7,
+    })).resolves.toEqual([])
+    expect(sleep).toHaveBeenCalledTimes(6)
+    expect(readPackage.mock.calls.map(call => call[0])).toEqual([
       PACKAGES[0].name,
       PACKAGES[1].name,
       PACKAGES[1].name,
+      PACKAGES[1].name,
+      PACKAGES[1].name,
+      PACKAGES[1].name,
+      PACKAGES[1].name,
+      PACKAGES[1].name,
     ])
-    expect(write).toHaveBeenCalledWith(expect.stringContaining(`${PACKAGES[1].name}@0.3.2`))
+    expect(onVisible).toHaveBeenCalledTimes(2)
+    expect(write).toHaveBeenCalledWith(expect.stringContaining(`${PACKAGES[0].name}@0.20.0`))
+    expect(write).toHaveBeenCalledWith(expect.stringContaining(`${PACKAGES[1].name}@0.20.0`))
   })
 
-  it('returns a persistent half-release after the retry budget', async () => {
+  it('does not query packages already observed', async () => {
+    const readPackage = vi.fn(async name => ({
+      kind: name === PACKAGES[0].name ? 'visible' : 'absent',
+      manifest: { name, version: '0.20.0' },
+    }))
+    const sleep = vi.fn(async () => {})
+
+    await expect(waitForPublished(PACKAGES, { readPackage, sleep, write: () => {}, attempts: 3 }))
+      .resolves.toEqual([`${PACKAGES[1].name}@0.20.0`])
+    expect(readPackage.mock.calls.map(call => call[0])).toEqual([
+      PACKAGES[0].name,
+      PACKAGES[1].name,
+      PACKAGES[1].name,
+      PACKAGES[1].name,
+    ])
+  })
+
+  it('returns only genuinely missing packages at the bounded timeout', async () => {
     const sleep = vi.fn(async () => {})
     const missing = await waitForPublished(PACKAGES, {
-      isPublished: item => item === PACKAGES[0].name,
+      readPackage: async name => name === PACKAGES[0].name
+        ? { kind: 'visible', manifest: { name, version: '0.20.0' } }
+        : { kind: 'absent' },
       sleep,
       write: () => {},
       attempts: 3,
     })
 
-    expect(missing).toEqual([`${PACKAGES[1].name}@0.3.2`])
+    expect(missing).toEqual([`${PACKAGES[1].name}@0.20.0`])
     expect(sleep).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries transient registry errors instead of calling them absence', async () => {
+    let calls = 0
+    const sleep = vi.fn(async () => {})
+    const readPackage = vi.fn(async name => {
+      calls += 1
+      if (calls === 1) throw new RegistryReadError('transient', 'registry returned HTTP 503')
+      return { kind: 'visible', manifest: { name, version: '0.20.0' } }
+    })
+
+    await expect(waitForPublished(PACKAGES, { readPackage, sleep, write: () => {}, attempts: 2 }))
+      .resolves.toEqual([])
+    expect(sleep).toHaveBeenCalledTimes(1)
+    expect(readPackage).toHaveBeenCalledTimes(3)
+  })
+
+  it('fails with a useful error when a transient registry failure persists', async () => {
+    const sleep = vi.fn(async () => {})
+    await expect(waitForPublished(PACKAGES, {
+      readPackage: async () => {
+        throw new RegistryReadError('transient', 'registry returned HTTP 503')
+      },
+      sleep,
+      write: () => {},
+      attempts: 2,
+    })).rejects.toThrow('registry remained unavailable')
+  })
+
+  it('shares one bounded deadline instead of granting every phase a new window', async () => {
+    let clock = 0
+    const readPackage = vi.fn(async name => ({ kind: 'absent', manifest: { name, version: '0.20.0' } }))
+    const sleep = vi.fn(async milliseconds => { clock += milliseconds })
+    await expect(waitForPublished(PACKAGES, {
+      readPackage,
+      sleep,
+      now: () => clock,
+      windowMs: 100,
+      attempts: 60,
+      write: () => {},
+    })).resolves.toEqual(PACKAGES.map(item => `${item.name}@${item.version}`))
+    expect(readPackage).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(100)
+  })
+
+  it('fails explicitly for an unexpected registry response', async () => {
+    await expect(waitForPublished(PACKAGES, {
+      readPackage: async () => {
+        throw new RegistryReadError('unexpected', 'registry returned HTTP 403')
+      },
+      sleep: async () => {},
+      write: () => {},
+    })).rejects.toThrow('HTTP 403')
+  })
+})
+
+describe('readExactPackage()', () => {
+  it('distinguishes an absent exact version from registry failures', async () => {
+    await expect(readExactPackage('@dshline/renderer', '0.20.0', {
+      fetchImpl: async () => response(undefined, 404),
+    })).resolves.toEqual({ kind: 'absent' })
+    await expect(readExactPackage('@dshline/renderer', '0.20.0', {
+      fetchImpl: async () => response({}, 503),
+    })).rejects.toMatchObject({ kind: 'transient' })
+    await expect(readExactPackage('@dshline/renderer', '0.20.0', {
+      fetchImpl: async () => response({}, 403),
+    })).rejects.toMatchObject({ kind: 'unexpected' })
+    await expect(readExactPackage('@dshline/renderer', '0.20.0', {
+      fetchImpl: async () => response({}, 429, { 'retry-after': '3' }),
+    })).rejects.toMatchObject({ kind: 'transient', retryAfterMs: 3000 })
+    await expect(readExactPackage('@dshline/renderer', '0.20.0', {
+      timeoutMs: 5,
+      fetchImpl: async () => ({ ok: true, status: 200, json: () => new Promise(() => {}) }),
+    })).rejects.toMatchObject({ kind: 'transient' })
+    await expect(readExactPackage('@dshline/renderer', '0.20.0', {
+      timeoutMs: 5,
+      fetchImpl: () => new Promise(() => {}),
+    })).rejects.toMatchObject({ kind: 'transient' })
+    await expect(readExactPackage('@dshline/renderer', '0.20.0', {
+      fetchImpl: async () => { throw new Error('DNS unavailable') },
+    })).rejects.toThrow('DNS unavailable')
+  })
+
+  it('uses the public npm registry exact-version endpoint', async () => {
+    const fetchImpl = vi.fn(async () => response({ name: '@dshline/renderer', version: '0.20.0' }))
+    await expect(readExactPackage('@dshline/renderer', '0.20.0', { fetchImpl })).resolves.toMatchObject({ kind: 'visible' })
+    expect(fetchImpl.mock.calls[0][0]).toBe(`${NPM_REGISTRY}/%40dshline%2Frenderer/0.20.0`)
+    expect(fetchImpl.mock.calls[0][1].headers['Cache-Control']).toBe('no-cache')
+    expect(fetchImpl.mock.calls[0][1].redirect).toBe('manual')
+  })
+
+  it('rejects a malformed latest dist-tag instead of waiting on it', async () => {
+    await expect(readDistTags('@dshline/renderer', {
+      fetchImpl: async () => response({ 'dist-tags': { latest: null } }),
+    })).rejects.toMatchObject({ kind: 'unexpected' })
+  })
+})
+
+describe('verifyRelease()', () => {
+  it('verifies the published dependency generation and stable latest tags', async () => {
+    const manifests = new Map([
+      [PACKAGES[0].name, { name: PACKAGES[0].name, version: '0.20.0' }],
+      [PACKAGES[1].name, {
+        name: PACKAGES[1].name,
+        version: '0.20.0',
+        dependencies: { '@dshline/renderer': '^0.20.0' },
+      }],
+    ])
+    const readPackage = vi.fn(async name => ({ kind: 'visible', manifest: manifests.get(name) }))
+    const readTags = vi.fn(async () => ({ latest: '0.20.0' }))
+
+    await expect(verifyRelease(PACKAGES, { readPackage, readTags, sleep: async () => {}, write: () => {} }))
+      .resolves.toMatchObject({ missing: [], distTags: expect.any(Map) })
+    expect(readTags).toHaveBeenCalledTimes(2)
+  })
+
+  it('waits for stable latest tags without re-reading confirmed package tags', async () => {
+    const readPackage = async name => ({
+      kind: 'visible',
+      manifest: name === PACKAGES[1].name
+        ? { name, version: '0.20.0', dependencies: { '@dshline/renderer': '^0.20.0' } }
+        : { name, version: '0.20.0' },
+    })
+    const counts = new Map()
+    const readTags = vi.fn(async name => {
+      const count = (counts.get(name) ?? 0) + 1
+      counts.set(name, count)
+      return { latest: name === PACKAGES[0].name || count >= 2 ? '0.20.0' : '0.19.0' }
+    })
+
+    await expect(verifyRelease(PACKAGES, { readPackage, readTags, sleep: async () => {}, write: () => {}, attempts: 2 }))
+      .resolves.toMatchObject({ missing: [] })
+    expect(readTags.mock.calls.map(call => call[0])).toEqual([
+      PACKAGES[0].name,
+      PACKAGES[1].name,
+      PACKAGES[0].name,
+      PACKAGES[1].name,
+    ])
+  })
+
+  it('recovers an old exact tag without consulting mutable latest tags', async () => {
+    const readPackage = async name => ({
+      kind: 'visible',
+      manifest: name === PACKAGES[1].name
+        ? { name, version: '0.20.0', dependencies: { '@dshline/renderer': '^0.20.0' } }
+        : { name, version: '0.20.0' },
+    })
+    const readTags = vi.fn(() => { throw new Error('latest must not be read during historical recovery') })
+
+    await expect(verifyRelease(PACKAGES, {
+      readPackage,
+      readTags,
+      latestPolicy: 'skip',
+      sleep: async () => {},
+      write: () => {},
+    })).resolves.toMatchObject({ missing: [], distTags: new Map() })
+    expect(readTags).not.toHaveBeenCalled()
+  })
+
+  it('rejects a published manifest from the wrong renderer generation', async () => {
+    const readPackage = async name => ({
+      kind: 'visible',
+      manifest: name === PACKAGES[1].name
+        ? { name, version: '0.20.0', dependencies: { '@dshline/renderer': '^0.19.0' } }
+        : { name, version: '0.20.0' },
+    })
+
+    await expect(verifyRelease(PACKAGES, { readPackage, sleep: async () => {}, write: () => {} }))
+      .rejects.toThrow('instead of ^0.20.0')
   })
 })


### PR DESCRIPTION
## Incident

Run [[34215590586](https://github.com/riesbri/dshline/actions/runs/34215590586)](https://github.com/riesbri/dshline/actions/runs/34215590586) published `0.20.0` from tag `v0.20.0` (tag object `c156f200e13c21a4587fa2f570a39cb17e863917`, peeled commit `794a556dc557fbaf39965acdc808fe0306985cdf`) but its registry verifier timed out.

The initial publish had already been accepted by npm. Rerunning publication was therefore unsafe: npm rejected the already-staged immutable version with:

```text id="6m88os"
E409 Cannot publish over previously staged version "0.20.0"
```

The incident was caused by npm registry visibility lag after successful publication, combined with a verifier window that was too short and a workflow topology that retried publication when verification failed.

## Final package state

* `@dshline/renderer@0.20.0` is published and visible.
* `@dshline/dshline@0.20.0` is published and visible.
* Both npm `latest` tags resolve to `0.20.0`.
* `@dshline/dshline@0.20.0` depends on `@dshline/renderer: ^0.20.0`.
* The immutable `v0.20.0` tag still peels to `794a556dc557fbaf39965acdc808fe0306985cdf`.
* The GitHub Release for `v0.20.0` now exists and is neither a draft nor a prerelease.

No `0.20.1` recovery release was required.

## What changed

Release orchestration is split into four ordinary release stages:

1. `release-preflight`

   * No OIDC.
   * Checks the release tag and Harness release channel.
   * Installs, builds, typechecks, tests, and audits.
   * Packs no-script npm tarballs.
   * Uploads the validated package artifacts.

2. `publish-to-npm`

   * The only ordinary npm OIDC job.
   * Downloads the validated tarballs.
   * Re-checks the mutable Harness `latest` channel immediately before the trusted-publishing boundary.
   * Uses an isolated npm configuration with ambient npm credentials cleared.
   * Publishes with provenance, fixed registry, `--ignore-scripts`, and `latest`.

3. `verify-registry`

   * Runs separately from npm publication.
   * Uses one bounded, scanning-aware verification window.
   * Verifies exact package identities, versions, renderer dependency coherence, and stable dist-tags.
   * Retries transient registry visibility/network conditions without repeating publication.

4. `github-release`

   * Runs only after registry verification succeeds.
   * Has `contents: write` but no npm OIDC permission.
   * Creates or safely reuses the GitHub Release for the existing immutable tag.

The Harness release-channel check intentionally runs twice: once during preflight and again in `publish-to-npm` after artifact download and before the first irreversible npm write. This closes the TOCTOU window around the mutable `@deepseek-ai/dsh@latest` pointer.

## Idempotency and recovery

The publisher now distinguishes immutable publication from eventual registry visibility:

* exact package versions already visible on npm are skipped;
* only npm's exact expected staged-version `E409` for the expected registry/package/version may be treated as already accepted;
* generic conflicts, authentication failures, permission failures, 5xx responses, or unexpected registry states still fail closed;
* final registry verification remains authoritative.

A separate existing-tag recovery path is available through `workflow_dispatch`.

Recovery:

* must be dispatched from reviewed `main`;
* accepts an explicit existing stable `v*` tag;
* checks out and validates the exact tagged tree;
* verifies that the tag is reachable from `main`;
* validates the tagged Harness target;
* verifies exact npm package versions and dependency coherence read-only;
* does not consult mutable npm/Harness `latest` values for historical recovery;
* never publishes npm;
* never creates, moves, deletes, or recreates the release tag;
* creates or reuses the GitHub Release only after verification succeeds.

## Security boundaries

* `release-preflight`: `contents: read`, no OIDC.
* `publish-to-npm`: `contents: read` + `id-token: write`.
* `verify-registry`: read-only, no OIDC.
* `github-release`: `contents: write`, no npm OIDC.
* recovery verification: read-only.
* recovered GitHub Release creation: `contents: write`, no npm OIDC.

The OIDC-bearing publisher consumes prebuilt validated tarballs and does not install dependencies, build, test, pack, or execute package lifecycle scripts.

## Validation

Final PR head:

`1cd3ada29a9cc58a5571e876afda364488773884`

Validation before merge:

* Focused follow-up suite: **83 passed**.
* Full suite: **3168 passed, 37 skipped**.
* `pnpm typecheck`: passed.
* `pnpm build`: passed.
* `pnpm security`: passed.
* `pnpm run lint:workflows`: passed.
* `pnpm run verify-docs`: passed.
* CodeQL: passed with no new alerts in changed code.
* Required CI checks: passed.
* Required Security checks: passed.
* `git diff --check`: passed.

PR #180 merged as:

`f7e93d04354046ac3ccf067139b7de720d73f02d`

## Follow-up workflow parser hotfix

After merge, the first recovery dispatch exposed a GitHub Actions YAML parser error caused by defining both:

```yaml id="7xd2rm"
NPM_CONFIG_USERCONFIG
npm_config_userconfig
```

in the same environment map.

PR #181 removed only the lowercase duplicate and added focused regression coverage:

https://github.com/riesbri/dshline/pull/181

PR #181 merged as:

`8c05ca3efadbfa9d7b147dab2007418525e2f9bd`

No npm publication, tag mutation, or GitHub Release mutation occurred during the failed parser-level dispatch.

## Recovery completed

Existing-tag recovery was successfully executed from reviewed `main`:

https://github.com/riesbri/dshline/actions/runs/34233213107

The successful recovery path was:

```text id="pptdbt"
verify existing tag recovery
        ↓
create recovered GitHub Release
```

The following ordinary publication jobs were skipped:

* `verify npm trusted publishers`
* `validate and pack release`
* `publish accepted npm operations`
* `verify npm registry visibility`
* ordinary `create GitHub Release`

The recovery verifier confirmed:

* `v0.20.0` resolves to the existing immutable release tree;
* the tag peels to `794a556dc557fbaf39965acdc808fe0306985cdf`;
* the tagged tree uses Harness `0.1.2-rc.1`;
* both exact npm `0.20.0` packages are visible;
* the release generation is coherent.

The recovery job then created the previously missing GitHub Release:

https://github.com/riesbri/dshline/releases/tag/v0.20.0

No npm package was republished and the existing tag was not changed.

## Final outcome

`v0.20.0` recovery is complete.

* npm publication: complete
* npm `latest`: `0.20.0`
* immutable tag: unchanged
* GitHub Release: created
* republish: not performed
* `0.20.1`: not required

The release pipeline now separates irreversible npm publication from retryable registry verification and provides a read-only recovery path for already-published existing tags.

## Residual risks

* The `v*` tag ruleset must continue restricting tag creation/deletion to the release identity; workflow checks cannot replace repository policy.
* npm staged publication and public registry indexing can still be delayed; registry verification is therefore intentionally bounded and independently rerunnable.
* An exact staged npm `E409` proves npm accepted that package/version identity, not independently that another actor's staged bytes are identical. Exact registry manifest/dependency verification remains authoritative after visibility.
* Historical recovery intentionally relies on the immutable tagged tree and exact npm versions rather than current mutable dist-tags.