### PR TITLE
fix(dshline): hold a foreign raw write off the live region's terminal

### DIFF
--- a/.changeset/hold-foreign-stderr-off-the-live-region.md
+++ b/.changeset/hold-foreign-stderr-off-the-live-region.md
@@ -1,0 +1,34 @@
+---
+'@dshline/dshline': patch
+---
+
+Keep a foreign raw write off the terminal the live region owns, so spawning a
+subagent stops printing the root chrome into scrollback a second time.
+
+`Screen` is correct only because it is the sole writer: it remembers the live
+region's height and where it left the cursor, and every redraw climbs that
+remembered geometry to erase the frame before drawing the next one. A write it
+did not issue scrolls the screen out from under that geometry, and from then on
+the erase starts below the frame's first rows instead of above them — so the
+blank separator and `╭─ dshline ─… ─╮` are never erased again, scroll up as
+ordinary output, and stay in native scrollback for good. One more copy lands
+with every commit that follows.
+
+A subagent backend in the adopted Harness generation forwards a delegated child
+process's stderr with `writeFileSync(process.stderr.fd, bytes)` for the whole
+life of the delegation. On an interactive launch descriptor 2 is the terminal
+dshline draws on, which is why the duplicate appears the moment a subagent
+starts and has nothing to do with whether `/work` is open. Patching
+`process.stderr.write` would not catch it — the forward never touches the
+stream — but it reads `process.stderr.fd` on every write, so that is what moves:
+while the window owns the terminal, the descriptor that property reports is a
+writable hole rather than the terminal. `process.stderr.write` is left alone, so
+dshline's own boot-failure reporting and every ordinary stream writer are
+unchanged, and a stderr that is not a terminal (`2>log`) is not touched at all.
+
+The cost is stated rather than hidden: a raw-descriptor writer's bytes are now
+dropped instead of overwriting the input frame. That loses no failure reporting
+— a backend's run failures reach the transcript through the subagent lifecycle,
+not through descriptor 2 — and the bytes being dropped were unreadable anyway.
+The real fix belongs upstream, in a backend that should not write to a
+frontend's terminal; this keeps the frame correct until it does.

--- a/.changeset/hold-foreign-stderr-off-the-live-region.md
+++ b/.changeset/hold-foreign-stderr-off-the-live-region.md
@@ -14,21 +14,47 @@ blank separator and `╭─ dshline ─… ─╮` are never erased again, scrol
 ordinary output, and stay in native scrollback for good. One more copy lands
 with every commit that follows.
 
-A subagent backend in the adopted Harness generation forwards a delegated child
-process's stderr with `writeFileSync(process.stderr.fd, bytes)` for the whole
-life of the delegation. On an interactive launch descriptor 2 is the terminal
-dshline draws on, which is why the duplicate appears the moment a subagent
-starts and has nothing to do with whether `/work` is open. Patching
-`process.stderr.write` would not catch it — the forward never touches the
-stream — but it reads `process.stderr.fd` on every write, so that is what moves:
-while the window owns the terminal, the descriptor that property reports is a
-writable hole rather than the terminal. `process.stderr.write` is left alone, so
-dshline's own boot-failure reporting and every ordinary stream writer are
-unchanged, and a stderr that is not a terminal (`2>log`) is not touched at all.
+A subagent backend in the generation named by `HARNESS_TARGET`
+(`@deepseek-ai/dsh-subagent-codex@0.1.5-alpha.1`, `startCodexRun`'s stderr
+forward) writes a delegated child process's stderr straight to descriptor 2 —
+`writeFileSync(process.stderr.fd, bytes)` — unconditionally, for the whole life
+of the run. On an interactive launch descriptor 2 is the terminal dshline draws
+on, which is why the duplicate appears the moment a subagent starts and has
+nothing to do with whether `/work` is open. Nothing in dshline's runtime names
+that backend or branches on a provider: what is contained is a write shape.
 
-The cost is stated rather than hidden: a raw-descriptor writer's bytes are now
-dropped instead of overwriting the input frame. That loses no failure reporting
-— a backend's run failures reach the transcript through the subagent lifecycle,
-not through descriptor 2 — and the bytes being dropped were unreadable anyway.
-The real fix belongs upstream, in a backend that should not write to a
-frontend's terminal; this keeps the frame correct until it does.
+**This is a temporary compatibility shim, not a dshline abstraction.** The real
+fix is upstream — a delegated child's diagnostics belong on a Host-owned
+diagnostic seam, not on a frontend's terminal. `src/stderr.ts` carries the
+removal condition in its own header: it is deleted, with its wiring and its two
+specs, when `HARNESS_TARGET` advances to a generation whose subagent backends no
+longer write raw child diagnostics to the frontend's terminal.
+
+Patching `process.stderr.write` would not catch the forward — it never touches
+the stream — but it reads `process.stderr.fd` on every write, so that is what
+moves: while the window owns the terminal, the descriptor that property reports
+is a writable hole. Whether that is safe depends on two Node behaviours, and
+both are now pinned by real child processes rather than by stubs: a raw
+`writeFileSync` follows the substituted descriptor, and a socket-backed
+`process.stderr` — a pipe in the test, a terminal in production, both writing
+through a libuv handle opened once — does not, so the ordinary stream path keeps
+reaching the terminal. A FILE-backed `process.stderr` is `SyncWriteStream` and
+*does* re-resolve the property on every write, which is recorded as the stronger
+reason the shim refuses to hold a stderr that is not a terminal.
+
+That refusal is now a real device-identity test rather than an inference.
+`isTTY` on both streams does not establish that stdout and stderr are the same
+terminal — the previous version of this check claimed it did — so
+`rawStderrReach` stats both descriptors: two handles on one terminal report one
+non-zero `rdev`, and two terminals report two. It answers `reaches`,
+`cannot-reach`, or `unknown`, and holds on the first and the last. A Windows
+console reports an `rdev` of zero and lands in `unknown`, where protecting the
+frame is the conservative choice; a proven second terminal, a piped stderr and a
+`2>log` run are all left exactly as found.
+
+No capture, tee, or logging sink is added. Harness owns Host diagnostics and
+subagent failure reporting, and a second authority over the same bytes in the
+frontend would be worse than dropping them: a run's own failure reaches the
+transcript through the subagent lifecycle, never through descriptor 2, and the
+bytes being dropped were unreadable anyway because they were landing on top of
+the frame they corrupted.

--- a/.changeset/hold-foreign-stderr-off-the-live-region.md
+++ b/.changeset/hold-foreign-stderr-off-the-live-region.md
@@ -26,9 +26,20 @@ that backend or branches on a provider: what is contained is a write shape.
 **This is a temporary compatibility shim, not a dshline abstraction.** The real
 fix is upstream — a delegated child's diagnostics belong on a Host-owned
 diagnostic seam, not on a frontend's terminal. `src/stderr.ts` carries the
-removal condition in its own header: it is deleted, with its wiring and its two
-specs, when `HARNESS_TARGET` advances to a generation whose subagent backends no
-longer write raw child diagnostics to the frontend's terminal.
+removal condition in its own header, and the shim is registered in a new root
+file, `HARNESS_COMPAT`, so it cannot quietly become permanent.
+
+That register lists each temporary workaround with the generation it was last
+confirmed to still be needed against, and `node tools/harness-target.mjs` — the
+coherence check the Harness-Sync adoption proposal, the blocking `Harness
+target` lane and every release already run — fails while a record names any
+generation other than the adopted one. So advancing `HARNESS_TARGET` cannot go
+green until the adopter decides, per shim: confirm the upstream behavior is
+still there and bump the record deliberately, or delete the shim with its
+wiring, its tests and its record. A record whose module no longer exists fails
+too, so the register cannot outlive what it describes. The check is a string
+comparison between two files in this repository — it parses no upstream source,
+so nothing couples a build to a backend's internal layout.
 
 Patching `process.stderr.write` would not catch the forward — it never touches
 the stream — but it reads `process.stderr.fd` on every write, so that is what

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,16 @@ jobs:
             echo "version=$(node tools/harness-target.mjs --version)"
           } >> "$GITHUB_OUTPUT"
 
+      # Two files in THIS repository against the target above: every dsh-*
+      # spec is exactly the adopted version, and every temporary workaround in
+      # HARNESS_COMPAT has been reconciled with it. Nothing here reads upstream
+      # source, so it costs a second and couples this lane to no external
+      # layout — it exists so a hand-edited HARNESS_TARGET is caught here
+      # rather than at release, which is where the Harness-Sync proposal and
+      # the publish lane already run the same check.
+      - name: this repository is coherent with the adopted target
+        run: node tools/harness-target.mjs
+
       - name: check out the adopted harness revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/HARNESS_COMPAT
+++ b/HARNESS_COMPAT
@@ -1,0 +1,42 @@
+# Temporary compatibility shims for defects in the adopted Harness generation.
+#
+# dshline supports one Harness generation at a time and deletes obsolete
+# assumptions rather than carrying them behind a compatibility layer
+# (HARNESS_TARGET explains why). Occasionally a generation ships a defect
+# dshline has to work around locally until upstream fixes it. Such a workaround
+# is not architecture, and the failure mode is not that it is wrong — it is
+# that it is forgotten, kept forever, and eventually read as a design decision
+# by whoever finds it next.
+#
+# This file is the list of them, and it exists to force a decision at the one
+# moment a decision is possible: adopting the next generation. Each record
+# names a shim and the generation it was last confirmed to still be needed
+# against. `node tools/harness-target.mjs` — the coherence check the
+# Harness-Sync proposal, the blocking `Harness target` lane, and every release
+# already run — fails while a record names a generation other than the adopted
+# one.
+#
+# So advancing HARNESS_TARGET fails until the adopter answers, per shim:
+#
+#   - does the new generation still perform the offending behavior?
+#     yes → bump this record's version, deliberately, in the migration commit
+#     no  → delete the shim, its wiring, its tests, and this record
+#
+# The check is a string comparison between two files in this repository. It
+# deliberately does NOT parse upstream source: a check that read a backend's
+# internals would couple every build to their layout and would break on a
+# refactor that fixed nothing. Confirming the behavior is the adopter's job,
+# once per generation, with the upstream checkout the migration already has in
+# front of it.
+#
+#   shim <path> <generation the shim was last confirmed against>
+#
+# The path is the shim's own module, and that module's header is where the
+# behavior, the reasoning, and the removal condition are written down. This
+# file holds no second copy of them.
+
+# A subagent backend forwards a delegated child process's stderr straight to
+# file descriptor 2 for the life of the run, which on an interactive launch is
+# the terminal the live region is drawn on. Read the module header before
+# touching this record.
+shim packages/dshline/src/stderr.ts 0.1.5-alpha.1

--- a/HARNESS_TARGET
+++ b/HARNESS_TARGET
@@ -34,6 +34,15 @@
 # to match, and edit the two lines below. Never advance it to a revision
 # dshline does not already work against — a green `Harness target` is the claim
 # this file makes.
+#
+# One more thing belongs to that commit. HARNESS_COMPAT lists the temporary
+# workarounds dshline carries for defects in the generation named below, each
+# recorded against the generation it was last confirmed to still be needed
+# against. The same coherence check that reads this file fails while a record
+# names a different generation, so advancing this pointer forces a decision on
+# every one of them: confirm the upstream behavior is still there, or delete
+# the workaround. A workaround nobody is made to revisit is a workaround that
+# becomes permanent.
 
 revision 5dda764ed3aa172535a7967b06ff95d9cbfe536a
 version 0.1.5-alpha.1

--- a/packages/dshline/src/stderr.ts
+++ b/packages/dshline/src/stderr.ts
@@ -1,28 +1,26 @@
 /**
- * TEMPORARY COMPATIBILITY SHIM — remove when the adopted Harness generation
- * stops writing a delegated child's diagnostics to the frontend's terminal.
+ * TEMPORARY COMPATIBILITY SHIM for a defect in the adopted Harness generation.
+ * Not a dshline abstraction, and it should not grow into one.
  *
- * This module is not a dshline abstraction and should not grow into one. It
- * exists to contain one upstream defect, and its removal condition is written
- * down below so it is deleted rather than inherited.
+ * Registered in `HARNESS_COMPAT`, so the next generation cannot be adopted
+ * without someone deciding whether this is still needed. See ## Removal.
  *
  * ## What it contains
  *
- * `Screen`'s whole correctness argument is that it is the only writer: it
- * remembers how many rows the live region occupies and where it left the
- * cursor, and every redraw climbs that remembered geometry to erase the frame
- * before drawing the next one. A write it did not issue moves the cursor and
- * scrolls the screen behind its back, and from then on the climb starts from
- * the wrong row — so `CSI 0J` clears from below the frame's first rows instead
- * of from above them. Those rows are never erased again, scroll up as ordinary
- * output, and stay in native scrollback for good. What a reader sees is the
- * root chrome — `╭─ dshline ─… ─╮` — printed a second time, once per commit
- * that follows.
+ * `Screen` is correct only because it is the sole writer: it remembers how
+ * many rows the live region occupies and where it left the cursor, and every
+ * redraw climbs that remembered geometry to erase the frame before drawing the
+ * next one. A write it did not issue moves the cursor and scrolls the screen
+ * behind its back, so from then on the climb starts from the wrong row and
+ * `CSI 0J` clears from below the frame's first rows instead of from above
+ * them. Those rows are never erased again and stay in native scrollback for
+ * good: the root chrome — `╭─ dshline ─… ─╮` — printed a second time, once per
+ * commit that follows.
  *
- * dshline enforces that rule for its own code. It cannot enforce it
- * for a plugin that writes to file descriptor 2 directly, and a subagent
- * backend in the generation named by `HARNESS_TARGET` does exactly that: while
- * a delegation runs, it forwards the delegated child process's stderr with
+ * dshline enforces that rule for its own code. It cannot enforce it for a
+ * plugin writing to file descriptor 2 directly, and a subagent backend in the
+ * generation named by `HARNESS_TARGET` does exactly that for the whole life of
+ * a delegation:
  *
  * ```ts
  * child.stderr?.on('data', chunk => {
@@ -30,58 +28,65 @@
  * })
  * ```
  *
- * unconditionally, for the whole life of the run. On an interactive launch
- * descriptor 2 is the terminal dshline is drawing on, so a delegation's startup
- * diagnostics land inside the composer frame — which is why the duplicate
- * appears the moment a subagent is spawned and not before. Nothing about it is
- * specific to one backend's presentation, and nothing here branches on a
- * provider: the shim contains a WRITE SHAPE, not a vendor.
+ * On an interactive launch descriptor 2 is the terminal dshline is drawing on,
+ * so the delegated child's diagnostics land inside the composer frame — which
+ * is why the duplicate appears the moment a subagent is spawned. Nothing here
+ * branches on a provider: what is contained is a WRITE SHAPE, not a vendor.
  *
  * ## Why the descriptor and not the stream
  *
- * Replacing or wrapping `process.stderr.write` would not catch it — the
- * forward never goes through the stream. What it does read, on every write, is
- * `process.stderr.fd`. So that is what moves: while the window owns the
- * terminal, the descriptor that property reports is a writable hole rather than
- * the terminal, and a raw write through it changes no cell.
+ * Wrapping `process.stderr.write` would not catch the forward, which never
+ * goes through the stream. What it does read, on every write, is
+ * `process.stderr.fd` — so that is what moves: while the window owns the
+ * terminal, the descriptor that property reports is a writable hole, and a raw
+ * write through it changes no cell.
  *
- * The ordinary stream path survives that, but not by accident and not
- * universally. A terminal-backed `process.stderr` is a `tty.WriteStream` — a
- * `net.Socket` writing through a libuv handle opened once at construction — so
- * `write` never re-resolves the property and keeps reaching the terminal,
- * which is what leaves dshline's own boot-failure reporting and every ordinary
- * stream writer working. A FILE-backed `process.stderr` is a different class,
- * `SyncWriteStream`, which writes through `this.fd` on every call:
- * substituting it there would capture the stream path as well. That is the
- * second reason {@link rawStderrReach} refuses to hold a stderr that is not a
- * terminal, and it is the stronger of the two — the first reason is only that
- * no frame could be corrupted.
+ * That leaves the ordinary stream path alone, and the reason is a Node
+ * implementation detail rather than anything Node promises. What is actually
+ * tested, in real child processes (`tests/stderr-descriptor.spec.ts`), is:
  *
- * None of that is a guarantee this module can make about Node. It is pinned by
- * real child processes in `tests/stderr-descriptor.spec.ts` rather than
- * asserted here, so a release that changes the resolution order fails that test
- * instead of silently un-fixing this — or silently swallowing stderr.
+ * - a raw `writeFileSync(process.stderr.fd, …)` follows the substitution, and
+ *   the substitution reverses exactly;
+ * - a SOCKET-backed `process.stderr` writes through a handle rather than
+ *   through the property, so `write` is unaffected. The test drives a pipe; a
+ *   terminal is the same stream family (`tty.WriteStream` extends
+ *   `net.Socket`) but the suite cannot allocate a pty, so the production case
+ *   is inferred from the pipe rather than observed. That inference is the one
+ *   thing here taken on trust;
+ * - a FILE-backed `process.stderr` is `SyncWriteStream` and DOES re-resolve
+ *   the property per write, so holding one would capture ordinary stream
+ *   writes too.
+ *
+ * The third is why {@link rawStderrReach} refusing a non-terminal stderr is
+ * load-bearing rather than merely tidy, and it is the stronger of that
+ * refusal's two reasons — the other is only that no frame could be corrupted.
  *
  * ## What it deliberately is not
  *
- * Not a capture, tee, or logging subsystem. Harness owns Host diagnostics and
- * subagent failure reporting, and a second sink in the frontend would be a
- * second authority over the same bytes. A raw-descriptor writer's output is
- * therefore DROPPED while the window draws. For the writer this exists to
- * contain that costs no failure reporting — a run's own failure reaches the
- * transcript through the subagent lifecycle, never through descriptor 2 — and
- * the bytes being dropped were unreadable anyway, because they were landing on
- * top of the frame they corrupted.
+ * Not a capture, tee, or logging sink. Harness owns Host diagnostics and
+ * subagent failure reporting; a second sink here would be a second authority
+ * over the same bytes. So a raw-descriptor writer's output is DROPPED while
+ * the window draws. That costs no failure reporting — a run's own failure
+ * reaches the transcript through the subagent lifecycle, never through
+ * descriptor 2 — and the dropped bytes were unreadable anyway, because they
+ * were landing on top of the frame they corrupted.
  *
  * ## Removal
  *
- * Delete this module, its wiring in `./window.ts`, and its two specs when
- * `HARNESS_TARGET` advances to a generation whose subagent backends no longer
- * write raw child diagnostics to the frontend's terminal — a Host-owned
- * diagnostic sink, a session event, or any other frontend-safe seam. Advancing
- * that pointer IS the migration (see the file's own header), so the check
- * belongs in the same commit: if the write shape above is gone from the adopted
- * generation, this goes with it.
+ * Delete this module, its `ctx.effect` in `./window.ts`,
+ * `tests/stderr-descriptor.spec.ts`, the containment half of
+ * `tests/foreign-writes.spec.ts`, and this shim's `HARNESS_COMPAT` record,
+ * once a generation routes a delegated child's diagnostics through a
+ * Host-owned seam — a diagnostic sink, a session event, anything but the
+ * frontend's terminal descriptor.
+ *
+ * The `HARNESS_COMPAT` record is what forces that question to be asked:
+ * `node tools/harness-target.mjs` fails while the record names a generation
+ * other than the adopted one, and that check runs in the blocking `Harness
+ * target` lane, in the Harness-Sync adoption proposal, and at release. It
+ * cannot answer the question — confirming the upstream behavior is the
+ * adopter's job — it can only refuse to let the migration go green until
+ * someone has.
  * @module dshline/stderr
  */
 

--- a/packages/dshline/src/stderr.ts
+++ b/packages/dshline/src/stderr.ts
@@ -1,5 +1,12 @@
 /**
- * Hold foreign raw writes off the terminal the live region owns.
+ * TEMPORARY COMPATIBILITY SHIM — remove when the adopted Harness generation
+ * stops writing a delegated child's diagnostics to the frontend's terminal.
+ *
+ * This module is not a dshline abstraction and should not grow into one. It
+ * exists to contain one upstream defect, and its removal condition is written
+ * down below so it is deleted rather than inherited.
+ *
+ * ## What it contains
  *
  * `Screen`'s whole correctness argument is that it is the only writer: it
  * remembers how many rows the live region occupies and where it left the
@@ -12,49 +19,170 @@
  * root chrome — `╭─ dshline ─… ─╮` — printed a second time, once per commit
  * that follows.
  *
- * dshline can enforce that rule for its own code and does. It cannot enforce it
+ * dshline enforces that rule for its own code. It cannot enforce it
  * for a plugin that writes to file descriptor 2 directly, and a subagent
- * backend in the adopted Harness generation does exactly that: it forwards a
- * delegated child process's stderr with
- * `writeFileSync(process.stderr.fd, bytes)` for the whole life of the
- * delegation. On an interactive launch descriptor 2 IS the terminal dshline is
- * drawing on, so a delegation's startup diagnostics land inside the composer
- * frame — which is why this shows up the moment a subagent is spawned and not
- * before.
+ * backend in the generation named by `HARNESS_TARGET` does exactly that: while
+ * a delegation runs, it forwards the delegated child process's stderr with
  *
- * Patching `process.stderr.write` would not catch it — the forward never goes
- * through the stream. What it does read, every time, is `process.stderr.fd`. So
- * that is what this moves: while the window owns the terminal, the descriptor
- * that property reports is a writable hole rather than the terminal, and a raw
- * write through it changes no cell. `process.stderr.write` is deliberately left
- * alone, so dshline's own boot-failure reporting still reaches a real stderr,
- * and so does every ordinary stream writer.
+ * ```ts
+ * child.stderr?.on('data', chunk => {
+ *   writeFileSync(process.stderr.fd, Buffer.from(chunk))
+ * })
+ * ```
  *
- * The cost is stated rather than hidden: a raw-descriptor writer's bytes are
- * dropped instead of being drawn somewhere safe. For the writer this exists to
- * contain that is not a loss of failure reporting — a backend's own run
- * failures reach the transcript through the subagent lifecycle, not through
- * descriptor 2 — and the bytes it was dropping were unreadable anyway, because
- * they were overwriting the input frame they landed in. The real fix belongs
- * upstream, in a backend that should not be writing to a frontend's terminal
- * at all; this only keeps the frame correct until it does.
+ * unconditionally, for the whole life of the run. On an interactive launch
+ * descriptor 2 is the terminal dshline is drawing on, so a delegation's startup
+ * diagnostics land inside the composer frame — which is why the duplicate
+ * appears the moment a subagent is spawned and not before. Nothing about it is
+ * specific to one backend's presentation, and nothing here branches on a
+ * provider: the shim contains a WRITE SHAPE, not a vendor.
+ *
+ * ## Why the descriptor and not the stream
+ *
+ * Replacing or wrapping `process.stderr.write` would not catch it — the
+ * forward never goes through the stream. What it does read, on every write, is
+ * `process.stderr.fd`. So that is what moves: while the window owns the
+ * terminal, the descriptor that property reports is a writable hole rather than
+ * the terminal, and a raw write through it changes no cell.
+ *
+ * The ordinary stream path survives that, but not by accident and not
+ * universally. A terminal-backed `process.stderr` is a `tty.WriteStream` — a
+ * `net.Socket` writing through a libuv handle opened once at construction — so
+ * `write` never re-resolves the property and keeps reaching the terminal,
+ * which is what leaves dshline's own boot-failure reporting and every ordinary
+ * stream writer working. A FILE-backed `process.stderr` is a different class,
+ * `SyncWriteStream`, which writes through `this.fd` on every call:
+ * substituting it there would capture the stream path as well. That is the
+ * second reason {@link rawStderrReach} refuses to hold a stderr that is not a
+ * terminal, and it is the stronger of the two — the first reason is only that
+ * no frame could be corrupted.
+ *
+ * None of that is a guarantee this module can make about Node. It is pinned by
+ * real child processes in `tests/stderr-descriptor.spec.ts` rather than
+ * asserted here, so a release that changes the resolution order fails that test
+ * instead of silently un-fixing this — or silently swallowing stderr.
+ *
+ * ## What it deliberately is not
+ *
+ * Not a capture, tee, or logging subsystem. Harness owns Host diagnostics and
+ * subagent failure reporting, and a second sink in the frontend would be a
+ * second authority over the same bytes. A raw-descriptor writer's output is
+ * therefore DROPPED while the window draws. For the writer this exists to
+ * contain that costs no failure reporting — a run's own failure reaches the
+ * transcript through the subagent lifecycle, never through descriptor 2 — and
+ * the bytes being dropped were unreadable anyway, because they were landing on
+ * top of the frame they corrupted.
+ *
+ * ## Removal
+ *
+ * Delete this module, its wiring in `./window.ts`, and its two specs when
+ * `HARNESS_TARGET` advances to a generation whose subagent backends no longer
+ * write raw child diagnostics to the frontend's terminal — a Host-owned
+ * diagnostic sink, a session event, or any other frontend-safe seam. Advancing
+ * that pointer IS the migration (see the file's own header), so the check
+ * belongs in the same commit: if the write shape above is gone from the adopted
+ * generation, this goes with it.
  * @module dshline/stderr
  */
 
-import { closeSync, openSync } from 'node:fs'
+import { closeSync, fstatSync, openSync } from 'node:fs'
 import { devNull } from 'node:os'
+
+/**
+ * What is KNOWN about whether a raw descriptor-2 write can reach the terminal
+ * the live region is drawn on. Three answers, because two of them are facts and
+ * the third is the honest absence of one.
+ */
+type RawStderrReach =
+  /** Proven to be the same terminal device the live region is drawn on. */
+  | 'reaches'
+  /** Proven not to be: not a terminal at all, or a different terminal device. */
+  | 'cannot-reach'
+  /** Neither could be established on this platform. */
+  | 'unknown'
+
+/**
+ * The descriptor a stream reports, when it reports a numeric one at all.
+ *
+ * `NodeJS.WriteStream` does not declare `fd`, and a stand-in may expose it
+ * through an accessor, so it is read reflectively rather than cast into
+ * existence. A stream with no numeric descriptor is not an error here — it is
+ * simply nothing to stat.
+ * @param stream - the stream to read.
+ * @returns the descriptor, or nothing when there is no numeric one.
+ */
+function descriptorOf(stream: NodeJS.WriteStream): number | undefined {
+  const value: unknown = Reflect.get(stream, 'fd')
+  return typeof value === 'number' ? value : undefined
+}
+
+/**
+ * Whether a raw write to `stderr`'s descriptor can land on `stdout`'s terminal.
+ *
+ * `isTTY` on both streams does NOT establish this, and the previous version of
+ * this check claimed it did. It answers a weaker question — each descriptor is
+ * *a* terminal — and two terminals are exactly the case where moving stderr
+ * would be an unnecessary mutation of a process global.
+ *
+ * The stronger question is answerable on POSIX and is asked here: a terminal is
+ * a character device, and `fstat`'s `rdev` is the device it is a handle on, so
+ * two descriptors on ONE terminal report one non-zero `rdev` and descriptors on
+ * two terminals report two. That is a real identity test rather than an
+ * inference, and it is what `reaches` and `cannot-reach` are read off.
+ *
+ * It is not universally available. A Windows console handle is a character
+ * device with an `rdev` of zero, which distinguishes nothing, and a stream may
+ * report no own descriptor to stat at all. Those answer `unknown` rather than
+ * guessing, and the caller decides what to do about not knowing.
+ * @param stdout - the stream the live region is drawn on.
+ * @param stderr - the stream whose raw descriptor writes are in question.
+ * @returns what is known, never a guess dressed as a fact.
+ */
+export function rawStderrReach(
+  stdout: NodeJS.WriteStream,
+  stderr: NodeJS.WriteStream,
+): RawStderrReach {
+  // Nothing is being drawn on a terminal, or the descriptor in question is not
+  // one. Either answer settles it: there is no live region for a raw write to
+  // displace, or the write cannot arrive at a terminal to displace it. The
+  // second case is also the one where holding would be actively wrong — a
+  // file-backed `process.stderr` resolves `this.fd` on every stream write, so
+  // substituting it would redirect writes this module has no business
+  // redirecting. See the module doc.
+  if (stdout.isTTY !== true || stderr.isTTY !== true) return 'cannot-reach'
+  const drawn = descriptorOf(stdout)
+  const raw = descriptorOf(stderr)
+  if (drawn === undefined || raw === undefined) return 'unknown'
+  try {
+    const drawnStat = fstatSync(drawn)
+    const rawStat = fstatSync(raw)
+    // A zero `rdev` carries no device identity — Windows consoles report one —
+    // so it is read as an absence of evidence rather than as a match.
+    if (
+      !drawnStat.isCharacterDevice() || !rawStat.isCharacterDevice()
+      || drawnStat.rdev === 0 || rawStat.rdev === 0
+    ) return 'unknown'
+    return drawnStat.rdev === rawStat.rdev ? 'reaches' : 'cannot-reach'
+  } catch {
+    // A descriptor that cannot be stat'd tells us nothing about where it points.
+    return 'unknown'
+  }
+}
 
 /**
  * Point `process.stderr.fd` at a hole for as long as the window draws.
  *
- * Nothing happens unless it would matter. A stderr that is not a terminal — a
- * `2>log` run, a pipe, a test — cannot displace a live region however it is
- * written to, so its descriptor is left exactly as it was found; the same goes
- * for a stream that reports no own `fd` to move, and for a platform with no
- * openable null device.
+ * Engaged on `reaches` and on `unknown`, and that asymmetry is the conservative
+ * choice made explicit: where the platform cannot prove the two descriptors are
+ * different terminals, the frame is protected. The cost of being wrong that way
+ * is a dropped raw-descriptor diagnostic on a terminal nobody was drawing on;
+ * the cost of being wrong the other way is a corrupted transcript the reader
+ * cannot repair. `cannot-reach` is left completely alone, so a `2>log` run, a
+ * piped stderr, and a proven second terminal all keep their descriptor exactly
+ * as it was found.
  * @param stderr - the stream to hold; the process's own by default.
- * @param stdout - the stream the live region is drawn on, used only to decide
- *   whether a raw stderr write could reach it at all.
+ * @param stdout - the stream the live region is drawn on; the process's own by
+ *   default. Read only to decide whether holding is warranted at all.
  * @returns the disposer restoring the original descriptor; safe to call twice.
  */
 export function holdStderrOffTerminal(
@@ -62,10 +190,7 @@ export function holdStderrOffTerminal(
   stdout: NodeJS.WriteStream = process.stdout,
 ): () => void {
   const nothing = (): void => {}
-  // Both halves are required. A raw write can only corrupt the frame when the
-  // frame is on a terminal AND the descriptor being written to is one too;
-  // either answer being no makes this an unnecessary mutation of a global.
-  if (stdout.isTTY !== true || stderr.isTTY !== true) return nothing
+  if (rawStderrReach(stdout, stderr) === 'cannot-reach') return nothing
   const original = Object.getOwnPropertyDescriptor(stderr, 'fd')
   // An accessor, or nothing at all, is not a descriptor this may redefine
   // without changing what the property MEANS to whoever defined it.

--- a/packages/dshline/src/stderr.ts
+++ b/packages/dshline/src/stderr.ts
@@ -1,0 +1,96 @@
+/**
+ * Hold foreign raw writes off the terminal the live region owns.
+ *
+ * `Screen`'s whole correctness argument is that it is the only writer: it
+ * remembers how many rows the live region occupies and where it left the
+ * cursor, and every redraw climbs that remembered geometry to erase the frame
+ * before drawing the next one. A write it did not issue moves the cursor and
+ * scrolls the screen behind its back, and from then on the climb starts from
+ * the wrong row — so `CSI 0J` clears from below the frame's first rows instead
+ * of from above them. Those rows are never erased again, scroll up as ordinary
+ * output, and stay in native scrollback for good. What a reader sees is the
+ * root chrome — `╭─ dshline ─… ─╮` — printed a second time, once per commit
+ * that follows.
+ *
+ * dshline can enforce that rule for its own code and does. It cannot enforce it
+ * for a plugin that writes to file descriptor 2 directly, and a subagent
+ * backend in the adopted Harness generation does exactly that: it forwards a
+ * delegated child process's stderr with
+ * `writeFileSync(process.stderr.fd, bytes)` for the whole life of the
+ * delegation. On an interactive launch descriptor 2 IS the terminal dshline is
+ * drawing on, so a delegation's startup diagnostics land inside the composer
+ * frame — which is why this shows up the moment a subagent is spawned and not
+ * before.
+ *
+ * Patching `process.stderr.write` would not catch it — the forward never goes
+ * through the stream. What it does read, every time, is `process.stderr.fd`. So
+ * that is what this moves: while the window owns the terminal, the descriptor
+ * that property reports is a writable hole rather than the terminal, and a raw
+ * write through it changes no cell. `process.stderr.write` is deliberately left
+ * alone, so dshline's own boot-failure reporting still reaches a real stderr,
+ * and so does every ordinary stream writer.
+ *
+ * The cost is stated rather than hidden: a raw-descriptor writer's bytes are
+ * dropped instead of being drawn somewhere safe. For the writer this exists to
+ * contain that is not a loss of failure reporting — a backend's own run
+ * failures reach the transcript through the subagent lifecycle, not through
+ * descriptor 2 — and the bytes it was dropping were unreadable anyway, because
+ * they were overwriting the input frame they landed in. The real fix belongs
+ * upstream, in a backend that should not be writing to a frontend's terminal
+ * at all; this only keeps the frame correct until it does.
+ * @module dshline/stderr
+ */
+
+import { closeSync, openSync } from 'node:fs'
+import { devNull } from 'node:os'
+
+/**
+ * Point `process.stderr.fd` at a hole for as long as the window draws.
+ *
+ * Nothing happens unless it would matter. A stderr that is not a terminal — a
+ * `2>log` run, a pipe, a test — cannot displace a live region however it is
+ * written to, so its descriptor is left exactly as it was found; the same goes
+ * for a stream that reports no own `fd` to move, and for a platform with no
+ * openable null device.
+ * @param stderr - the stream to hold; the process's own by default.
+ * @param stdout - the stream the live region is drawn on, used only to decide
+ *   whether a raw stderr write could reach it at all.
+ * @returns the disposer restoring the original descriptor; safe to call twice.
+ */
+export function holdStderrOffTerminal(
+  stderr: NodeJS.WriteStream = process.stderr,
+  stdout: NodeJS.WriteStream = process.stdout,
+): () => void {
+  const nothing = (): void => {}
+  // Both halves are required. A raw write can only corrupt the frame when the
+  // frame is on a terminal AND the descriptor being written to is one too;
+  // either answer being no makes this an unnecessary mutation of a global.
+  if (stdout.isTTY !== true || stderr.isTTY !== true) return nothing
+  const original = Object.getOwnPropertyDescriptor(stderr, 'fd')
+  // An accessor, or nothing at all, is not a descriptor this may redefine
+  // without changing what the property MEANS to whoever defined it.
+  if (original === undefined || !('value' in original) || original.configurable !== true) return nothing
+  let hole: number
+  try {
+    hole = openSync(devNull, 'w')
+  } catch {
+    // No null device to hold the writes. The frame is better off with the
+    // corruption than with a boot that fails over a diagnostic sink.
+    return nothing
+  }
+  Object.defineProperty(stderr, 'fd', { ...original, value: hole })
+  let released = false
+  return () => {
+    // Terminal ownership is disposed on several paths, and the descriptor must
+    // go back exactly once: redefining it a second time would restore the hole
+    // that has already been closed.
+    if (released) return
+    released = true
+    Object.defineProperty(stderr, 'fd', original)
+    try {
+      closeSync(hole)
+    } catch {
+      // The descriptor is already gone; the property is what mattered.
+    }
+  }
+}

--- a/packages/dshline/src/window.ts
+++ b/packages/dshline/src/window.ts
@@ -287,12 +287,18 @@ export async function createWindow(ctx: Context, options: WindowOptions): Promis
   const exit = ctx.get('appExit')
   const startup = ctx.tuiStartup.options
   const terminal = acquireTerminal({ input: process.stdin, output: process.stdout })
-  // Taken with the terminal, and released with it. `Screen` is correct only
-  // while it is the sole writer, and a plugin that writes to descriptor 2
-  // directly is not something dshline can ask to stop — see ./stderr.ts for
-  // the writer this contains and why the descriptor, not the stream, is what
-  // moves. Registered before the screen exists, so no frame is ever drawn with
-  // the real descriptor still exposed.
+  // TEMPORARY: a compatibility shim for an upstream defect, not a dshline
+  // abstraction. `Screen` is correct only while it is the sole writer, and a
+  // subagent backend in the generation named by HARNESS_TARGET writes a
+  // delegated child's diagnostics straight to descriptor 2 for the life of the
+  // run — which on an interactive launch is this terminal. ./stderr.ts carries
+  // the write shape, why the descriptor rather than the stream is what moves,
+  // and the condition under which both files are deleted: the real fix is a
+  // Host-owned diagnostic seam upstream, and this goes away with the
+  // generation that provides one.
+  //
+  // Taken with the terminal and released with it, before the screen exists, so
+  // no frame is ever drawn with the real descriptor still exposed.
   ctx.effect(() => holdStderrOffTerminal(), 'dshline: foreign stderr writes')
   // Installed here, and before the screen exists, because this is the one
   // place already coupled to the real `process` streams — the renderer reads

--- a/packages/dshline/src/window.ts
+++ b/packages/dshline/src/window.ts
@@ -40,6 +40,7 @@ import type { CardDetail } from './cards.ts'
 import { pluginsSeams, sessionFacts } from './plugins/harness.ts'
 import type { AgentPresetsSeam } from './plugins/harness.ts'
 import { RedrawScheduler } from './redraw.ts'
+import { holdStderrOffTerminal } from './stderr.ts'
 import type { AttachTarget } from './sessions/reopen.ts'
 import type { TuiStartupOptions } from './startup.ts'
 import type { PeakWindow, PricingTable, UsageMode } from './usage.ts'
@@ -286,6 +287,13 @@ export async function createWindow(ctx: Context, options: WindowOptions): Promis
   const exit = ctx.get('appExit')
   const startup = ctx.tuiStartup.options
   const terminal = acquireTerminal({ input: process.stdin, output: process.stdout })
+  // Taken with the terminal, and released with it. `Screen` is correct only
+  // while it is the sole writer, and a plugin that writes to descriptor 2
+  // directly is not something dshline can ask to stop — see ./stderr.ts for
+  // the writer this contains and why the descriptor, not the stream, is what
+  // moves. Registered before the screen exists, so no frame is ever drawn with
+  // the real descriptor still exposed.
+  ctx.effect(() => holdStderrOffTerminal(), 'dshline: foreign stderr writes')
   // Installed here, and before the screen exists, because this is the one
   // place already coupled to the real `process` streams — the renderer reads
   // no ambient state of its own, so somebody who legitimately owns the

--- a/packages/dshline/tests/foreign-writes.spec.ts
+++ b/packages/dshline/tests/foreign-writes.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * What a writer dshline does not own does to the live region.
+ *
+ * `Screen` redraws by climbing the geometry it remembers, so a write it did not
+ * issue is not a cosmetic problem: it moves the origin every later erase is
+ * measured from, and the frame's first rows — the separator and the root
+ * chrome — are then never erased again. They scroll up as ordinary output and
+ * stay in native scrollback, once per commit that follows.
+ *
+ * Two claims are tested here, and they are different claims. The first is about
+ * the terminal: a raw write into the region really does make root chrome
+ * durable, so the containment below is guarding a real failure rather than a
+ * theory. The second is about the containment: while the window holds the
+ * terminal, `process.stderr.fd` is not the terminal, so the one raw-descriptor
+ * writer in the adopted Harness generation cannot reach a cell.
+ * @module dshline/tests/foreign-writes
+ */
+
+import { closeSync, mkdtempSync, openSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { Screen } from '@dshline/renderer'
+import { createEmulator } from '../../../tests/emulator.ts'
+import { rootFrame } from '../src/chrome.ts'
+import { holdStderrOffTerminal } from '../src/stderr.ts'
+
+/** Wide enough for the framed chrome, narrow enough to read in a failure. */
+const COLUMNS = 40
+
+/** Tall enough for a short transcript plus the chrome below it. */
+const ROWS = 12
+
+/** The window's live region: separator, framed composer, status row. */
+function chrome(): string[] {
+  return ['', ...rootFrame({ columns: COLUMNS, context: 'repo', body: ['> '] }), '  ready']
+}
+
+/** Rows of root chrome the terminal is holding, scrolled-off ones included. */
+async function heldChrome(emulator: ReturnType<typeof createEmulator>): Promise<string[]> {
+  return (await emulator.scrollback()).map(row => row.trimEnd()).filter(row => row.includes('dshline'))
+}
+
+describe('a raw write into the live region', () => {
+  it('makes root chrome durable, which is the failure being contained', async () => {
+    const emulator = createEmulator(COLUMNS, ROWS)
+    const screen = new Screen(emulator.target)
+    screen.commit(['● parent reply'])
+    // The cursor sits inside the composer's input row, where the window leaves it.
+    screen.setLive(chrome(), { row: 2, column: 4 })
+
+    // Exactly what `writeFileSync(process.stderr.fd, bytes)` does to the
+    // terminal dshline is drawing on: bytes at the cursor, and a newline that
+    // scrolls the screen out from under the geometry Screen remembers.
+    emulator.target.write('codex app-server: starting\ncodex app-server: ready\n')
+
+    for (let index = 0; index < 3; index += 1) {
+      screen.commit([`⏺ tool call ${String(index)}`])
+      screen.setLive(chrome(), { row: 2, column: 4 })
+    }
+
+    // Not an assertion about the fix — an assertion about the hazard. If this
+    // ever reports one row, a foreign write stopped being able to displace the
+    // region and the containment below is no longer load-bearing.
+    expect((await heldChrome(emulator)).length).toBeGreaterThan(1)
+    emulator.dispose()
+  })
+
+  it('never happens through dshline\'s own writes, however they interleave', async () => {
+    const emulator = createEmulator(COLUMNS, ROWS)
+    const screen = new Screen(emulator.target)
+    // A whole turn's worth of the two writes the window makes: a synchronous
+    // commit per session event, a coalesced repaint after it. The live chrome
+    // is temporary at every step, so the terminal may hold it exactly once.
+    for (let index = 0; index < 40; index += 1) {
+      screen.commit([`● line ${String(index)}`, `  continuation ${String(index)}`])
+      screen.setLive(chrome(), { row: 2, column: 4 })
+      screen.setLive(chrome(), { row: 2, column: 4 })
+    }
+    expect(await heldChrome(emulator)).toHaveLength(1)
+    emulator.dispose()
+  })
+})
+
+describe('holding stderr off the terminal', () => {
+  it('sends a raw descriptor write to the hole rather than the terminal', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'dshline-stderr-'))
+    const path = join(directory, 'stderr')
+    const captured = openSync(path, 'w+')
+    // A stand-in for the process's own stderr: a real descriptor a raw write
+    // can reach, claiming to be a terminal so the hold engages.
+    const stderr = { isTTY: true, fd: captured } as unknown as NodeJS.WriteStream
+    const stdout = { isTTY: true } as unknown as NodeJS.WriteStream
+    const release = holdStderrOffTerminal(stderr, stdout)
+    try {
+      expect(stderr.fd).not.toBe(captured)
+      writeFileSync(stderr.fd, Buffer.from('codex app-server: starting\n'))
+      expect(readFileSync(path, 'utf8')).toBe('')
+    } finally {
+      release()
+      closeSync(captured)
+    }
+    // Released with terminal ownership: the next process to own descriptor 2
+    // must find it where it was left.
+    expect(stderr.fd).toBe(captured)
+  })
+
+  it('is released exactly once, however many times ownership is disposed', () => {
+    const stderr = { isTTY: true, fd: 2 } as unknown as NodeJS.WriteStream
+    const stdout = { isTTY: true } as unknown as NodeJS.WriteStream
+    const release = holdStderrOffTerminal(stderr, stdout)
+    release()
+    release()
+    expect(stderr.fd).toBe(2)
+  })
+
+  it('leaves a stderr that is not the terminal exactly as it was', () => {
+    // `2>log` is a workflow, not a hazard: a redirected stderr cannot displace
+    // a live region, so nothing about it is moved.
+    const stderr = { isTTY: false, fd: 2 } as unknown as NodeJS.WriteStream
+    const stdout = { isTTY: true } as unknown as NodeJS.WriteStream
+    const release = holdStderrOffTerminal(stderr, stdout)
+    expect(stderr.fd).toBe(2)
+    release()
+    expect(stderr.fd).toBe(2)
+  })
+
+  it('leaves stderr alone when nothing is drawing on a terminal at all', () => {
+    const stderr = { isTTY: true, fd: 2 } as unknown as NodeJS.WriteStream
+    const stdout = { isTTY: false } as unknown as NodeJS.WriteStream
+    holdStderrOffTerminal(stderr, stdout)()
+    expect(stderr.fd).toBe(2)
+  })
+
+  it('leaves the stream writing path alone, so dshline can still report a failure', () => {
+    const written: string[] = []
+    const stderr = {
+      isTTY: true,
+      fd: 2,
+      write: (chunk: string) => { written.push(chunk); return true },
+    } as unknown as NodeJS.WriteStream
+    const stdout = { isTTY: true } as unknown as NodeJS.WriteStream
+    const release = holdStderrOffTerminal(stderr, stdout)
+    stderr.write('dshline: boot failed\r\n')
+    release()
+    expect(written).toEqual(['dshline: boot failed\r\n'])
+  })
+})

--- a/packages/dshline/tests/foreign-writes.spec.ts
+++ b/packages/dshline/tests/foreign-writes.spec.ts
@@ -7,23 +7,43 @@
  * chrome — are then never erased again. They scroll up as ordinary output and
  * stay in native scrollback, once per commit that follows.
  *
- * Two claims are tested here, and they are different claims. The first is about
- * the terminal: a raw write into the region really does make root chrome
- * durable, so the containment below is guarding a real failure rather than a
- * theory. The second is about the containment: while the window holds the
- * terminal, `process.stderr.fd` is not the terminal, so the one raw-descriptor
- * writer in the adopted Harness generation cannot reach a cell.
+ * Three separate claims are tested here. The first is about the terminal: a raw
+ * write into the region really does make root chrome durable, so the
+ * containment is guarding a real failure rather than a theory. The second is
+ * what the containment actually KNOWS — whether a raw descriptor-2 write can
+ * land on the terminal being drawn on — which is a device-identity question and
+ * not the weaker `isTTY` on both streams it used to be answered with. The third
+ * is the containment's own policy: what it holds, what it refuses to touch, and
+ * that it puts the descriptor back exactly once.
+ *
+ * What Node does with a substituted descriptor is deliberately NOT asserted
+ * here. That is a runtime behaviour rather than a dshline decision, and a
+ * stubbed stream would only prove what the stub does; real child processes pin
+ * it in `stderr-descriptor.spec.ts`.
  * @module dshline/tests/foreign-writes
  */
 
 import { closeSync, mkdtempSync, openSync, readFileSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { devNull, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { Screen } from '@dshline/renderer'
 import { createEmulator } from '../../../tests/emulator.ts'
 import { rootFrame } from '../src/chrome.ts'
-import { holdStderrOffTerminal } from '../src/stderr.ts'
+import { holdStderrOffTerminal, rawStderrReach } from '../src/stderr.ts'
+
+/** A second character device, so two DIFFERENT terminals can be stood in for. */
+const OTHER_DEVICE = '/dev/zero'
+
+/**
+ * A stream stand-in with a real descriptor, which is what the reach test stats.
+ * @param fd - the descriptor this stream reports.
+ * @param isTTY - what it claims to be.
+ * @returns the stand-in.
+ */
+function stream(fd: number, isTTY: boolean): NodeJS.WriteStream {
+  return { fd, isTTY } as unknown as NodeJS.WriteStream
+}
 
 /** Wide enough for the framed chrome, narrow enough to read in a failure. */
 const COLUMNS = 40
@@ -82,67 +102,144 @@ describe('a raw write into the live region', () => {
   })
 })
 
+describe('what is known about a raw stderr write reaching the drawn terminal', () => {
+  it.skipIf(process.platform === 'win32')('proves one terminal from two descriptors on it', () => {
+    // Two descriptors on ONE character device report one non-zero `rdev`,
+    // which is an identity rather than the inference `isTTY` on both supports.
+    const first = openSync(devNull, 'w')
+    const second = openSync(devNull, 'w')
+    try {
+      expect(rawStderrReach(stream(first, true), stream(second, true))).toBe('reaches')
+    } finally {
+      closeSync(first)
+      closeSync(second)
+    }
+  })
+
+  it.skipIf(process.platform === 'win32')('proves two terminals apart, and leaves them alone', () => {
+    // The case the old `isTTY && isTTY` condition claimed to have ruled out and
+    // had not: both are terminals, and a raw write to one cannot reach the
+    // other, so nothing should be moved.
+    const drawn = openSync(devNull, 'w')
+    const other = openSync(OTHER_DEVICE, 'w')
+    try {
+      expect(rawStderrReach(stream(drawn, true), stream(other, true))).toBe('cannot-reach')
+      const stderr = stream(other, true)
+      holdStderrOffTerminal(stderr, stream(drawn, true))()
+      expect(stderr.fd).toBe(other)
+    } finally {
+      closeSync(drawn)
+      closeSync(other)
+    }
+  })
+
+  it('settles it without a stat when either end is not a terminal', () => {
+    // `2>log` is a workflow, not a hazard — and holding a file-backed stderr
+    // would capture its ordinary stream writes, which is the stronger reason.
+    expect(rawStderrReach(stream(1, true), stream(2, false))).toBe('cannot-reach')
+    // Nothing is being drawn on a terminal, so there is no frame to protect.
+    expect(rawStderrReach(stream(1, false), stream(2, true))).toBe('cannot-reach')
+  })
+
+  it('answers unknown rather than guessing when the platform cannot say', () => {
+    // A Windows console handle is a character device with an `rdev` of zero,
+    // and a regular file stands in for that here: claiming to be a terminal,
+    // carrying no device identity to compare. The honest answer is that neither
+    // fact was established.
+    const directory = mkdtempSync(join(tmpdir(), 'dshline-reach-'))
+    const path = join(directory, 'not-a-device')
+    const fd = openSync(path, 'w+')
+    try {
+      expect(rawStderrReach(stream(fd, true), stream(fd, true))).toBe('unknown')
+    } finally {
+      closeSync(fd)
+    }
+  })
+
+  it('answers unknown when a stream reports no descriptor to stat', () => {
+    const nofd = { isTTY: true } as unknown as NodeJS.WriteStream
+    expect(rawStderrReach(nofd, nofd)).toBe('unknown')
+  })
+})
+
 describe('holding stderr off the terminal', () => {
   it('sends a raw descriptor write to the hole rather than the terminal', () => {
     const directory = mkdtempSync(join(tmpdir(), 'dshline-stderr-'))
     const path = join(directory, 'stderr')
     const captured = openSync(path, 'w+')
-    // A stand-in for the process's own stderr: a real descriptor a raw write
-    // can reach, claiming to be a terminal so the hold engages.
-    const stderr = { isTTY: true, fd: captured } as unknown as NodeJS.WriteStream
-    const stdout = { isTTY: true } as unknown as NodeJS.WriteStream
-    const release = holdStderrOffTerminal(stderr, stdout)
+    // A regular file claiming to be a terminal is the `unknown` branch: the
+    // platform cannot prove the two descriptors are different terminals, and
+    // the conservative answer is to protect the frame.
+    const stderr = stream(captured, true)
+    const release = holdStderrOffTerminal(stderr, stream(captured, true))
     try {
       expect(stderr.fd).not.toBe(captured)
-      writeFileSync(stderr.fd, Buffer.from('codex app-server: starting\n'))
+      writeFileSync(stderr.fd, Buffer.from('a delegated child diagnostic\n'))
       expect(readFileSync(path, 'utf8')).toBe('')
     } finally {
       release()
       closeSync(captured)
     }
-    // Released with terminal ownership: the next process to own descriptor 2
-    // must find it where it was left.
+    // Released with terminal ownership: the next owner of the descriptor must
+    // find it where it was left.
     expect(stderr.fd).toBe(captured)
   })
 
   it('is released exactly once, however many times ownership is disposed', () => {
-    const stderr = { isTTY: true, fd: 2 } as unknown as NodeJS.WriteStream
-    const stdout = { isTTY: true } as unknown as NodeJS.WriteStream
-    const release = holdStderrOffTerminal(stderr, stdout)
-    release()
-    release()
-    expect(stderr.fd).toBe(2)
+    const directory = mkdtempSync(join(tmpdir(), 'dshline-stderr-'))
+    const fd = openSync(join(directory, 'stderr'), 'w+')
+    try {
+      const stderr = stream(fd, true)
+      const release = holdStderrOffTerminal(stderr, stream(fd, true))
+      release()
+      release()
+      expect(stderr.fd).toBe(fd)
+    } finally {
+      closeSync(fd)
+    }
   })
 
   it('leaves a stderr that is not the terminal exactly as it was', () => {
-    // `2>log` is a workflow, not a hazard: a redirected stderr cannot displace
-    // a live region, so nothing about it is moved.
-    const stderr = { isTTY: false, fd: 2 } as unknown as NodeJS.WriteStream
-    const stdout = { isTTY: true } as unknown as NodeJS.WriteStream
-    const release = holdStderrOffTerminal(stderr, stdout)
+    const stderr = stream(2, false)
+    const release = holdStderrOffTerminal(stderr, stream(1, true))
     expect(stderr.fd).toBe(2)
     release()
     expect(stderr.fd).toBe(2)
   })
 
   it('leaves stderr alone when nothing is drawing on a terminal at all', () => {
-    const stderr = { isTTY: true, fd: 2 } as unknown as NodeJS.WriteStream
-    const stdout = { isTTY: false } as unknown as NodeJS.WriteStream
-    holdStderrOffTerminal(stderr, stdout)()
+    const stderr = stream(2, true)
+    holdStderrOffTerminal(stderr, stream(1, false))()
+    expect(stderr.fd).toBe(2)
+  })
+
+  it('refuses a descriptor property it cannot put back the way it found it', () => {
+    // An accessor is not a value property, and redefining it would change what
+    // the property MEANS to whoever defined it.
+    const stderr = { isTTY: true, get fd() { return 2 } } as unknown as NodeJS.WriteStream
+    holdStderrOffTerminal(stderr, { isTTY: true, fd: 1 } as unknown as NodeJS.WriteStream)()
     expect(stderr.fd).toBe(2)
   })
 
   it('leaves the stream writing path alone, so dshline can still report a failure', () => {
+    // Only that the shim does not touch `write`. Where a real stream's bytes
+    // actually land under substitution is a Node behaviour, pinned by real
+    // child processes in stderr-descriptor.spec.ts.
     const written: string[] = []
-    const stderr = {
-      isTTY: true,
-      fd: 2,
-      write: (chunk: string) => { written.push(chunk); return true },
-    } as unknown as NodeJS.WriteStream
-    const stdout = { isTTY: true } as unknown as NodeJS.WriteStream
-    const release = holdStderrOffTerminal(stderr, stdout)
-    stderr.write('dshline: boot failed\r\n')
-    release()
+    const directory = mkdtempSync(join(tmpdir(), 'dshline-stderr-'))
+    const fd = openSync(join(directory, 'stderr'), 'w+')
+    try {
+      const stderr = {
+        isTTY: true,
+        fd,
+        write: (chunk: string) => { written.push(chunk); return true },
+      } as unknown as NodeJS.WriteStream
+      const release = holdStderrOffTerminal(stderr, stream(fd, true))
+      stderr.write('dshline: boot failed\r\n')
+      release()
+    } finally {
+      closeSync(fd)
+    }
     expect(written).toEqual(['dshline: boot failed\r\n'])
   })
 })

--- a/packages/dshline/tests/stderr-descriptor.spec.ts
+++ b/packages/dshline/tests/stderr-descriptor.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * The Node runtime behaviour the stderr shim is built on, pinned by real processes.
+ *
+ * `src/stderr.ts` contains an upstream defect by substituting the descriptor
+ * `process.stderr.fd` reports. Whether that is correct is a question about Node,
+ * not about dshline, and a stubbed `WriteStream` cannot answer it — it answers
+ * what the stub does. So these tests drive real `node` children with real
+ * descriptors and read the files afterwards.
+ *
+ * Three facts are pinned, and the third is the reason the shim has a guard at
+ * all:
+ *
+ * 1. `writeFileSync(process.stderr.fd, …)` resolves the property at call time,
+ *    so a raw write follows the substituted descriptor, and the substitution is
+ *    exactly reversible.
+ * 2. Where `process.stderr` is a socket-backed stream — a pipe here, and a
+ *    terminal in production, both `net.Socket` writing through a libuv handle
+ *    opened once — `write` does NOT re-resolve the property, so the ordinary
+ *    stream path is untouched by the substitution. This is the case the shim
+ *    actually runs in.
+ * 3. Where `process.stderr` is a FILE, Node uses `SyncWriteStream`, which
+ *    writes through `this.fd` on every call — so substituting it would capture
+ *    the ordinary stream path too. That is not a hazard in production only
+ *    because `rawStderrReach` refuses to hold a stderr that is not a terminal.
+ *    The refusal is load-bearing, so the reason for it is recorded here rather
+ *    than asserted in a comment.
+ *
+ * The children mirror the shim's two operations rather than importing it: the
+ * claims under test are the runtime's, and a child that had to resolve the
+ * frontend's TypeScript would be testing a loader as well. `foreign-writes.spec.ts`
+ * covers the shim's own policy.
+ * @module dshline/tests/stderr-descriptor
+ */
+
+import { execFile } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { describe, expect, it } from 'vitest'
+
+const run = promisify(execFile)
+
+/** Long enough for a cold Node start on a loaded runner, short enough to fail fast. */
+const CHILD_TIMEOUT_MS = 30_000
+
+/** Distinct markers, because the whole question is which destination each reaches. */
+const RAW_HELD = 'raw-while-held'
+const STREAM_HELD = 'stream-while-held'
+const RAW_RELEASED = 'raw-after-release'
+
+/** One driven child: its own temp directory, its own destinations, its own verdict. */
+interface Child {
+  /** Whatever the program printed on stdout, including its own diagnostics. */
+  readonly stdout: string
+  /** The program's exit status, read back through the shell. */
+  readonly status: number
+  /** Contents of the file the substituted descriptor was opened on. */
+  readonly hole: string
+  /** Contents of whatever the child's real stderr was redirected into. */
+  readonly stderr: string
+}
+
+/**
+ * Run one child program with its stderr redirected the way a case needs.
+ *
+ * `sh -c` owns the redirection so the child inherits descriptor 2 as the shell
+ * set it up — which is the only way to give a child a stderr that is a file in
+ * one case and a pipe in another without Node choosing for us.
+ * @param source - the program, as a function of its hole path.
+ * @param redirect - shell redirection for descriptor 2, given the stderr path.
+ * @returns what the child printed, exited with, and left in each destination.
+ */
+async function drive(
+  source: (hole: string) => string,
+  redirect: (stderrPath: string) => string,
+): Promise<Child> {
+  const directory = mkdtempSync(join(tmpdir(), 'dshline-stderr-fd-'))
+  try {
+    const hole = join(directory, 'hole')
+    const stderrPath = join(directory, 'real-stderr')
+    const script = join(directory, 'child.mjs')
+    // Created up front so a case whose child never writes to one still reads an
+    // empty string rather than failing on a missing file.
+    writeFileSync(hole, '')
+    writeFileSync(stderrPath, '')
+    writeFileSync(script, source(hole))
+    const command = `${JSON.stringify(process.execPath)} ${JSON.stringify(script)} ${redirect(stderrPath)}; echo "exit:$?"`
+    const result = await run('sh', ['-c', command], { timeout: CHILD_TIMEOUT_MS })
+    return {
+      stdout: result.stdout,
+      status: Number(/exit:(?<code>\d+)/u.exec(result.stdout)?.groups?.code ?? '-1'),
+      hole: readFileSync(hole, 'utf8'),
+      stderr: readFileSync(stderrPath, 'utf8'),
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}
+
+/**
+ * The shim's own sequence: substitute, write raw, write through the stream,
+ * restore, write raw again.
+ *
+ * The preconditions are checked in the child and reported by exit status, so a
+ * runtime that stops honouring one names which one rather than producing a
+ * confusing file comparison.
+ * @param hole - path the substituted descriptor is opened on.
+ * @returns the program's source.
+ */
+function shimSequence(hole: string): string {
+  return `
+import { closeSync, openSync, writeFileSync } from 'node:fs'
+
+const original = Object.getOwnPropertyDescriptor(process.stderr, 'fd')
+if (original === undefined || !('value' in original) || original.configurable !== true) {
+  console.log('process.stderr.fd is not a redefinable value property')
+  process.exit(3)
+}
+const realFd = original.value
+const hole = openSync(${JSON.stringify(hole)}, 'w')
+console.log('stream=' + process.stderr.constructor.name)
+
+// Exactly what src/stderr.ts does, and nothing more.
+Object.defineProperty(process.stderr, 'fd', { ...original, value: hole })
+if (process.stderr.fd !== hole) { console.log('the substitution did not take'); process.exit(4) }
+
+writeFileSync(process.stderr.fd, ${JSON.stringify(RAW_HELD)})
+process.stderr.write(${JSON.stringify(STREAM_HELD)})
+
+Object.defineProperty(process.stderr, 'fd', original)
+if (process.stderr.fd !== realFd) { console.log('the substitution did not reverse'); process.exit(5) }
+closeSync(hole)
+
+writeFileSync(process.stderr.fd, ${JSON.stringify(RAW_RELEASED)})
+console.log('ok')
+`
+}
+
+describe.skipIf(process.platform === 'win32')('substituting the descriptor process.stderr reports', () => {
+  it('holds the raw path and leaves a socket-backed stream path alone', async () => {
+    // A pipe, which is the same stream family a terminal gets: `net.Socket`
+    // writing through a handle opened once, rather than through the property.
+    // This is the configuration the shim actually engages in.
+    const child = await drive(shimSequence, path => `2>&1 1>/dev/null | cat > ${JSON.stringify(path)}`)
+    expect(child.status, child.stdout).toBe(0)
+
+    // (1) the raw write while held followed the substituted descriptor, and
+    // nothing else did.
+    expect(child.hole).toBe(RAW_HELD)
+
+    // (2) the ordinary stream path was untouched, and (1) reversed cleanly: the
+    // post-release raw write is back on the real descriptor.
+    expect(child.stderr).toBe(`${STREAM_HELD}${RAW_RELEASED}`)
+    expect(child.stderr).not.toContain('exit:')
+  })
+
+  it('would capture a file-backed stream path too, which is why a non-terminal stderr is never held', async () => {
+    // Node writes a file-backed stderr through `SyncWriteStream`, which reads
+    // `this.fd` on every call — the same property the shim substitutes. So here
+    // the ordinary stream path follows the hole as well.
+    //
+    // `rawStderrReach` returns `cannot-reach` for any stderr that is not a
+    // terminal, so this configuration is never held in production. This test is
+    // the record of WHY that refusal matters: it is not only that a raw write
+    // could not corrupt a frame, it is that holding would redirect writes the
+    // shim has no business redirecting.
+    const child = await drive(shimSequence, path => `2> ${JSON.stringify(path)}`)
+    expect(child.status, child.stdout).toBe(0)
+    expect(child.stdout).toContain('stream=SyncWriteStream')
+    expect(child.hole).toContain(RAW_HELD)
+    expect(child.hole).toContain(STREAM_HELD)
+  })
+})

--- a/packages/dshline/tests/stderr-descriptor.spec.ts
+++ b/packages/dshline/tests/stderr-descriptor.spec.ts
@@ -13,11 +13,14 @@
  * 1. `writeFileSync(process.stderr.fd, …)` resolves the property at call time,
  *    so a raw write follows the substituted descriptor, and the substitution is
  *    exactly reversible.
- * 2. Where `process.stderr` is a socket-backed stream — a pipe here, and a
- *    terminal in production, both `net.Socket` writing through a libuv handle
- *    opened once — `write` does NOT re-resolve the property, so the ordinary
- *    stream path is untouched by the substitution. This is the case the shim
- *    actually runs in.
+ * 2. Where `process.stderr` is a socket-backed stream, `write` does NOT
+ *    re-resolve the property, so the ordinary stream path is untouched by the
+ *    substitution. The case driven here is a PIPE. Production is a terminal,
+ *    which is the same stream family — `tty.WriteStream` extends `net.Socket`
+ *    — but this suite cannot allocate a pty, so the production case is
+ *    inferred from the pipe rather than observed. That inference is stated
+ *    where the shim relies on it, in `src/stderr.ts`, rather than dressed up
+ *    as a measurement here.
  * 3. Where `process.stderr` is a FILE, Node uses `SyncWriteStream`, which
  *    writes through `this.fd` on every call — so substituting it would capture
  *    the ordinary stream path too. That is not a hazard in production only
@@ -139,9 +142,8 @@ console.log('ok')
 
 describe.skipIf(process.platform === 'win32')('substituting the descriptor process.stderr reports', () => {
   it('holds the raw path and leaves a socket-backed stream path alone', async () => {
-    // A pipe, which is the same stream family a terminal gets: `net.Socket`
-    // writing through a handle opened once, rather than through the property.
-    // This is the configuration the shim actually engages in.
+    // A pipe: socket-backed, like the terminal the shim actually engages on,
+    // and the closest configuration this suite can allocate to it.
     const child = await drive(shimSequence, path => `2>&1 1>/dev/null | cat > ${JSON.stringify(path)}`)
     expect(child.status, child.stdout).toBe(0)
 

--- a/tools/harness-target.mjs
+++ b/tools/harness-target.mjs
@@ -30,15 +30,27 @@
  *   node tools/harness-target.mjs --pin              # rewrite dependency pins to the target version
  *   node tools/harness-target.mjs --published        # has npm published the target version yet?
  *   node tools/harness-target.mjs --verify-source .harness   # is that checkout the adopted generation?
+ *
+ * The no-flag run also fails while `HARNESS_COMPAT` records a temporary shim
+ * confirmed against some other generation — see {@link parseCompat}.
  * @module tools/harness-target
  */
 
-import { readFile, writeFile } from 'node:fs/promises'
+import { readFile, stat, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const TARGET_FILE = join(repoRoot, 'HARNESS_TARGET')
+/**
+ * The register of temporary workarounds for defects in the adopted generation.
+ *
+ * Separate from `HARNESS_TARGET` rather than folded into it: that file's format
+ * is two `key value` lines precisely so a migration can edit it without
+ * understanding a parser, and records carrying a path would erode that. Its
+ * header points here instead, and this module is what makes the two coherent.
+ */
+const COMPAT_FILE = 'HARNESS_COMPAT'
 /**
  * The same two manifests as path SEGMENTS, so a caller can resolve them
  * against a root other than this repository's. Only `pinTargetVersion` needs
@@ -270,27 +282,121 @@ export async function pinTargetVersion(version, fields = PINNED_FIELDS, root = r
 }
 
 /**
+ * One temporary workaround for a defect in the adopted Harness generation.
+ * @typedef {object} CompatShim
+ * @property {string} path - the shim's own module, repository-relative.
+ * @property {string} confirmed - the generation it was last confirmed to still be needed against.
+ */
+
+/**
+ * Parse `HARNESS_COMPAT`.
+ *
+ * `shim <path> <version>` records and comments, in the same read-at-a-glance
+ * spirit as `HARNESS_TARGET`. No description field: the shim's own module
+ * header is where the behavior and the removal condition are written down, and
+ * a second copy here would be the one that goes stale.
+ * @param text - the file's contents.
+ * @returns the recorded shims, in file order.
+ * @throws when a record is malformed or names a path twice — never a partial register.
+ */
+export function parseCompat(text) {
+  /** @type {CompatShim[]} */
+  const shims = []
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/#.*$/, '').trim()
+    if (line === '') continue
+    const [key, path, confirmed, ...rest] = line.split(/\s+/)
+    if (key !== 'shim') throw new Error(`${COMPAT_FILE}: unknown field: ${key}`)
+    if (path === undefined || confirmed === undefined || rest.length > 0) {
+      throw new Error(`${COMPAT_FILE}: expected "shim <path> <version>", got: ${line}`)
+    }
+    if (!HARNESS_VERSION.test(confirmed)) {
+      throw new Error(`${COMPAT_FILE}: ${path} confirmed against something that is not a version: ${confirmed}`)
+    }
+    if (shims.some(shim => shim.path === path)) throw new Error(`${COMPAT_FILE}: ${path} recorded twice`)
+    shims.push({ path, confirmed })
+  }
+  return shims
+}
+
+/**
+ * Read the register, treating its absence as an empty one.
+ *
+ * Absence is not an error: a released tag predating this file is checked with
+ * `RELEASE_ROOT` pointing at it, and a repository carrying no workarounds is
+ * the state this register exists to return to.
+ * @param root - repository root whose register should be read.
+ * @returns the recorded shims, or none.
+ */
+export async function readCompat(root = repoRoot) {
+  try {
+    return parseCompat(await readFile(join(root, COMPAT_FILE), 'utf8'))
+  } catch (error) {
+    if (error !== null && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') return []
+    throw error
+  }
+}
+
+/**
+ * Every recorded shim that the adopted generation has not been reconciled with.
+ *
+ * Two ways a record can be wrong, and both are worth failing on. A shim
+ * confirmed against another generation means a migration moved the target
+ * without deciding what to do about the workaround — which is the whole reason
+ * the register exists. A record whose module is gone means the workaround was
+ * deleted and its entry was not, so the next migration would be asked to
+ * reconfirm a file nobody can read.
+ * @param target - the adopted target.
+ * @param shims - the recorded shims.
+ * @param root - repository root the paths resolve against.
+ * @returns one entry per unreconciled record; empty when the register agrees with the target.
+ */
+export async function compatProblems(target, shims, root = repoRoot) {
+  const problems = []
+  for (const shim of shims) {
+    const present = await stat(join(root, shim.path)).then(() => true, () => false)
+    if (!present) problems.push({ ...shim, reason: 'missing' })
+    else if (shim.confirmed !== target.version) problems.push({ ...shim, reason: 'unconfirmed' })
+  }
+  return problems
+}
+
+/**
  * Render the coherence report.
  * @param target - the adopted target.
  * @param problems - `{ manifest, field, name, from }` entries whose spec is not the target version.
+ * @param shims - `{ path, confirmed, reason }` entries from {@link compatProblems}.
  * @returns the report text, ending in a newline.
  */
-export function formatReport(target, problems) {
+export function formatReport(target, problems, shims = []) {
   const lines = [`Harness target ${target.version} @ ${target.revision.slice(0, 8)}`]
   if (problems.length === 0) {
     lines.push(`✓ every dsh-* dependency, devDependency, and peerDependency is exactly ${target.version}`)
+  } else {
+    lines.push(`✗ ${String(problems.length)} dsh-* spec${problems.length === 1 ? '' : 's'} not exactly ${target.version}:`)
+    for (const problem of problems) {
+      lines.push(`  ${problem.manifest} (${problem.field}): ${problem.name} ${problem.from}`)
+    }
+    lines.push('run `node tools/harness-target.mjs --pin && pnpm install` for dependencies.')
+    if (problems.some(problem => problem.field === 'peerDependencies')) {
+      lines.push('peerDependencies are never rewritten by a tool: a peer range is the public')
+      lines.push('compatibility promise, and one generation means one exact version, not a range.')
+    }
+  }
+  if (shims.length === 0) {
     return [...lines, ''].join('\n')
   }
-  lines.push(`✗ ${String(problems.length)} dsh-* spec${problems.length === 1 ? '' : 's'} not exactly ${target.version}:`)
-  for (const problem of problems) {
-    lines.push(`  ${problem.manifest} (${problem.field}): ${problem.name} ${problem.from}`)
+  // Named as a decision rather than as a failure: the tool cannot tell whether
+  // the workaround is still needed, and guessing would be worse than stopping.
+  lines.push(`✗ ${String(shims.length)} temporary shim${shims.length === 1 ? '' : 's'} in ${COMPAT_FILE} not reconciled with ${target.version}:`)
+  for (const shim of shims) {
+    lines.push(shim.reason === 'missing'
+      ? `  ${shim.path} is recorded but does not exist — delete the record`
+      : `  ${shim.path} last confirmed against ${shim.confirmed}`)
   }
-  const peersWrong = problems.some(problem => problem.field === 'peerDependencies')
-  lines.push('run `node tools/harness-target.mjs --pin && pnpm install` for dependencies.')
-  if (peersWrong) {
-    lines.push('peerDependencies are never rewritten by a tool: a peer range is the public')
-    lines.push('compatibility promise, and one generation means one exact version, not a range.')
-  }
+  lines.push(`read each module's header, then either delete the shim with its wiring,`)
+  lines.push(`its tests and its ${COMPAT_FILE} record, or bump the record to ${target.version}`)
+  lines.push('to state deliberately that this generation still needs it.')
   return [...lines, ''].join('\n')
 }
 
@@ -360,8 +466,12 @@ if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(
       : `pinned ${String(applied.length)} package(s) to ${target.version}; run \`pnpm install\` to refresh the lockfile\n`)
   } else if (flag === undefined) {
     const problems = await collectProblems(target, targetRoot)
-    process.stdout.write(formatReport(target, problems))
-    process.exit(problems.length > 0 ? 1 : 0)
+    // The same run, because they are the same question asked of two files: is
+    // this repository coherent with the generation it says it adopts. A
+    // migration that bumps the target sees both answers at once.
+    const shims = await compatProblems(target, await readCompat(targetRoot), targetRoot)
+    process.stdout.write(formatReport(target, problems, shims))
+    process.exit(problems.length + shims.length > 0 ? 1 : 0)
   } else {
     process.stderr.write(`unknown flag: ${flag}\n${usage}`)
     process.exit(2)

--- a/tools/harness-target.spec.mjs
+++ b/tools/harness-target.spec.mjs
@@ -14,9 +14,12 @@ import { readFile } from 'node:fs/promises'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  compatProblems,
   formatReport,
   isPublished,
+  parseCompat,
   parseTarget,
+  readCompat,
   sourceVersion,
   targetUpdates,
 } from './harness-target.mjs'
@@ -183,5 +186,83 @@ describe('isPublished()', () => {
       .rejects.toThrow('invalid versions map')
     await expect(isPublished('@deepseek-ai/dsh', '0.1.1-rc.2', () => Promise.resolve({ versions: [] })))
       .rejects.toThrow('invalid versions map')
+  })
+})
+
+describe('HARNESS_COMPAT, the register of temporary workarounds', () => {
+  it('reads shim records and ignores comments and blank lines', () => {
+    expect(parseCompat([
+      '# why this one exists',
+      '',
+      'shim packages/dshline/src/stderr.ts 0.1.5-alpha.1',
+      'shim packages/dshline/src/other.ts 0.1.5-alpha.1 # trailing note',
+    ].join('\n'))).toEqual([
+      { path: 'packages/dshline/src/stderr.ts', confirmed: '0.1.5-alpha.1' },
+      { path: 'packages/dshline/src/other.ts', confirmed: '0.1.5-alpha.1' },
+    ])
+  })
+
+  it('refuses a malformed, duplicated, or unknown record rather than guessing', () => {
+    expect(() => parseCompat('shim packages/a.ts\n')).toThrow(/expected "shim <path> <version>"/)
+    expect(() => parseCompat('shim packages/a.ts 0.1.5 extra\n')).toThrow(/expected "shim <path> <version>"/)
+    expect(() => parseCompat('workaround packages/a.ts 0.1.5\n')).toThrow(/unknown field: workaround/)
+    expect(() => parseCompat('shim packages/a.ts main\n')).toThrow(/not a version/)
+    expect(() => parseCompat('shim packages/a.ts 0.1.5\nshim packages/a.ts 0.1.6\n')).toThrow(/recorded twice/)
+  })
+
+  it('treats an absent register as an empty one, so an older tag still checks', async () => {
+    // `publish.yml` runs this check with RELEASE_ROOT pointing at a released
+    // tag, which may predate the file. A repository carrying no workarounds is
+    // also the state the register exists to return to.
+    // This directory is a real one that carries no register.
+    await expect(readCompat(new URL('.', import.meta.url).pathname)).resolves.toEqual([])
+  })
+
+  it('fails while a record names a generation other than the adopted one', async () => {
+    // The whole point. Advancing HARNESS_TARGET cannot go green until someone
+    // has confirmed the upstream behavior is still there, or deleted the shim.
+    const shims = [{ path: 'tools/harness-target.mjs', confirmed: '0.1.1-rc.1' }]
+    await expect(compatProblems({ ...TARGET }, shims)).resolves.toEqual([
+      { path: 'tools/harness-target.mjs', confirmed: '0.1.1-rc.1', reason: 'unconfirmed' },
+    ])
+  })
+
+  it('passes a record confirmed against the adopted generation', async () => {
+    const shims = [{ path: 'tools/harness-target.mjs', confirmed: TARGET.version }]
+    await expect(compatProblems({ ...TARGET }, shims)).resolves.toEqual([])
+  })
+
+  it('fails a record whose module is gone, so the register cannot outlive the shim', async () => {
+    const shims = [{ path: 'packages/dshline/src/deleted.ts', confirmed: TARGET.version }]
+    await expect(compatProblems({ ...TARGET }, shims)).resolves.toEqual([
+      { path: 'packages/dshline/src/deleted.ts', confirmed: TARGET.version, reason: 'missing' },
+    ])
+  })
+
+  it('names the decision in the report rather than only the failure', () => {
+    const report = formatReport(TARGET, [], [
+      { path: 'packages/dshline/src/stderr.ts', confirmed: '0.1.1-rc.1', reason: 'unconfirmed' },
+    ])
+    expect(report).toContain('1 temporary shim in HARNESS_COMPAT')
+    expect(report).toContain('packages/dshline/src/stderr.ts last confirmed against 0.1.1-rc.1')
+    expect(report).toContain(`bump the record to ${TARGET.version}`)
+  })
+
+  it('the committed register agrees with the committed target', async () => {
+    // The same claim the blocking lane makes, asserted here so a stale record
+    // fails in seconds rather than in a CI job.
+    const target = parseTarget(await readFile(new URL('../HARNESS_TARGET', import.meta.url), 'utf8'))
+    await expect(compatProblems(target, await readCompat())).resolves.toEqual([])
+  })
+
+  it('every recorded shim says it is temporary in its own first lines', async () => {
+    // A register entry is a reminder to revisit; the module is where the
+    // behavior and the removal condition live. One without the other is how a
+    // workaround gets read as a design decision.
+    for (const shim of await readCompat()) {
+      const source = await readFile(new URL(`../${shim.path}`, import.meta.url), 'utf8')
+      expect(source.slice(0, 400), shim.path).toMatch(/TEMPORARY/)
+      expect(source, shim.path).toContain('HARNESS_COMPAT')
+    }
   })
 })


### PR DESCRIPTION
Spawning a subagent printed dshline's root chrome — `╭─ dshline ─… ─╮` — into
native scrollback a second time, and once more per commit after that. Not the
work/subagent projection, not `activeWork`, not `/work`.

> **This is a temporary compatibility shim for an upstream defect, not a dshline
> abstraction.** It is registered in `HARNESS_COMPAT`, so the next Harness
> generation cannot be adopted without someone deciding whether it is still
> needed. The upstream issue draft is
> [in a comment below](#issuecomment-5600886712).

## The invariant

`packages/renderer/src/screen.ts` is correct only because it is the sole writer:
it remembers the live region's height and where it left the cursor, and every
redraw climbs that remembered geometry to erase the frame before drawing the
next one. Its own module doc states the rule — *"the live region must be the
last thing on screen, so every write goes through this class."*

A write it did not issue scrolls the screen out from under that geometry. With
`liveRows.length = 5` and `cursor = { row: 2 }` (the composer's input row),
`eraseLive()` descends `bottom - cursor.row` = 2, `\r`, then climbs `bottom` =
4 — so after a foreign two-line write the origin lands **two rows below** the
real region top, and `CSI 0J` clears from there. The separator and the top
border sit above the erase origin, are never erased again, and become durable
output.

## The foreign writer

A subagent backend in the generation named by `HARNESS_TARGET` forwards a
delegated child process's stderr with `writeFileSync(process.stderr.fd, bytes)`,
unconditionally, for the whole life of the delegation. On an interactive launch
descriptor 2 is the terminal dshline is drawing on, so the child's startup
diagnostics land inside the composer frame — which is why this appears the
moment a subagent starts, and why `/work` is irrelevant. It is the only
direct-descriptor terminal writer in the whole installed dependency tree
(`grep -rn "writeFileSync(process" node_modules/@deepseek-ai/*/lib/*.js` → one
hit). No dshline runtime file names that backend or branches on a provider: what
is contained is a **write shape**.

## The containment

Patching `process.stderr.write` would not catch it: the forward never touches
the stream. What it does read, on every write, is `process.stderr.fd` — a
writable, configurable own property. So that is what moves. While the window
owns the terminal, the descriptor that property reports is an `os.devNull`
handle:

```ts
ctx.effect(() => holdStderrOffTerminal(), 'dshline: foreign stderr writes')
```

Taken with terminal ownership in `createWindow` and released with it, exactly
once.

### What it knows before it engages

`isTTY` on both streams does **not** establish that stdout and stderr are the
same terminal, and the first version of this check claimed it did. It answers a
weaker question — each descriptor is *a* terminal — and two terminals are
exactly the case where moving stderr would be a pointless mutation of a process
global.

`rawStderrReach` now asks the answerable question. A terminal is a character
device, and `fstat`'s `rdev` is the device a handle is on, so two descriptors on
one terminal report one non-zero `rdev` and descriptors on two terminals report
two. Three answers, and the third is the honest absence of one:

| | meaning | behaviour |
|---|---|---|
| `reaches` | proven same terminal device | hold |
| `cannot-reach` | not a terminal, or a proven *different* terminal | leave completely alone |
| `unknown` | platform cannot say (a Windows console reports `rdev` 0; a stream may expose no descriptor) | hold |

Holding on `unknown` is the conservative asymmetry made explicit: being wrong
that way drops a raw diagnostic on a terminal nobody was drawing on, being wrong
the other way corrupts a transcript the reader cannot repair. A `2>log` run, a
piped stderr and a proven second terminal all keep their descriptor as found.

### The Node behaviour it depends on, pinned by real processes

Whether substituting the descriptor is safe is a question about Node, and a
stubbed `WriteStream` only proves what the stub does. `stderr-descriptor.spec.ts`
drives real `node` children with real descriptors and reads the files afterwards:

- a raw `writeFileSync(process.stderr.fd, …)` **follows** the substitution, and
  the substitution reverses exactly;
- a **socket-backed** `process.stderr` does **not** re-resolve the property, so
  the ordinary stream path keeps its own destination. The case driven is a
  **pipe**; production is a terminal, the same stream family
  (`tty.WriteStream extends net.Socket`), but this suite cannot allocate a pty
  — so that step is named as an **inference** in `src/stderr.ts` rather than
  presented as a measurement;
- a **file-backed** `process.stderr` is `SyncWriteStream` and *does* re-resolve
  `this.fd` on every write, so holding one would capture ordinary stream writes
  too. This was found by writing the test and is now the **stronger** reason the
  shim refuses a non-terminal stderr — the first reason was only that no frame
  could be corrupted. The refusal is load-bearing, so the reason is recorded as
  a test rather than as a comment.

### What it deliberately is not

No capture, tee, or logging sink. Harness owns Host diagnostics and subagent
failure reporting, and a second authority over the same bytes in the frontend
would be worse than dropping them. A raw-descriptor writer's output is dropped
while the window draws: that costs no failure reporting — a run's own failure
reaches the transcript through the subagent lifecycle, never through descriptor
2 — and the bytes were unreadable anyway, because they were landing on top of
the frame they corrupted.

## Making sure it does not become permanent

Prose does not fail a build. A workaround nobody is made to revisit is a
workaround that becomes permanent and is eventually read as a design decision.

**`HARNESS_COMPAT`** (new, at the repository root beside `HARNESS_TARGET`) lists
each temporary workaround with the generation it was last confirmed to still be
needed against:

```
shim packages/dshline/src/stderr.ts 0.1.5-alpha.1
```

`node tools/harness-target.mjs` — the coherence check the Harness-Sync adoption
proposal and every release **already** run — now fails while a record names any
generation other than the adopted one, and the blocking `Harness target` lane
runs it too, so a hand-edited `HARNESS_TARGET` is caught there rather than at
release. A record whose module no longer exists fails as well, so the register
cannot outlive what it describes.

The resulting migration flow is exactly the one asked for:

```
HARNESS_TARGET bumped
→ node tools/harness-target.mjs fails: "stderr.ts last confirmed against 0.1.5-alpha.1"
→ adopter reads the module header and checks the upstream checkout the migration already has
→ still broken  → bump the record, deliberately, in the migration commit
→ fixed         → delete stderr.ts, its ctx.effect, its specs, and the record
```

Deliberate non-goals, per review:

- **No upstream parsing.** The check is a string comparison between two files in
  this repository, so nothing couples a build to a backend's internal layout and
  a refactor that fixed nothing cannot silently satisfy it. Confirming the
  behaviour is the adopter's job, once per generation.
- **No parallel mechanism.** It is consumed by the existing adoption tooling and
  the existing checks; `HARNESS_TARGET`'s own header points at it.
- **Kept out of `HARNESS_TARGET`.** That file's format is two `key value` lines
  precisely so a migration can edit it without understanding a parser, and
  records carrying a path would erode that.
- **No runtime dependency.** Nothing in dshline's runtime imports
  `dsh-subagent-codex` or branches on a provider; `work.spec.ts`'s
  provider-neutrality gate still holds.

## What was ruled out, by probe rather than by reading

- **Live-region overflow.** Property-probed the real `TuiSlots.compose` with the
  real views across a wide width × height matrix and every composer state:
  physical rows never exceed the terminal at ordinary widths. (The narrow-width
  overflow that probe *did* find is #187, and is not this bug.)
- **Every overlay** already carries a `physicalRows(...) <= terminalRows`
  backstop, work's included, and its fallback is bounded.
- **`Screen.commit` arithmetic**, at exactly-full-height and over-height
  regions: the commit/redraw ordering is correct.
- **The subagent projection path** only calls `invalidate()`, and its
  `session/event`, `agent/assistant-stream` and `agent/status` listeners are all
  filtered by exact session or agent identity.

## Tests

`packages/dshline/tests/foreign-writes.spec.ts` (13) — three separate claims:

- a **hazard guard** on a real terminal emulator asserting that a raw write into
  the region *does* make root chrome durable. If it ever reports one row, a
  foreign write stopped being able to displace the region and this containment
  is no longer load-bearing — the suite says so rather than passing quietly.
- forty turns of the two writes the window actually makes (a synchronous commit
  per session event, a coalesced repaint after it) leave the terminal holding
  root chrome **exactly once**.
- `rawStderrReach` against **real character devices**: two handles on one device
  prove `reaches`; two different devices prove `cannot-reach` and are left
  untouched; a non-terminal at either end settles it without a stat; a regular
  file claiming to be a terminal and a stream with no descriptor both answer
  `unknown`. Plus policy: release is idempotent, an accessor-backed `fd` is
  refused rather than redefined, and `write` is never touched.

`packages/dshline/tests/stderr-descriptor.spec.ts` (2) — the Node behaviours
above, in real child processes.

`tools/harness-target.spec.mjs` (+8) — the register: record parsing and its
refusals, an absent register treated as empty (so a released tag still checks),
a record naming another generation fails, one naming the adopted generation
passes, a record whose module is gone fails, the report names the *decision*
rather than only the failure, the committed register agrees with the committed
target, and every recorded shim says `TEMPORARY` in its own first lines and
points back at `HARNESS_COMPAT`.

```
Test Files  168 passed | 1 skipped (169)
Tests       3243 passed | 22 skipped (3265)
pnpm typecheck / pnpm build   clean
git diff --check              clean
node tools/lint-workflows.mjs no findings
```

Independent of #187 — the two touch no common file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
