### PR TITLE
fix(dshline): keep timing and completion rows inside the terminal

### DIFF
--- a/.changeset/keep-timing-and-completion-rows-inside-the-terminal.md
+++ b/.changeset/keep-timing-and-completion-rows-inside-the-terminal.md
@@ -1,0 +1,43 @@
+---
+'@dshline/dshline': patch
+---
+
+Keep the timing panel's measured rows and the completion list's rows inside the
+terminal, so a narrow window cannot leave root chrome in scrollback.
+
+`TuiSlots.compose` budgets the live region in LOGICAL lines and hands each view
+the rows the views above it have not spent. That is only the same thing as the
+physical budget while every row fits the terminal's width: `Screen.wrap`
+re-wraps an overlong row into two AFTER the budgeting is finished, so one row
+wider than the terminal is one row of overflow no view's own accounting can see.
+Once the region is taller than the screen its first rows cannot be climbed back
+to and erased, and the next redraw leaves `╭─ dshline ─… ─╮` in native
+scrollback for good.
+
+Two views could emit such a row, for two different reasons:
+
+- **The completion list** laid its rows out against `chromeWidth(columns)`,
+  which floors at the shared chrome minimum and therefore returns a width WIDER
+  than the terminal below that floor. Its label budget also carried a floor of
+  eight columns independent of the terminal, and its shortest row — the
+  `… N more` marker — was not cut at all, so `… 14 more` drew thirteen columns
+  at every width. The width is now clamped to the terminal, the label budget
+  floors at one, and every row is cut. This is the same correction the status
+  line already carries, for the reason its own comment gives.
+- **The timing panel's measured rows** are budgeted from the DATA as well as
+  from the width: the label width, field gap and bar cells are what is left
+  after the longest duration's width is subtracted, and the label and gap have
+  floors of one. A long-running turn on a narrow terminal therefore produced a
+  row wider than the width it was laid out for. The heading and the elision row
+  were already cut for this reason; the measured rows now are too.
+
+Neither is reachable at an ordinary window size, and neither is the cause of the
+duplicate header a subagent produces — that is a foreign writer on descriptor 2,
+fixed separately. These are the same failure class found while probing for it.
+
+The regression test is the property both bugs broke, checked over the real views
+composed together: no row wider than the terminal, no more physical rows than
+the terminal has, and no cursor outside the drawn region — across 8–200 columns
+and 10–50 rows, with an empty, short, thirty-line and two-thousand-character
+composer, a standing completion offer, streaming on and off, and the timing
+panel on and off. It reports 2583 violations without these two changes.

--- a/.changeset/keep-timing-and-completion-rows-inside-the-terminal.md
+++ b/.changeset/keep-timing-and-completion-rows-inside-the-terminal.md
@@ -21,23 +21,50 @@ Two views could emit such a row, for two different reasons:
   than the terminal below that floor. Its label budget also carried a floor of
   eight columns independent of the terminal, and its shortest row — the
   `… N more` marker — was not cut at all, so `… 14 more` drew thirteen columns
-  at every width. The width is now clamped to the terminal, the label budget
-  floors at one, and every row is cut. This is the same correction the status
-  line already carries, for the reason its own comment gives.
+  at every width. Worse, only the label was ever bounded: every row carries a
+  fixed four-column prefix (`  › `) that sat outside the budget entirely, so at
+  one to four columns the row was five columns wide no matter what the label was
+  cut to. The width is now clamped to the terminal, the prefix is one named
+  constant shared by every budget that has to account for it, the WHOLE
+  assembled row is cut rather than only its payload, and below a prefix plus one
+  column of label the list stands down instead of spending a live row on a
+  candidate it cannot name.
 - **The timing panel's measured rows** are budgeted from the DATA as well as
   from the width: the label width, field gap and bar cells are what is left
   after the longest duration's width is subtracted, and the label and gap have
   floors of one. A long-running turn on a narrow terminal therefore produced a
-  row wider than the width it was laid out for. The heading and the elision row
-  were already cut for this reason; the measured rows now are too.
+  row wider than the width it was laid out for.
+
+  Cutting the row would have bounded it and broken a different rule this file
+  already keeps: the duration sits at the right edge, so a plain truncation
+  turns `2h 41m` into `2h 4` — not a narrower fact but a different, entirely
+  plausible one, which is what the heading's own ladder exists to avoid. So the
+  fields are not cut and the FORM is chosen instead, by a ladder from
+  `label + bar + duration` through `label + duration`, an indented duration, a
+  bare duration, and finally `…` where not even a whole duration fits. The
+  widest form that fits is picked once for the panel rather than per row, so a
+  narrow panel stays aligned instead of going ragged for a reason no reader
+  could see.
 
 Neither is reachable at an ordinary window size, and neither is the cause of the
 duplicate header a subagent produces — that is a foreign writer on descriptor 2,
 fixed separately. These are the same failure class found while probing for it.
 
 The regression test is the property both bugs broke, checked over the real views
-composed together: no row wider than the terminal, no more physical rows than
-the terminal has, and no cursor outside the drawn region — across 8–200 columns
-and 10–50 rows, with an empty, short, thirty-line and two-thousand-character
-composer, a standing completion offer, streaming on and off, and the timing
-panel on and off. It reports 2583 violations without these two changes.
+composed together — stream, composer, completion, timing and status at once,
+because the failure only appears in combination and a view that fits alone can
+still be the one that pushes the region over. Six claims per composition: every
+logical row fits the terminal's width, the wrapped physical rows fit its height,
+and the cursor's row and column are each non-negative and inside what was
+actually drawn.
+
+Widths run **exhaustively from one column** to the shared chrome floor — the
+same range `narrow-root.spec.ts` already holds the root chrome to — and then
+across representative ordinary widths to 200, over heights 10–50, with an empty,
+short, thirty-line and two-thousand-character composer, a standing completion
+offer, streaming on and off, and the timing panel on and off. Extending it below
+eight columns is what exposed the completion prefix; the previous sampling
+started at eight and could not see it. Two focused cases name each view
+directly, assert the stand-down policy rather than leaving it to whatever the
+arithmetic happens to do, and check that a duration which appears at all appears
+whole. All three fail without these two changes.

--- a/packages/dshline/src/completion.ts
+++ b/packages/dshline/src/completion.ts
@@ -246,7 +246,16 @@ export function createCompletion(
     view: {
       render(columns, terminalRows = 24) {
         if (candidates.length === 0) return []
-        const width = chromeWidth(columns)
+        // Clamped to the terminal, not merely derived from it. `chromeWidth`
+        // floors at the shared chrome minimum, so below that floor it returns a
+        // width WIDER than the terminal it was asked about — and every row here
+        // is laid out against it. `compose` has already spent the live region's
+        // rows by the time `Screen` re-wraps an overlong row into two, so the
+        // region grows past the screen and the next redraw leaves root chrome in
+        // scrollback. This is the same correction the status line already
+        // carries, for the same reason: a presentation-only minimum independent
+        // of the terminal is not a narrower list, it is the duplicate-frame bug.
+        const width = Math.max(1, Math.min(columns, chromeWidth(columns)))
         // Six rows are what this list WANTS; what is left of the screen decides
         // what it gets. `terminalRows` is already net of the stream and the
         // composer above, so a ten-row prompt shrinks this list rather than
@@ -273,7 +282,10 @@ export function createCompletion(
           const note = candidate.note === undefined
             ? ''
             : ` ${paint(escapeControls(candidate.note), 'muted')}`
-          return `  ${mark} ${truncateToWidth(`${label}${note}`, Math.max(8, width - 4))}`
+          // `Math.max(1, …)`, never a floor of eight: the four columns of mark
+          // and indent are real, so a floor above what is left of the width
+          // draws past the right edge instead of drawing a shorter label.
+          return `  ${mark} ${truncateToWidth(`${label}${note}`, Math.max(1, width - 4))}`
         })
         // What is BELOW the window, not what the window omits. `candidates.length -
         // shown.length` is the same number at every scroll position — nine of
@@ -282,8 +294,16 @@ export function createCompletion(
         // position in the help line rather than by a second marker row, because a
         // completion list shares the live region with the composer.
         const below = candidates.length - (start + shown.length)
-        if (below > 0) rows.push(`    ${paint(`… ${String(below)} more`, 'muted')}`)
-        rows.push(`    ${paint(helpLine(cursor, candidates.length, Math.max(1, width - 4)), 'muted')}`)
+        // Cut like every other row. This one is the shortest and was the one
+        // left unbounded, so it outgrew the terminal first — `… 14 more` is
+        // thirteen columns whatever the width happens to be.
+        if (below > 0) {
+          rows.push(truncateToWidth(`    ${paint(`… ${String(below)} more`, 'muted')}`, width))
+        }
+        rows.push(truncateToWidth(
+          `    ${paint(helpLine(cursor, candidates.length, Math.max(1, width - 4)), 'muted')}`,
+          width,
+        ))
         return rows
       },
     },

--- a/packages/dshline/src/completion.ts
+++ b/packages/dshline/src/completion.ts
@@ -31,6 +31,14 @@ const VISIBLE_ROWS = 6
  */
 const CHROME_ROWS = 2
 
+/**
+ * Columns every row spends before any candidate text: two of indent, the
+ * selection mark, and one of separation. Shared by the label budget, the
+ * help-line budget, and the width below which the list has nothing to draw, so
+ * the prefix is one number rather than a `4` repeated at each of them.
+ */
+const ROW_PREFIX_COLUMNS = 4
+
 /** Marker on the highlighted row. */
 const CURSOR = '›'
 
@@ -256,6 +264,16 @@ export function createCompletion(
         // carries, for the same reason: a presentation-only minimum independent
         // of the terminal is not a narrower list, it is the duplicate-frame bug.
         const width = Math.max(1, Math.min(columns, chromeWidth(columns)))
+        // Every row here carries a fixed four-column prefix — two of indent, the
+        // selection mark, one of separation — before any candidate text. Below
+        // the width where that prefix plus one column of label fits, the list
+        // has no row to offer: `  › ` alone names no candidate, and a row cut
+        // down to it would spend a live row saying nothing while the composer
+        // beside it is what the keystrokes are actually going to. So the list
+        // stands down, exactly as it does when the screen leaves it no rows.
+        // Typing one more character narrows the candidates, and at an ordinary
+        // width that is how it comes back.
+        if (width < ROW_PREFIX_COLUMNS + 1) return []
         // Six rows are what this list WANTS; what is left of the screen decides
         // what it gets. `terminalRows` is already net of the stream and the
         // composer above, so a ten-row prompt shrinks this list rather than
@@ -282,10 +300,17 @@ export function createCompletion(
           const note = candidate.note === undefined
             ? ''
             : ` ${paint(escapeControls(candidate.note), 'muted')}`
-          // `Math.max(1, …)`, never a floor of eight: the four columns of mark
-          // and indent are real, so a floor above what is left of the width
-          // draws past the right edge instead of drawing a shorter label.
-          return `  ${mark} ${truncateToWidth(`${label}${note}`, Math.max(1, width - 4))}`
+          // Budgeted against what the prefix leaves, never against a floor of
+          // its own: the prefix's columns are real, so a label budget larger
+          // than what remains draws past the right edge instead of drawing a
+          // shorter label. Then the WHOLE row is cut, because the budget is the
+          // guarantee for the payload while the row is what the terminal draws
+          // — cutting the assembled row is what makes the bound true of the
+          // prefix as well, not only of the text after it.
+          return truncateToWidth(
+            `  ${mark} ${truncateToWidth(`${label}${note}`, width - ROW_PREFIX_COLUMNS)}`,
+            width,
+          )
         })
         // What is BELOW the window, not what the window omits. `candidates.length -
         // shown.length` is the same number at every scroll position — nine of
@@ -301,7 +326,7 @@ export function createCompletion(
           rows.push(truncateToWidth(`    ${paint(`… ${String(below)} more`, 'muted')}`, width))
         }
         rows.push(truncateToWidth(
-          `    ${paint(helpLine(cursor, candidates.length, Math.max(1, width - 4)), 'muted')}`,
+          `    ${paint(helpLine(cursor, candidates.length, Math.max(1, width - ROW_PREFIX_COLUMNS)), 'muted')}`,
           width,
         ))
         return rows

--- a/packages/dshline/src/timing.ts
+++ b/packages/dshline/src/timing.ts
@@ -417,19 +417,36 @@ export function timingLines(profile: TurnTiming | undefined, columns: number, ro
 }
 
 /**
+ * The smallest truthful thing a measured row can say: something was here.
+ *
+ * One column, and the same mark the panel's elision row uses, so a row that
+ * cannot state a fact still accounts for itself rather than vanishing.
+ */
+const ELLIPSIS = '\u2026'
+
+/**
  * Render measured rows after every untrusted label has been made safe.
  *
- * Every row returned is cut to `width`, and that cut is the load-bearing part
- * rather than a tidy-up. The fields are budgeted from the DATA as well as from
- * the width — `durationWidth` is however wide the longest measured span
- * formats to — while the label width and the field gap have floors of one, so
- * a long duration on a narrow terminal produces a row wider than the budget it
- * was laid out for. `TuiSlots.compose` has already spent the live region's rows
- * by then, and `Screen` re-wraps an overlong row into two: the region grows
- * past the screen, its first rows can no longer be climbed to and erased, and
- * the next redraw leaves root chrome in scrollback. The heading and the elision
- * row above already cut for this reason; measured rows were the ones that did
- * not.
+ * No row may be wider than `width`, and no DURATION may be cut to get there.
+ * Both halves matter, and they pull against each other.
+ *
+ * The geometry half is absolute. `TuiSlots.compose` budgets the live region in
+ * logical rows, and `Screen` re-wraps an overlong row into two AFTER that
+ * budget is spent — so one row a column too wide is one row of overflow no
+ * view's own accounting can see, and once the region is taller than the screen
+ * its first rows can no longer be climbed to and erased. That is how root
+ * chrome ends up in scrollback.
+ *
+ * The truthfulness half is this file's existing rule, and cutting the row's
+ * right edge would break it: the duration sits there, so a plain
+ * `truncateToWidth` turns `2h 41m` into `2h 4` — not a narrower fact but a
+ * different, entirely plausible one. The heading ladder above gives up whole
+ * facts for exactly this reason.
+ *
+ * So the fields are not cut, the FORM is chosen. The widest form that fits is
+ * picked once for the whole panel rather than per row, because every field is
+ * padded to a shared width and a panel where some rows carried a bar and
+ * others did not would be ragged for a reason no reader could see.
  */
 function spanLines(spans: readonly TurnSpan[], width: number): string[] {
   const safe = spans.map(span => escapeControls(span.label))
@@ -445,19 +462,41 @@ function spanLines(spans: readonly TurnSpan[], width: number): string[] {
   const barCells = width - indentWidth - labelWidth - durationWidth - gap * 2
   const longest = Math.max(...spans.map(span => span.ms), 1)
 
+  // The ladder, richest first, with each rung's exact drawn width. `gap` and
+  // `labelWidth` have floors of one, so the arithmetic above can ask for more
+  // columns than there are — which is precisely what these predictions catch.
+  const form = barCells >= MIN_BAR_CELLS
+      && indentWidth + labelWidth + gap + barCells + gap + durationWidth <= width
+    ? 'bar'
+    : indentWidth + labelWidth + gap + durationWidth <= width
+      ? 'labelled'
+      : indentWidth + durationWidth <= width
+        ? 'indented-duration'
+        : durationWidth <= width
+          // The indent is alignment with the status line, and alignment is the
+          // one thing here worth less than a whole duration.
+          ? 'duration'
+          : 'elided'
+
+  if (form === 'elided') {
+    // Not even a bare duration fits, and half of one would read as another.
+    const mark = indentWidth + 1 <= width ? `${INDENT}${ELLIPSIS}` : ELLIPSIS
+    return spans.map(() => truncateToWidth(paint(mark, 'subdued'), Math.max(0, width)))
+  }
+
   return spans.map((span, index) => {
+    const durationText = durations[index] ?? ''
+    const duration = paint(
+      `${' '.repeat(durationWidth - displayWidth(durationText))}${durationText}`,
+      span.running ? 'timing-active' : 'subdued',
+    )
+    if (form === 'duration') return duration
+    if (form === 'indented-duration') return `${INDENT}${duration}`
     const cut = truncateToWidth(safe[index] ?? '', labelWidth)
     // Padded by DISPLAY width, not by string length: a label with a wide
     // character measures two columns per unit, and `padEnd` counts units.
-    const label = `${cut}${' '.repeat(labelWidth - displayWidth(cut))}`
-    const durationText = durations[index] ?? ''
-    const duration = `${' '.repeat(durationWidth - displayWidth(durationText))}${durationText}`
-    if (barCells < MIN_BAR_CELLS) {
-      return truncateToWidth(
-        `${INDENT}${paint(label, 'subdued')}${' '.repeat(gap)}${paint(duration, span.running ? 'timing-active' : 'subdued')}`,
-        width,
-      )
-    }
+    const label = paint(`${cut}${' '.repeat(labelWidth - displayWidth(cut))}`, 'subdued')
+    if (form === 'labelled') return `${INDENT}${label}${' '.repeat(gap)}${duration}`
     // Any measured span rounds up to one cell, for the reason the context bar
     // does: a blank row beside a real duration reads as a drawing fault. A
     // freshly arrived bar starts from that same single cell and grows to its
@@ -468,10 +507,7 @@ function spanLines(spans: readonly TurnSpan[], width: number): string[] {
     // reads as spent bar rather than unspent scale.
     const fill = paint(BAR_FULL.repeat(cells), 'timing-active')
     const track = cells < barCells ? paint(BAR_EMPTY.repeat(barCells - cells), 'subdued') : ''
-    return truncateToWidth(
-      `${INDENT}${paint(label, 'subdued')}${' '.repeat(gap)}${fill}${track}${' '.repeat(gap)}${paint(duration, span.running ? 'timing-active' : 'subdued')}`,
-      width,
-    )
+    return `${INDENT}${label}${' '.repeat(gap)}${fill}${track}${' '.repeat(gap)}${duration}`
   })
 }
 

--- a/packages/dshline/src/timing.ts
+++ b/packages/dshline/src/timing.ts
@@ -416,7 +416,21 @@ export function timingLines(profile: TurnTiming | undefined, columns: number, ro
   return lines
 }
 
-/** Render measured rows after every untrusted label has been made safe. */
+/**
+ * Render measured rows after every untrusted label has been made safe.
+ *
+ * Every row returned is cut to `width`, and that cut is the load-bearing part
+ * rather than a tidy-up. The fields are budgeted from the DATA as well as from
+ * the width — `durationWidth` is however wide the longest measured span
+ * formats to — while the label width and the field gap have floors of one, so
+ * a long duration on a narrow terminal produces a row wider than the budget it
+ * was laid out for. `TuiSlots.compose` has already spent the live region's rows
+ * by then, and `Screen` re-wraps an overlong row into two: the region grows
+ * past the screen, its first rows can no longer be climbed to and erased, and
+ * the next redraw leaves root chrome in scrollback. The heading and the elision
+ * row above already cut for this reason; measured rows were the ones that did
+ * not.
+ */
 function spanLines(spans: readonly TurnSpan[], width: number): string[] {
   const safe = spans.map(span => escapeControls(span.label))
   const durations = spans.map(span => formatSpan(span.ms))
@@ -439,7 +453,10 @@ function spanLines(spans: readonly TurnSpan[], width: number): string[] {
     const durationText = durations[index] ?? ''
     const duration = `${' '.repeat(durationWidth - displayWidth(durationText))}${durationText}`
     if (barCells < MIN_BAR_CELLS) {
-      return `${INDENT}${paint(label, 'subdued')}${' '.repeat(gap)}${paint(duration, span.running ? 'timing-active' : 'subdued')}`
+      return truncateToWidth(
+        `${INDENT}${paint(label, 'subdued')}${' '.repeat(gap)}${paint(duration, span.running ? 'timing-active' : 'subdued')}`,
+        width,
+      )
     }
     // Any measured span rounds up to one cell, for the reason the context bar
     // does: a blank row beside a real duration reads as a drawing fault. A
@@ -451,7 +468,10 @@ function spanLines(spans: readonly TurnSpan[], width: number): string[] {
     // reads as spent bar rather than unspent scale.
     const fill = paint(BAR_FULL.repeat(cells), 'timing-active')
     const track = cells < barCells ? paint(BAR_EMPTY.repeat(barCells - cells), 'subdued') : ''
-    return `${INDENT}${paint(label, 'subdued')}${' '.repeat(gap)}${fill}${track}${' '.repeat(gap)}${paint(duration, span.running ? 'timing-active' : 'subdued')}`
+    return truncateToWidth(
+      `${INDENT}${paint(label, 'subdued')}${' '.repeat(gap)}${fill}${track}${' '.repeat(gap)}${paint(duration, span.running ? 'timing-active' : 'subdued')}`,
+      width,
+    )
   })
 }
 

--- a/packages/dshline/tests/live-region-bounds.spec.ts
+++ b/packages/dshline/tests/live-region-bounds.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * The one property the whole live region depends on, checked over the real views.
+ *
+ * `Screen` redraws by climbing the rows it remembers, so a region taller than
+ * the terminal is not a cosmetic problem: its first rows have scrolled off,
+ * cannot be climbed back to, and are never erased again — they become durable
+ * scrollback, and what a reader sees is the root chrome printed a second time.
+ *
+ * `TuiSlots.compose` budgets in LOGICAL lines and hands each view the rows the
+ * views above it have not spent, which is only equivalent to the physical
+ * budget while every row fits the terminal's width. `Screen.wrap` re-wraps an
+ * overlong row into two AFTER that budgeting is finished, so one row wider than
+ * the terminal is one row of overflow that no view's own accounting can see.
+ * That makes width the load-bearing half of a height invariant, which is why
+ * this asserts both against the same composition.
+ *
+ * Every view is asked at once, across the widths and heights a real terminal
+ * actually opens at, because the failure only appears in combination: a view
+ * that fits alone can still be the one that pushes the region over.
+ * @module dshline/tests/live-region-bounds
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import { Composer, displayWidth, stripAnsi, wrapToWidth } from '@dshline/renderer'
+import { createCompletion } from '../src/completion.ts'
+import { TuiSlots } from '../src/slots.ts'
+import { StreamBuffer } from '../src/stream.ts'
+import { createTimingView, TurnTimer } from '../src/timing.ts'
+import { createComposerView, createStatusView } from '../src/views.ts'
+
+/** Terminal widths from the narrowest split pane to a wide window. */
+const WIDTHS = [8, 10, 11, 12, 13, 14, 16, 20, 24, 30, 40, 60, 80, 100, 120, 200] as const
+
+/** Terminal heights from a cramped pane to a tall window. */
+const HEIGHTS = [10, 12, 14, 16, 20, 24, 30, 40, 50] as const
+
+/** Composer contents that exercise the empty, one-row, tall and completing frames. */
+const CONTENTS = [
+  '',
+  'short',
+  Array.from({ length: 30 }, (_, index) => `line ${String(index)}`).join('\n'),
+  'x'.repeat(2000),
+  '/com',
+] as const
+
+/** What the runner spends its rows on beneath the composer. */
+const ROWS_BELOW = 2
+
+/** A turn whose spans are many and whose durations are long, which is the timing worst case. */
+function measuredTurn(): TurnTimer {
+  const timer = new TurnTimer()
+  let seq = 0
+  const event = (type: string, data: unknown, time: number): SessionEvent =>
+    ({ type, data, seq: (seq += 1), time } as unknown as SessionEvent)
+  timer.observe(event('turn/start', { turn: 1 }, 0))
+  for (let index = 0; index < 12; index += 1) {
+    // Far enough apart to format wide. The panel derives its label width, gap
+    // and bar cells by subtracting the DURATION's width from the terminal's, so
+    // the duration string is the input that decides whether a measured row fits
+    // at all — a long-running turn is what makes it wide in production, and a
+    // wide one is what this reproduces.
+    timer.observe(event(
+      'tool/call',
+      { callId: `c${String(index)}`, name: `tool_number_${String(index)}`, arguments: '{}' },
+      3_600_000 * (index + 1),
+    ))
+  }
+  return timer
+}
+
+/** The status line with every optional reading present, which is its widest form. */
+function busyStatus(): ReturnType<typeof createStatusView> {
+  return createStatusView(() => ({
+    busy: true,
+    tick: 3,
+    elapsedMs: 12_345,
+    activityWord: 'working',
+    activity: { title: 'delegated_subagent', others: 2 },
+    model: 'deepseek-v4-flash',
+    effort: 'high',
+    usage: '$1.23',
+    cacheRead: '42% cached',
+    tokens: 120_000,
+    contextWindow: 1_000_000,
+    detail: 'full',
+    work: '1 workflow · 3 subagents · 2 jobs',
+    pending: { queued: 1, steering: 1 },
+    todo: '3/7',
+    plan: true,
+    replay: undefined,
+    goal: { label: 'goal 4/12', running: true },
+  } as never))
+}
+
+/** One registry holding every view the runner registers, composed as it composes them. */
+async function window(
+  content: string,
+  timer: TurnTimer,
+  timing: () => boolean,
+  stream: StreamBuffer,
+): Promise<Context> {
+  const composer = new Composer()
+  if (content !== '') composer.handle({ kind: 'paste', text: content })
+  const rowsBelow = (): number => ROWS_BELOW
+  const completion = createCompletion(composer, {
+    commands: () => Array.from({ length: 20 }, (_, index) => ({
+      name: `command-${String(index)}`,
+      summary: 'does a thing worth describing at length',
+    })),
+    commandArguments: () => undefined,
+    paths: async () => [],
+  } as never, () => {}, rowsBelow)
+  // A standing offer, not a fresh one: the list is only in the region while it
+  // has candidates, and a `/`-prefixed token is how it gets them.
+  if (content.startsWith('/')) await completion.refresh()
+
+  const ctx = new Context()
+  await ctx.plugin(TuiSlots)
+  ctx.tuiSlots.register('stream', { render: (columns: number) => stream.live(columns) })
+  ctx.tuiSlots.register('status', busyStatus())
+  ctx.tuiSlots.register('composer', createComposerView(composer, '/work/repo', rowsBelow))
+  ctx.tuiSlots.register('completion', completion.view)
+  ctx.tuiSlots.register('timing', createTimingView(timer, timing, () => 0))
+  return ctx
+}
+
+describe('the composed live region', () => {
+  it('draws no row wider than the terminal, and no more rows than it has', async () => {
+    const timer = measuredTurn()
+    const stream = new StreamBuffer()
+    const failures: string[] = []
+    for (const content of CONTENTS) {
+      for (const streaming of [false, true]) {
+        stream.reset()
+        // An unfinished line long enough to fill the stream region's own bound.
+        if (streaming) stream.push('text', 'y'.repeat(600), 80)
+        for (const timing of [false, true]) {
+          const ctx = await window(content, timer, () => timing, stream)
+          for (const rows of HEIGHTS) {
+            for (const columns of WIDTHS) {
+              const { lines, cursor } = ctx.tuiSlots.compose(columns, rows)
+              const where = `content=${JSON.stringify(content.slice(0, 6))} stream=${String(streaming)} timing=${String(timing)} ${String(columns)}x${String(rows)}`
+              for (const [index, line] of lines.entries()) {
+                const width = displayWidth(line)
+                if (width > columns) {
+                  failures.push(`${where}: row ${String(index)} is ${String(width)} of ${String(columns)} columns — ${JSON.stringify(stripAnsi(line))}`)
+                }
+              }
+              const physical = lines.flatMap(line => wrapToWidth(line, Math.max(1, columns)))
+              if (physical.length > rows) {
+                failures.push(`${where}: ${String(physical.length)} physical rows of ${String(rows)} (${String(lines.length)} logical)`)
+              }
+              // A cursor outside the drawn region places the caret on chrome
+              // the frame does not hold, which is the same arithmetic going
+              // wrong one step earlier.
+              if (cursor !== undefined && cursor.row >= physical.length) {
+                failures.push(`${where}: cursor row ${String(cursor.row)} of ${String(physical.length)} rows`)
+              }
+            }
+          }
+        }
+      }
+    }
+    expect(failures.slice(0, 12), `${String(failures.length)} violations`).toEqual([])
+  })
+})
+
+describe('below the shared chrome floor', () => {
+  it('keeps every completion row inside the terminal', async () => {
+    // `chromeWidth` floors at the chrome minimum, so under it the list was laid
+    // out against a width wider than the terminal, and its shortest row — the
+    // `… N more` marker — was not cut at all.
+    const stream = new StreamBuffer()
+    const ctx = await window('/com', measuredTurn(), () => false, stream)
+    for (const columns of [8, 10, 11, 12, 13, 14]) {
+      const rows = ctx.tuiSlots.compose(columns, 24).lines
+      const offenders = rows
+        .filter(row => displayWidth(row) > columns)
+        .map(row => `${String(displayWidth(row))} of ${String(columns)}: ${JSON.stringify(stripAnsi(row))}`)
+      expect(offenders, `at ${String(columns)} columns`).toEqual([])
+      // The list contributes rows at these widths rather than standing down, so
+      // the widths above are measuring the list and not its absence. Its labels
+      // are cut to whatever is left of the width, which is why presence is
+      // asserted here and the readable form is asserted at a real width below.
+      expect(rows.length, `at ${String(columns)} columns`).toBeGreaterThan(0)
+    }
+    // Above the floor the same fixture is legible, which is what makes the
+    // narrow cases a bound on a real offer.
+    const wide = ctx.tuiSlots.compose(80, 24).lines
+    expect(wide.some(row => stripAnsi(row).includes('command-0'))).toBe(true)
+  })
+
+  it('keeps every measured timing row inside the terminal', async () => {
+    // The measured rows are budgeted from the duration's width as well as the
+    // terminal's, and their label and gap have floors of one, so the sum could
+    // exceed the width they were laid out for.
+    const stream = new StreamBuffer()
+    const ctx = await window('', measuredTurn(), () => true, stream)
+    for (const columns of [8, 10, 11, 12, 13, 14, 16, 18]) {
+      const rows = ctx.tuiSlots.compose(columns, 24).lines
+      const offenders = rows
+        .filter(row => displayWidth(row) > columns)
+        .map(row => `${String(displayWidth(row))} of ${String(columns)}: ${JSON.stringify(stripAnsi(row))}`)
+      expect(offenders, `at ${String(columns)} columns`).toEqual([])
+      expect(rows.some(row => stripAnsi(row).includes('timing'))).toBe(true)
+    }
+  })
+})

--- a/packages/dshline/tests/live-region-bounds.spec.ts
+++ b/packages/dshline/tests/live-region-bounds.spec.ts
@@ -24,14 +24,28 @@ import { describe, expect, it } from 'vitest'
 import { Context } from '@deepseek-ai/cordis'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { Composer, displayWidth, stripAnsi, wrapToWidth } from '@dshline/renderer'
+import { CHROME_MIN_COLUMNS } from '../src/chrome.ts'
 import { createCompletion } from '../src/completion.ts'
+import type { TuiSlotView } from '../src/slots.ts'
 import { TuiSlots } from '../src/slots.ts'
 import { StreamBuffer } from '../src/stream.ts'
 import { createTimingView, TurnTimer } from '../src/timing.ts'
 import { createComposerView, createStatusView } from '../src/views.ts'
 
-/** Terminal widths from the narrowest split pane to a wide window. */
-const WIDTHS = [8, 10, 11, 12, 13, 14, 16, 20, 24, 30, 40, 60, 80, 100, 120, 200] as const
+/**
+ * Every pathological width, then representative ordinary ones.
+ *
+ * The range below the shared chrome floor is exhaustive rather than sampled,
+ * which is the contract `narrow-root.spec.ts` already holds the root chrome to:
+ * these are the widths where `chromeWidth` returns more columns than the
+ * terminal has, where a fixed row prefix can outgrow the whole row, and where
+ * every field budget hits its floor at once. One column is included because a
+ * terminal can be one column wide, and the invariant is not "usually".
+ */
+const WIDTHS: readonly number[] = [
+  ...Array.from({ length: CHROME_MIN_COLUMNS }, (_, index) => index + 1),
+  13, 14, 16, 20, 24, 30, 40, 60, 80, 100, 120, 200,
+]
 
 /** Terminal heights from a cramped pane to a tall window. */
 const HEIGHTS = [10, 12, 14, 16, 20, 24, 30, 40, 50] as const
@@ -67,6 +81,34 @@ function measuredTurn(): TurnTimer {
       3_600_000 * (index + 1),
     ))
   }
+  return timer
+}
+
+/**
+ * A CLOSED turn whose spans are hours long, so every duration is a fixed string.
+ *
+ * The running fixture above measures against the wall clock, which is what
+ * makes it a width stress but also makes its durations move between two
+ * renders. Anything that compares one render's durations with another's needs a
+ * turn whose closing events have all arrived.
+ * @returns the fold, with a finished turn retained.
+ */
+function finishedTurn(): TurnTimer {
+  const timer = new TurnTimer()
+  let seq = 0
+  const event = (type: string, data: unknown, time: number): SessionEvent =>
+    ({ type, data, seq: (seq += 1), time } as unknown as SessionEvent)
+  timer.observe(event('turn/start', { turn: 1 }, 0))
+  for (let index = 0; index < 12; index += 1) {
+    const callId = `c${String(index)}`
+    timer.observe(event('tool/call', { callId, name: `tool_number_${String(index)}`, arguments: '{}' }, 0))
+    timer.observe(event(
+      'tool/result',
+      { message: { role: 'tool', content: [{ type: 'tool-result', toolCallId: callId, content: [] }] } },
+      3_600_000 * (index + 1),
+    ))
+  }
+  timer.observe(event('turn/end', { turn: 1 }, 3_600_000 * 13))
   return timer
 }
 
@@ -126,6 +168,55 @@ async function window(
   return ctx
 }
 
+/**
+ * Every way one composition can break the live region's contract with `Screen`.
+ *
+ * Six claims, returned rather than asserted so one run reports the whole
+ * failure surface instead of the first violation it meets:
+ *
+ * - no logical row is wider than the terminal, because `Screen.wrap` turns one
+ *   that is into two physical rows after `compose` has spent the budget;
+ * - no more physical rows than the terminal has, because rows that scroll off
+ *   cannot be climbed back to and erased;
+ * - the cursor row is inside the drawn region, at or above zero, because
+ *   `Screen` climbs from the region's bottom to place it and a row outside the
+ *   region is an erase origin outside it too;
+ * - the cursor column is at or above zero and no further right than the
+ *   terminal's own last cell boundary, for the same reason: the placement is a
+ *   `CUF` from column zero, and one past the width is a column the frame does
+ *   not have.
+ * @param ctx - a registry holding the composed window's views.
+ * @param columns - the terminal's width.
+ * @param rows - the terminal's height.
+ * @param where - what to name this composition in a failure.
+ * @returns one line per violation, empty when the composition is sound.
+ */
+function violations(ctx: Context, columns: number, rows: number, where: string): string[] {
+  const found: string[] = []
+  const at = `${where} ${String(columns)}x${String(rows)}`
+  const { lines, cursor } = ctx.tuiSlots.compose(columns, rows)
+  for (const [index, line] of lines.entries()) {
+    const width = displayWidth(line)
+    if (width > columns) {
+      found.push(`${at}: row ${String(index)} is ${String(width)} of ${String(columns)} columns — ${JSON.stringify(stripAnsi(line))}`)
+    }
+  }
+  const physical = lines.flatMap(line => wrapToWidth(line, Math.max(1, columns)))
+  if (physical.length > rows) {
+    found.push(`${at}: ${String(physical.length)} physical rows of ${String(rows)} (${String(lines.length)} logical)`)
+  }
+  if (cursor === undefined) return found
+  if (cursor.row < 0) found.push(`${at}: cursor row ${String(cursor.row)} is negative`)
+  if (cursor.row >= physical.length) {
+    found.push(`${at}: cursor row ${String(cursor.row)} of ${String(physical.length)} drawn rows`)
+  }
+  if (cursor.column < 0) found.push(`${at}: cursor column ${String(cursor.column)} is negative`)
+  if (cursor.column > columns) {
+    found.push(`${at}: cursor column ${String(cursor.column)} past ${String(columns)} columns`)
+  }
+  return found
+}
+
 describe('the composed live region', () => {
   it('draws no row wider than the terminal, and no more rows than it has', async () => {
     const timer = measuredTurn()
@@ -140,24 +231,7 @@ describe('the composed live region', () => {
           const ctx = await window(content, timer, () => timing, stream)
           for (const rows of HEIGHTS) {
             for (const columns of WIDTHS) {
-              const { lines, cursor } = ctx.tuiSlots.compose(columns, rows)
-              const where = `content=${JSON.stringify(content.slice(0, 6))} stream=${String(streaming)} timing=${String(timing)} ${String(columns)}x${String(rows)}`
-              for (const [index, line] of lines.entries()) {
-                const width = displayWidth(line)
-                if (width > columns) {
-                  failures.push(`${where}: row ${String(index)} is ${String(width)} of ${String(columns)} columns — ${JSON.stringify(stripAnsi(line))}`)
-                }
-              }
-              const physical = lines.flatMap(line => wrapToWidth(line, Math.max(1, columns)))
-              if (physical.length > rows) {
-                failures.push(`${where}: ${String(physical.length)} physical rows of ${String(rows)} (${String(lines.length)} logical)`)
-              }
-              // A cursor outside the drawn region places the caret on chrome
-              // the frame does not hold, which is the same arithmetic going
-              // wrong one step earlier.
-              if (cursor !== undefined && cursor.row >= physical.length) {
-                failures.push(`${where}: cursor row ${String(cursor.row)} of ${String(physical.length)} rows`)
-              }
+              failures.push(...violations(ctx, columns, rows, `content=${JSON.stringify(content.slice(0, 6))} stream=${String(streaming)} timing=${String(timing)}`))
             }
           }
         }
@@ -168,43 +242,108 @@ describe('the composed live region', () => {
 })
 
 describe('below the shared chrome floor', () => {
-  it('keeps every completion row inside the terminal', async () => {
-    // `chromeWidth` floors at the chrome minimum, so under it the list was laid
-    // out against a width wider than the terminal, and its shortest row — the
-    // `… N more` marker — was not cut at all.
-    const stream = new StreamBuffer()
-    const ctx = await window('/com', measuredTurn(), () => false, stream)
-    for (const columns of [8, 10, 11, 12, 13, 14]) {
-      const rows = ctx.tuiSlots.compose(columns, 24).lines
-      const offenders = rows
-        .filter(row => displayWidth(row) > columns)
-        .map(row => `${String(displayWidth(row))} of ${String(columns)}: ${JSON.stringify(stripAnsi(row))}`)
-      expect(offenders, `at ${String(columns)} columns`).toEqual([])
-      // The list contributes rows at these widths rather than standing down, so
-      // the widths above are measuring the list and not its absence. Its labels
-      // are cut to whatever is left of the width, which is why presence is
-      // asserted here and the readable form is asserted at a real width below.
-      expect(rows.length, `at ${String(columns)} columns`).toBeGreaterThan(0)
+  /** Every width from one column up to and including the floor. */
+  const NARROW: readonly number[] = Array.from(
+    { length: CHROME_MIN_COLUMNS + 2 },
+    (_, index) => index + 1,
+  )
+
+  /**
+   * Rows one view contributes on its own, isolated from the composed window.
+   * @param view - the view to draw.
+   * @param columns - the terminal's width.
+   * @returns the view's own logical rows.
+   */
+  const drawn = (view: TuiSlotView, columns: number): readonly string[] => view.render(columns, 24)
+
+  /**
+   * Rows wider than the terminal, described for a failure message.
+   * @param rows - the rows to measure.
+   * @param columns - the terminal's width.
+   * @returns one description per offending row.
+   */
+  const wider = (rows: readonly string[], columns: number): string[] => rows
+    .filter(row => displayWidth(row) > columns)
+    .map(row => `${String(displayWidth(row))} of ${String(columns)}: ${JSON.stringify(stripAnsi(row))}`)
+
+  it('keeps every completion row inside the terminal, or draws none', async () => {
+    // Two failures, one row. `chromeWidth` floors at the chrome minimum, so
+    // below it the list was laid out against a width wider than the terminal;
+    // and the row's four-column prefix was outside the budget entirely, so
+    // cutting the label could not bound the row it sat in.
+    const composer = new Composer()
+    composer.handle({ kind: 'paste', text: '/com' })
+    const completion = createCompletion(composer, {
+      commands: () => Array.from({ length: 20 }, (_, index) => ({
+        name: `command-${String(index)}`,
+        summary: 'does a thing worth describing at length',
+      })),
+      commandArguments: () => undefined,
+      paths: async () => [],
+    } as never, () => {}, () => ROWS_BELOW)
+    await completion.refresh()
+
+    for (const columns of NARROW) {
+      const rows = drawn(completion.view, columns)
+      expect(wider(rows, columns), `at ${String(columns)} columns`).toEqual([])
+      // The policy, stated as an assertion rather than left to whatever the
+      // arithmetic happens to do: below a prefix plus one column of label there
+      // is no row that names a candidate, so the list stands down whole rather
+      // than spending a live row on `  › `.
+      if (columns < 5) expect(rows, `at ${String(columns)} columns`).toEqual([])
+      else expect(rows.length, `at ${String(columns)} columns`).toBeGreaterThan(0)
     }
-    // Above the floor the same fixture is legible, which is what makes the
-    // narrow cases a bound on a real offer.
-    const wide = ctx.tuiSlots.compose(80, 24).lines
-    expect(wide.some(row => stripAnsi(row).includes('command-0'))).toBe(true)
+
+    // Above the floor the same offer is legible, which is what makes the narrow
+    // cases a bound on a real list rather than on its absence.
+    expect(drawn(completion.view, 80).some(row => stripAnsi(row).includes('command-0'))).toBe(true)
   })
 
-  it('keeps every measured timing row inside the terminal', async () => {
-    // The measured rows are budgeted from the duration's width as well as the
-    // terminal's, and their label and gap have floors of one, so the sum could
-    // exceed the width they were laid out for.
-    const stream = new StreamBuffer()
-    const ctx = await window('', measuredTurn(), () => true, stream)
-    for (const columns of [8, 10, 11, 12, 13, 14, 16, 18]) {
-      const rows = ctx.tuiSlots.compose(columns, 24).lines
-      const offenders = rows
-        .filter(row => displayWidth(row) > columns)
-        .map(row => `${String(displayWidth(row))} of ${String(columns)}: ${JSON.stringify(stripAnsi(row))}`)
-      expect(offenders, `at ${String(columns)} columns`).toEqual([])
-      expect(rows.some(row => stripAnsi(row).includes('timing'))).toBe(true)
+  it('keeps every measured timing row inside the terminal without cutting a duration', () => {
+    // The measured rows are budgeted from the DURATION's width as well as the
+    // terminal's, and the label and gap have floors of one, so their sum could
+    // exceed the width they were laid out for. Cutting the row would have
+    // bounded it and turned `2h 41m` into `2h 4` — a different valid reading,
+    // which is what this file's heading ladder already refuses to produce. So
+    // the panel gives up whole fields instead, and this checks both halves.
+    const view = createTimingView(finishedTurn(), () => true, () => 0)
+
+    /**
+     * The trailing duration a row states, when it states one.
+     *
+     * Elision rows are excluded rather than parsed. `… +8 more` degrades to
+     * `… +8` by its own ladder, whose trailing number is a COUNT — and a count
+     * read as a duration would fail this check for saying something true.
+     * Both the panel's elision marker and a span row too narrow for any field
+     * open with the same mark, and neither claims a duration.
+     * @param row - one rendered panel row.
+     * @returns the duration, or nothing when the row states none.
+     */
+    const stated = (row: string): string | undefined => {
+      const text = stripAnsi(row).trimEnd()
+      if (text.trimStart().startsWith('\u2026')) return undefined
+      return /(?<duration>\d[\dhms ]*)$/u.exec(text)?.groups?.duration
+    }
+
+    // Reference set: at a comfortable width every row draws its duration in
+    // full, so these are the whole facts the narrow forms may state.
+    const whole = new Set(drawn(view, 80).slice(1).map(stated).filter(row => row !== undefined))
+    expect(whole.size).toBeGreaterThan(0)
+
+    for (const columns of NARROW) {
+      const rows = drawn(view, columns)
+      expect(wider(rows, columns), `at ${String(columns)} columns`).toEqual([])
+      // The panel never disappears: a heading always fits, and every span still
+      // accounts for itself even where it can only say `…`.
+      expect(rows.length, `at ${String(columns)} columns`).toBeGreaterThan(1)
+      for (const row of rows.slice(1)) {
+        const shown = stated(row)
+        if (shown === undefined) continue
+        expect(
+          whole.has(shown),
+          `at ${String(columns)} columns: ${JSON.stringify(stripAnsi(row))} states a partial duration`,
+        ).toBe(true)
+      }
     }
   })
 })


### PR DESCRIPTION
Found while probing for the duplicate-header bug in #186, and independent of it.
Same failure class, different trigger: two live views can emit a row wider than
the terminal, and one overlong row is one row of live-region overflow.

## Why width is a height invariant

`TuiSlots.compose` budgets the live region in **logical** lines and hands each
view the rows the views above it have not spent. That is only the same thing as
the physical budget while every row fits the terminal's width — `Screen.wrap`
re-wraps an overlong row into two **after** the budgeting is finished, so no
view's own accounting can see the overflow. Once the region is taller than the
screen, its first rows cannot be climbed back to and erased: they become durable
scrollback, and what a reader sees is `╭─ dshline ─… ─╮` printed a second time.

## The completion list

Laid out against `chromeWidth(columns)`, which floors at `CHROME_MIN_COLUMNS`
and so returns a width *wider than the terminal* below that floor. Its label
budget also carried `Math.max(8, width - 4)` — a presentation-only minimum
independent of the terminal — and its shortest row was not cut at all:

```
cols=8  completion[0] width=12  "  › /command"
cols=8  completion[6] width=13  "    … 14 more"
cols=12 completion[6] width=13  "    … 14 more"
```

And **only the label was ever bounded.** Every row carries a fixed four-column
prefix (`  › `) that sat outside the budget entirely, so at one to four columns
the row was five columns wide whatever the label was cut to:

```
cols=1  "  › /"   5 of 1 columns
cols=4  "    /"   5 of 4 columns
```

The previous width sampling started at eight and could not see it.

Now: the width is clamped to the terminal; the prefix is one named constant
(`ROW_PREFIX_COLUMNS`) shared by the label budget, the help-line budget and the
stand-down threshold, rather than a `4` repeated at each; the **whole assembled
row** is cut rather than only its payload; and below a prefix plus one column of
label the list stands down entirely instead of spending a live row on `  › `,
which names no candidate. That last part is the same call the list already makes
when the screen leaves it no rows, and the same one the status line already makes
about a presentation-only minimum:

> The old `Math.max(10, ...)` floor gave this line a presentation-only minimum
> independent of the terminal, so a terminal narrower than 12 columns got a
> budget wider than itself and the two-column indent pushed the drawn row past
> the real width.

## The timing panel's measured rows

These are budgeted from the **data** as well as from the width: `labelWidth`,
`gap` and `barCells` are what is left after the longest duration's width is
subtracted, and `labelWidth` and `gap` have floors of one. A long-running turn
on a narrow terminal therefore produces a row wider than the width it was laid
out for:

```
cols=16 timing[1] width=17  "  t 2h 41m 17s"   (label starved to one column)
```

The first version of this PR bounded it with a whole-row `truncateToWidth`. That
satisfied the geometry invariant by breaking a different rule the file already
keeps: **the duration sits at the right edge**, so cutting the row turns
`2h 41m` into `2h 4` — not a narrower fact but a different, entirely plausible
one. `timingLines` already gives up whole facts in its heading ladder for
exactly this reason (*"a heading ending in `· 4` reads as a broken duration"*).

So the fields are no longer cut; the **form** is chosen:

```
label + bar + duration
  → label + duration
    → indented duration
      → bare duration          (the indent is alignment; a whole duration outranks it)
        → …                    (nothing truthful fits, so say only that something is here)
```

Each rung's exact drawn width is predicted before it is chosen, which is what
catches the floored `gap` and `labelWidth` asking for more columns than exist.
The widest form that fits is picked **once for the panel** rather than per row —
every field is padded to a shared width, and a panel where some rows carried a
bar and others did not would be ragged for a reason no reader could see.

## Reachability, stated plainly

Neither is reachable at an ordinary window size, and **neither is the cause of
the duplicate header a subagent produces** — that is a foreign writer on
descriptor 2, fixed in #186. These are the bugs the probe turned up on the way
there. They bite a narrow split pane, and the timing one needs `/timing` on and
a turn long enough to format wide.

## The test

`packages/dshline/tests/live-region-bounds.spec.ts` — the property both bugs
broke, over the real views composed together (stream, composer, completion,
timing, status), because the failure only appears in combination and a view that
fits alone can still be the one that pushes the region over. **Six claims** per
composition:

- every logical row is `<= columns`
- wrapped physical rows are `<= rows`
- `cursor.row >= 0`
- `cursor.row` is inside the drawn region
- `cursor.column >= 0`
- `cursor.column <= columns`

Widths run **exhaustively from one column** through `CHROME_MIN_COLUMNS` — the
range `narrow-root.spec.ts` already holds the root chrome to — then across
representative ordinary widths to 200, over heights 10–50, with an empty, short,
thirty-line and two-thousand-character composer, a standing completion offer,
streaming on and off, and the timing panel on and off.

Two focused cases below the floor name each view directly:

- **completion**: no row wider than the terminal at any width down to one, and
  the stand-down policy asserted as a policy — nothing below five columns,
  something above it — rather than left to whatever the arithmetic happens to
  do. A legible row at 80 columns proves the narrow cases bound a real offer and
  not its absence.
- **timing**: no row wider than the terminal, the panel never disappears, and a
  duration that appears at all appears **whole**. Checked against the panel's own
  wide rendering as the reference set, over a *closed* turn so the durations do
  not move between renders, with elision rows excluded because `… +8` states a
  count and not a time.

All three fail without the two source changes.

```
Test Files  166 passed | 1 skipped (167)
Tests       3222 passed | 22 skipped (3244)
pnpm typecheck / pnpm build   clean
git diff --check              clean
```

Independent of #186 — the two touch no common file, and this PR changes no
foreign-write handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
