### PR TITLE
fix(dshline): keep ctrl-c from exiting with active work

### DIFF
--- a/.changeset/guard-ctrl-c-while-work-is-owned.md
+++ b/.changeset/guard-ctrl-c-while-work-is-owned.md
@@ -1,0 +1,13 @@
+---
+'@dshline/dshline': patch
+---
+
+Keep idle `ctrl-c` from closing dshline while Harness still publishes a Job or
+subagent owned by the current session.
+
+One-shot `subagent/end` reports `run.result` settlement, not completion of the
+consumer-owned `run.dispose()` teardown. The standard background tool path keeps
+that interval visible through its nonterminal Job, while foreground work keeps
+the parent Agent running until disposal returns. The terminal now reads the
+generic Work snapshot before treating idle `ctrl-c` as quit; explicit `ctrl-d`
+remains the unconditional exit boundary.

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -1966,6 +1966,18 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
           }
           return
         }
+        // An idle parent can still own a background Job or continuable child.
+        // `ctrl-c` is the interrupt-or-quit boundary, not the explicit `ctrl-d`
+        // exit boundary, so do not retire the session while Harness still
+        // publishes owned work. The Job/subagent snapshot is the generic
+        // authority here; never infer ownership from provider processes.
+        const snapshot = work.snapshot()
+        if (activeWorkCount(snapshot) > 0) {
+          const summary = workSummary(snapshot) ?? 'active work'
+          commit([paint(`· ${summary} still attached to this session.`, 'muted')])
+          draw()
+          return
+        }
         w.requestExit()
         return
       }

--- a/packages/dshline/src/views.ts
+++ b/packages/dshline/src/views.ts
@@ -536,9 +536,10 @@ export function createStatusView(state: () => StatusState): TuiSlotView {
         facts.push(`${bareStatus}${elapsed}`)
       } else if (current.compacting === true) {
         // Compaction is a model-free maintenance call, so it must not enter the
-        // busy branch: ctrl-c still quits an idle agent. It does need a visible
-        // state, though, because a summarizer can take longer than a local
-        // command and the durable start event is intentionally transcript-silent.
+        // busy branch: ctrl-c still quits an idle agent with no owned work. It
+        // does need a visible state, though, because a summarizer can take longer
+        // than a local command and the durable start event is intentionally
+        // transcript-silent.
         bareStatus = `${paint(spinnerFrame(current.tick), 'busy')}  ${paint('compacting', 'busy')}`
         facts.push(bareStatus)
       } else if (current.replay !== undefined) {

--- a/packages/dshline/tests/exit-lifecycle.spec.ts
+++ b/packages/dshline/tests/exit-lifecycle.spec.ts
@@ -27,6 +27,8 @@ interface FixtureOptions {
   readonly cleanupFailure?: boolean
   /** Make the public Agent cancellation seam throw synchronously. */
   readonly cancelFailure?: boolean
+  /** Publish one owned nonterminal Job through the generic Work seam. */
+  readonly activeJob?: boolean
 }
 
 /** One assembled attachment and the controls needed by these tests. */
@@ -76,6 +78,15 @@ async function fixture(options: FixtureOptions = {}): Promise<Fixture> {
     }),
   }
   ctx.provide('commands', commands as never)
+  ctx.provide('jobs', {
+    list: () => options.activeJob
+      ? [{
+        id: 'job-1', kind: 'subagent', label: 'long child', status: 'running', startedAt: 0,
+        ownerSession: 'exit-test', reported: false,
+      }]
+      : [],
+    onJobsChanged: () => () => {},
+  } as never)
 
   const events: string[] = []
   const exit = vi.fn(() => { events.push('appExit') })
@@ -173,6 +184,25 @@ describe('attachment exit lifecycle', () => {
     f.globalQuit()
     expect(f.agent.cancel).toHaveBeenCalledOnce()
     expect(f.exit).toHaveBeenCalledOnce()
+  })
+
+  it('does not turn idle ctrl-c into exit while an owned Job remains active', async () => {
+    // A background one-shot is result-settled before its consumer-owned dispose
+    // finishes; its Job stays nonterminal through that interval. The generic Job
+    // snapshot, not the provider process, is the authority this guard consumes.
+    const f = await fixture({ activeJob: true })
+    f.dispatch()?.({ kind: 'key', name: 'ctrl-c' })
+    expect(f.agent.cancel).not.toHaveBeenCalled()
+    expect(f.exit).not.toHaveBeenCalled()
+  })
+
+  it('cancels a running Agent instead of exiting on ctrl-c', async () => {
+    // This is the foreground result→dispose gap: the parent remains running
+    // while its tool awaits consumer-owned provider teardown.
+    const f = await fixture({ status: 'running' })
+    f.dispatch()?.({ kind: 'key', name: 'ctrl-c' })
+    expect(f.agent.cancel).toHaveBeenCalledWith({ kind: 'user' })
+    expect(f.exit).not.toHaveBeenCalled()
   })
 
   it('cancels a running Agent before requesting app exit', async () => {


### PR DESCRIPTION
## Summary

- prevent idle `ctrl-c` from requesting dshline exit while Harness still publishes owned Jobs or subagents
- preserve `agent.cancel({ kind: 'user' })` for a running parent
- preserve Work-overlay `ctrl-c` navigation and global unconditional `ctrl-d`
- add focused lifecycle regressions and a patch changeset

## Root cause

Harness `0.1.5-alpha.1` intentionally emits one-shot `subagent/end` when `run.result` settles, before the consumer-owned `run.dispose()` reaches provider quiescence. The standard background tool path remains represented by its nonterminal Job during disposal; foreground work keeps the parent Agent running until disposal returns. The old idle composer path ignored `activeWorkCount()` and could exit while an owned Job remained active.

This change consumes only the generic Work snapshot. It does not retain settled subagent rows, inspect provider processes, or introduce a second lifecycle state machine. Harness still needs a generic disposal observation seam for arbitrary direct one-shot consumers; that is outside this dshline fix.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- `node tools/harness-target.mjs`
