### PR TITLE
fix(deps): resolve js-yaml to 4.3.2 for GHSA-2883-xcg3-v3hh

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1460,8 +1460,8 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsonc-parser@3.3.1:
@@ -1780,7 +1780,7 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.2(@deepseek-ai/cordis-plugin-include@1.0.7)(@deepseek-ai/cordis-plugin-loader@1.0.3)
       '@deepseek-ai/cordis-plugin-loader': 1.0.3(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/cosmokit': 1.8.3
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
 
   '@deepseek-ai/cordis-plugin-loader@1.0.3(@deepseek-ai/cordis@4.0.2)':
     dependencies:
@@ -1822,7 +1822,7 @@ snapshots:
       '@deepseek-ai/dsh-tools': 0.1.3-alpha.2(b9204c495d3850b6216a3df3a444b8f7)
       '@deepseek-ai/dsh-typert-protocol': 0.1.3-alpha.2(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/schemastery': 3.18.2
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       zod: 4.4.3
 
   '@deepseek-ai/dsh-agent@0.1.3-alpha.2(8a6b2890fc43277c92629a7561891c34)':
@@ -2689,7 +2689,7 @@ snapshots:
 
   jju@1.4.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
`js-yaml@4.3.1` carries [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) (high), patched in `4.3.2`. `pnpm audit --audit-level moderate` — the `advisories` gate in `.github/workflows/security.yml` — fails on `main` today because of it, independently of any open pull request.

## Root cause

`js-yaml` is not a dependency this repository declares. It arrives transitively:

```
@deepseek-ai/cordis-plugin-include@1.0.7  → js-yaml: ^4.1.0
@deepseek-ai/cordis-plugin-loader@1.0.3   → js-yaml: ^4.1.0
```

Both ranges already admit `4.3.2`; a fresh resolve of `^4.1.0` picks it. The lockfile simply still recorded the resolution it made before `4.3.2` was published (2026-08-26, so well outside the two-hour `minimumReleaseAge` window).

## Fix

Lockfile only — **no manifest change and no root `overrides` entry.** An override would have this repository assert a constraint on a package it does not depend on, to reach a version the existing ranges already allow.

`pnpm update js-yaml -r --depth Infinity` does not move an already-recorded transitive resolution, so the lockfile's two dependency edges and its package/snapshot entries were retargeted to `4.3.2` and the graph re-verified from an empty `node_modules`.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts` from a clean tree — supply-chain policies pass over all 235 entries
- `pnpm audit --audit-level moderate` — **no known vulnerabilities found**
- `pnpm peers check`, `pnpm typecheck`, `pnpm build` — clean
- `pnpm test` — 3200 passed, 22 skipped
- `pnpm run lint:workflows`, `pnpm run verify-docs`, `git diff --check` — clean

## Scope

Deliberately separate from #183 (Harness `0.1.5-alpha.1` adoption). The advisory is about a dependency neither branch chose, and keeping it out of the migration keeps that PR atomic. Once this lands, #183 picks it up on its next rebase.
