### PR TITLE
fix(ci): separate bootstrap distribution diagnostic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,22 +353,18 @@ jobs:
       # pre-creates the profile — the harness initializes and installs it from
       # inside the wrapper's first run, while a real terminal answers the
       # question — and the session it continues into has to reach `ready`.
-      #
-      # Deliberately NOT pinned to the adopted target, unlike the step above.
-      # The two steps install different plugins: that one packs THIS commit, so
-      # the adopted generation is the only launcher it can be paired with; this
-      # one lets the harness install `@dshline/dshline` from the registry, which
-      # is the PREVIOUS release, built for whatever generation was adopted when
-      # it shipped. Pinning that pair to a generation dshline has only just
-      # adopted asks whether an already-published plugin supports a Harness it
-      # was never released for — a pair no user can install, and one every
-      # migration commit would fail by construction. Following `latest` on both
-      # sides reproduces what a new user actually gets, which is the question
-      # this step exists to ask; what it proves is THIS commit's wrapper driving
-      # the first-run lifecycle.
+      # The launcher is pinned to the same exact adopted target as the smoke
+      # above; only the plugin installation remains registry-backed because the
+      # wrapper asks the harness to install `@dshline/dshline` during first run.
+      # This keeps the merge gate deterministic while still proving THIS commit's
+      # wrapper driving the first-run lifecycle. A hand-run `pnpm test:consumer`
+      # may omit the flag and inspect the npm default; default-install coherence
+      # is a release-channel question owned by `.github/workflows/release-channel.yml`.
       - name: first run from nothing, beside the published launcher
         if: steps.published.outputs.published == 'true'
-        run: node tools/consumer-smoke.mjs --bootstrap
+        env:
+          TARGET_VERSION: ${{ steps.target.outputs.version }}
+        run: node tools/consumer-smoke.mjs --bootstrap --launcher-version "$TARGET_VERSION"
 
       - name: consumer verdict
         if: always()
@@ -379,7 +375,7 @@ jobs:
           {
             if [ "$PUBLISHED" = "true" ]; then
               echo "Consumer path validated against @deepseek-ai/dsh@$TARGET_VERSION"
-              echo 'First-run path validated against the published pair (latest launcher, latest plugin).'
+              echo "First-run path validated with @deepseek-ai/dsh@$TARGET_VERSION and the registry plugin selected by the wrapper."
             else
               echo "@deepseek-ai/dsh@$TARGET_VERSION is not on npm yet — consumer path NOT validated this run."
               echo 'This is publication lag, not an incompatibility: dshline targets an upstream'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,14 @@ name: ci
 #   Core              is dshline itself correct?                      BLOCKING
 #   Harness target    does it work against the exact upstream source
 #                     revision it claims to support (HARNESS_TARGET)?  BLOCKING
-#   Harness published can a real user install and boot it?            BLOCKING once npm carries the target
+#   Harness published does the packed bundle boot beside the exact target? BLOCKING once npm carries the target
+#   Bootstrap         does the current wrapper survive the default install? DIAGNOSTIC only
 #
-# Nothing here follows anything mutable — no branch, no npm dist-tag. Both are
-# pointers somebody else moves, and a merge gate keyed on one can turn red for
-# a reason no commit in this repository caused. The target is an exact commit
-# and an exact version; the published lane asks only whether that exact version
-# exists on the registry yet.
+# The blocking questions never follow anything mutable — no branch, no npm
+# dist-tag. Both are pointers somebody else moves, and a merge gate keyed on one
+# can turn red for a reason no commit in this repository caused. The bootstrap
+# diagnostic observes that mutable distribution state without making it a
+# compatibility claim or a merge gate.
 #
 # There is no scheduled run and no `Harness upstream · master` lane any more.
 # Watching a branch head was aimed at the wrong object: an arbitrary master
@@ -297,9 +298,10 @@ jobs:
           fi
 
   harness-published:
-    # The question npm answers and source cannot: can a normal user install
-    # this, and does it boot? Packed bundle, the real published launcher at the
-    # adopted version, a fresh profile, a real pseudo-terminal.
+    # The blocking question npm answers and source cannot: can this packed
+    # bundle boot beside the exact adopted launcher? The bootstrap below is a
+    # separate distribution diagnostic because its first run installs the
+    # published dshline package from the registry, not this source tree.
     #
     # Publication lag is reported as itself. GitHub source moves first and npm
     # catches up later; "the generation we target is not on the registry yet"
@@ -339,45 +341,52 @@ jobs:
       - if: steps.published.outputs.published == 'true'
         run: pnpm run build
 
-      # The consumer path: packed bundle, published launcher pinned to the
-      # adopted version, fresh profile, a real pseudo-terminal, startup banner,
-      # clean ctrl-d. Types resolving is not a boot.
+      # The authoritative consumer path: this commit's packed bundle beside
+      # the exact adopted launcher, a fresh profile, a real pseudo-terminal,
+      # startup banner, and clean ctrl-d. Types resolving is not a boot.
       - name: boot the packed plugin beside the published launcher
+        id: packed
         if: steps.published.outputs.published == 'true'
         env:
           TARGET_VERSION: ${{ steps.target.outputs.version }}
         run: node tools/consumer-smoke.mjs --launcher-version "$TARGET_VERSION"
 
-      # The other advertised sequence, and the one a new user actually types:
-      # `npm install -g` then `dshline`, against an empty harness home. Nothing
-      # pre-creates the profile — the harness initializes and installs it from
-      # inside the wrapper's first run, while a real terminal answers the
-      # question — and the session it continues into has to reach `ready`.
-      # The launcher is pinned to the same exact adopted target as the smoke
-      # above; only the plugin installation remains registry-backed because the
-      # wrapper asks the harness to install `@dshline/dshline` during first run.
-      # This keeps the merge gate deterministic while still proving THIS commit's
-      # wrapper driving the first-run lifecycle. A hand-run `pnpm test:consumer`
-      # may omit the flag and inspect the npm default; default-install coherence
-      # is a release-channel question owned by `.github/workflows/release-channel.yml`.
-      - name: first run from nothing, beside the published launcher
+      # This is the advertised default-install sequence: `npm install -g`
+      # then `dshline`, against an empty harness home. It intentionally follows
+      # npm's current distribution state: the wrapper comes from this commit,
+      # but the first run installs the published dshline package from the
+      # registry. That makes it useful operational evidence, not a compatibility
+      # verdict for this source tree. A hand-run `pnpm test:consumer` has the
+      # same default when no launcher version is supplied.
+      - name: first run from nothing, beside the default launcher
+        id: bootstrap
+        continue-on-error: true
         if: steps.published.outputs.published == 'true'
-        env:
-          TARGET_VERSION: ${{ steps.target.outputs.version }}
-        run: node tools/consumer-smoke.mjs --bootstrap --launcher-version "$TARGET_VERSION"
+        run: node tools/consumer-smoke.mjs --bootstrap
 
       - name: consumer verdict
         if: always()
         env:
           TARGET_VERSION: ${{ steps.target.outputs.version }}
           PUBLISHED: ${{ steps.published.outputs.published }}
+          PACKED_OUTCOME: ${{ steps.packed.outcome }}
+          BOOTSTRAP_OUTCOME: ${{ steps.bootstrap.outcome }}
         run: |
           {
             if [ "$PUBLISHED" = "true" ]; then
-              echo "Consumer path validated against @deepseek-ai/dsh@$TARGET_VERSION"
-              echo "First-run path validated with @deepseek-ai/dsh@$TARGET_VERSION and the registry plugin selected by the wrapper."
+              if [ "$PACKED_OUTCOME" = "success" ]; then
+                echo "Exact-target consumer: PASS (@deepseek-ai/dsh@$TARGET_VERSION)"
+              else
+                echo "Exact-target consumer: FAIL ($PACKED_OUTCOME)"
+              fi
+              if [ "$BOOTSTRAP_OUTCOME" = "success" ]; then
+                echo 'Default-install bootstrap: PASS (diagnostic only)'
+              else
+                echo "Default-install bootstrap: FAIL ($BOOTSTRAP_OUTCOME; diagnostic only; does not invalidate HARNESS_TARGET compatibility)"
+              fi
             else
-              echo "@deepseek-ai/dsh@$TARGET_VERSION is not on npm yet — consumer path NOT validated this run."
+              echo "Exact-target consumer: SKIPPED (@deepseek-ai/dsh@$TARGET_VERSION is not on npm yet)"
+              echo 'Default-install bootstrap: SKIPPED (adopted launcher is not published; diagnostic not run)'
               echo 'This is publication lag, not an incompatibility: dshline targets an upstream'
               echo 'source revision, and the registry catches up afterwards. It is never a reason'
               echo 'to support an older published generation.'

--- a/tools/ci-workflow.spec.mjs
+++ b/tools/ci-workflow.spec.mjs
@@ -120,6 +120,21 @@ describe('the adopted target lane is deterministic', () => {
   })
 })
 
+describe('the published consumer lane uses the adopted launcher', () => {
+  it('pins both smoke paths to the target output', async () => {
+    const job = extractJob(await readWorkflow(), 'harness-published')
+    const smokeSteps = job.split('\n      - ').filter(step => step.includes('node tools/consumer-smoke.mjs'))
+    expect(smokeSteps).toHaveLength(2)
+    expect(smokeSteps.map(step => step.match(/run:\s*(node tools\/consumer-smoke\.mjs[^\n]+)/u)?.[1])).toEqual([
+      'node tools/consumer-smoke.mjs --launcher-version "$TARGET_VERSION"',
+      'node tools/consumer-smoke.mjs --bootstrap --launcher-version "$TARGET_VERSION"',
+    ])
+    for (const step of smokeSteps) {
+      expect(step).toMatch(/TARGET_VERSION:\s*\$\{\{\s*steps\.target\.outputs\.version\s*\}\}/u)
+    }
+  })
+})
+
 describe('the obsolete multi-line compatibility machinery is gone', () => {
   it('carries no Minimum floor, no dist-tag lanes, and no rolling sync automation', async () => {
     const workflow = await readWorkflow()

--- a/tools/ci-workflow.spec.mjs
+++ b/tools/ci-workflow.spec.mjs
@@ -2,12 +2,12 @@
  * Guards the properties that make the Harness compatibility policy true
  * rather than merely written down.
  *
- * dshline targets ONE Harness architecture at a time, and `ci.yml` asks about
- * exactly that: an exact upstream commit, gating every merge. Nothing mutable
- * belongs in it — a `ref:` changed from a commit to a branch, or a dist-tag
- * read added "just to see", turns a merge gate into something DeepSeek can
- * fail from a thousand miles away. That mistake shows up in review as a
- * one-word diff, so it is checked here instead.
+ * dshline targets ONE Harness architecture at a time, and the blocking lanes in
+ * `ci.yml` ask about exactly that: an exact upstream commit, gating every merge.
+ * Nothing mutable may decide a merge — a `ref:` changed from a commit to a
+ * branch, or a dist-tag read added to a blocking path, turns a merge gate into
+ * something DeepSeek can fail from a thousand miles away. A diagnostic may
+ * observe distribution state, but it must remain outside that verdict.
  *
  * Watching upstream for a NEWER generation is a separate workflow with a
  * separate question (`harness-sync.yml`), and its own spec.
@@ -120,18 +120,38 @@ describe('the adopted target lane is deterministic', () => {
   })
 })
 
-describe('the published consumer lane uses the adopted launcher', () => {
-  it('pins both smoke paths to the target output', async () => {
+describe('the published consumer lane separates compatibility from distribution', () => {
+  it('keeps only the packed smoke on the exact-target path', async () => {
     const job = extractJob(await readWorkflow(), 'harness-published')
     const smokeSteps = job.split('\n      - ').filter(step => step.includes('node tools/consumer-smoke.mjs'))
     expect(smokeSteps).toHaveLength(2)
     expect(smokeSteps.map(step => step.match(/run:\s*(node tools\/consumer-smoke\.mjs[^\n]+)/u)?.[1])).toEqual([
       'node tools/consumer-smoke.mjs --launcher-version "$TARGET_VERSION"',
-      'node tools/consumer-smoke.mjs --bootstrap --launcher-version "$TARGET_VERSION"',
+      'node tools/consumer-smoke.mjs --bootstrap',
     ])
-    for (const step of smokeSteps) {
-      expect(step).toMatch(/TARGET_VERSION:\s*\$\{\{\s*steps\.target\.outputs\.version\s*\}\}/u)
-    }
+    expect(smokeSteps[0]).toMatch(/TARGET_VERSION:\s*\$\{\{\s*steps\.target\.outputs\.version\s*\}\}/u)
+    expect(smokeSteps[0]).not.toContain('continue-on-error')
+    expect(smokeSteps[1]).not.toContain('TARGET_VERSION')
+    expect(smokeSteps[1]).toMatch(/continue-on-error:\s*true/u)
+  })
+
+  it('surfaces the bootstrap outcome without making it authoritative', async () => {
+    const job = extractJob(await readWorkflow(), 'harness-published')
+    expect(job).toContain('BOOTSTRAP_OUTCOME: ${{ steps.bootstrap.outcome }}')
+    expect(job).toContain('Default-install bootstrap: PASS (diagnostic only)')
+    expect(job).toContain('Default-install bootstrap: FAIL (')
+    expect(job).toContain('diagnostic only; does not invalidate HARNESS_TARGET compatibility')
+    expect(job).not.toContain('First-run path validated')
+  })
+
+  it('keeps CI required dependent on the compatibility job, not a bootstrap verdict', async () => {
+    const workflow = await readWorkflow()
+    const required = extractJob(workflow, 'required')
+    expect(required).toContain('needs: [core, windows-launcher, docs, harness-target, harness-published]')
+    const published = extractJob(workflow, 'harness-published')
+    expect(published).toContain('id: packed')
+    expect(published).toContain('id: bootstrap')
+    expect(published).toContain('continue-on-error: true')
   })
 })
 

--- a/tools/consumer-smoke.mjs
+++ b/tools/consumer-smoke.mjs
@@ -18,8 +18,10 @@
  *
  * `--bootstrap` proves the other advertised sequence, the one a new user
  * actually types: install both packages, run `dshline`, answer the first-run
- * question, end up in a session. The two modes answer two different questions
- * and are kept apart on purpose:
+ * question, end up in a session. CI supplies `--launcher-version` to both
+ * modes so ordinary merge gates use the exact adopted Harness generation;
+ * a hand-run `pnpm test:consumer` may omit it and fall back to npm `latest`.
+ * The two modes answer two different questions and are kept apart on purpose:
  *
  * - the default mode asks whether the plugin code IN THIS COMMIT installs and
  *   boots against this Harness line, so it installs the packed tarball (and

--- a/tools/consumer-smoke.mjs
+++ b/tools/consumer-smoke.mjs
@@ -18,9 +18,10 @@
  *
  * `--bootstrap` proves the other advertised sequence, the one a new user
  * actually types: install both packages, run `dshline`, answer the first-run
- * question, end up in a session. CI supplies `--launcher-version` to both
- * modes so ordinary merge gates use the exact adopted Harness generation;
- * a hand-run `pnpm test:consumer` may omit it and fall back to npm `latest`.
+ * question, end up in a session. CI supplies `--launcher-version` to the
+ * default mode for its blocking exact-target check. The bootstrap mode
+ * intentionally omits it when CI runs the distribution diagnostic, just as a
+ * hand-run `pnpm test:consumer` may, so it can observe npm `latest`.
  * The two modes answer two different questions and are kept apart on purpose:
  *
  * - the default mode asks whether the plugin code IN THIS COMMIT installs and
@@ -210,10 +211,11 @@ function storeArgs() {
  * The version an ordinary consumer would install today, following `latest`
  * (`npm install -g @deepseek-ai/dsh`).
  *
- * Only the fallback for a hand-run `pnpm test:consumer`. CI always passes
- * `--launcher-version`, because the launcher it must boot against is the
- * adopted Harness generation in `HARNESS_TARGET` — an exact version — and not
- * whichever line a dist-tag happens to name that day.
+ * Used by the fallback for a hand-run `pnpm test:consumer` and by the CI
+ * bootstrap diagnostic. The blocking CI mode always passes
+ * `--launcher-version`, because the launcher it must boot against is the adopted
+ * Harness generation in `HARNESS_TARGET` — an exact version — and not whichever
+ * line a dist-tag happens to name that day.
  * @param packageName - the package to look up.
  * @returns the exact version string.
  */
@@ -631,9 +633,9 @@ if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(
   const bundleManifest = JSON.parse(await readFile(join(BUNDLE_DIR, 'package.json'), 'utf8'))
   const workspace = await mkdtemp(join(tmpdir(), 'dsh-consumer-smoke-'))
   try {
-    // CI always pins: the launcher it must boot against is the exact adopted
-    // Harness generation, and installing `latest` would prove a boot against
-    // a line this repository makes no claim about.
+    // The blocking CI mode pins the launcher to the exact adopted Harness
+    // generation. The bootstrap diagnostic deliberately leaves it unpinned so
+    // this mode can observe the default distribution state instead.
     const launcherVersion = pinnedLauncher ?? await publishedVersion(LAUNCHER_PACKAGE)
     const consumerDir = join(workspace, 'consumer')
     await mkdir(consumerDir, { recursive: true })
@@ -648,16 +650,16 @@ if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(
     await mkdir(scratch, { recursive: true })
 
     if (bootstrap) {
-      // What this mode proves, and nothing else: that THIS commit's wrapper
-      // implements the lifecycle a new user meets. So the only thing taken from
-      // the tarball is the executable, the harness home is genuinely empty, and
-      // the package the first run installs is whatever the registry serves for
-      // `@dshline/dshline` — because that is the name the wrapper passes, and
-      // making that name resolve to a local tarball would mean editing the
-      // profile's pnpm settings, i.e. testing a profile this script had already
-      // touched. Whether the UNPUBLISHED plugin code in this commit installs and
-      // boots is the other mode's question, and it answers it with the packed
-      // tarball and a renderer fallback this mode needs none of.
+      // What this mode proves, and nothing else: how THIS commit's wrapper
+      // behaves through the registry-backed lifecycle a new user meets. So the
+      // only thing taken from the tarball is the executable, the harness home is
+      // genuinely empty, and the package the first run installs is whatever the
+      // registry serves for `@dshline/dshline` — because that is the name the
+      // wrapper passes. Making that name resolve to a local tarball would mean
+      // editing the profile's pnpm settings, i.e. testing a profile this script
+      // had already touched. Whether the UNPUBLISHED plugin code in this commit
+      // installs and boots against the adopted target is the other mode's
+      // question; this mode is only a distribution diagnostic.
       const wrapper = await extractWrapper(tarball, join(workspace, 'unpacked'))
       const home = join(workspace, '.dsh-first-run')
       // Which outcome is CORRECT depends on the registry, so it is decided before


### PR DESCRIPTION
## Summary

PR #191 corrects the CI architecture without adopting another Harness generation. `HARNESS_TARGET` remains `0.1.5-alpha.2` at `b2e3b2a0125854567a4a5fcba75782e42fe84901`.

The first implementation in this PR pinned the bootstrap launcher, which was technically deterministic but paired Harness `0.1.5-alpha.2` with the registry-installed `@dshline/dshline@0.20.0`. Historical release evidence from PR #180 shows that package was released from the Harness `0.1.2-rc.1` generation. That invalid pair produced `cannot get property "agent" without inject`; it did not prove the current source was broken against alpha.2.

The corrected topology is:

- **Blocking:** the packed current-source consumer smoke with the exact launcher version from `HARNESS_TARGET`.
- **Diagnostic only:** the bootstrap/default-install smoke, intentionally unpinned so it observes npm distribution state and the registry-installed plugin. Its failures are explicitly reported and cannot affect `CI · required`.
- **Separate release concern:** `.github/workflows/release-channel.yml` owns whether mutable npm `latest` is coherent for a release.

The diagnostic result now reports `PASS`, `FAIL (diagnostic only)`, or `SKIPPED`; it never says the first-run path was validated after failure. Focused workflow tests protect the topology and outcome reporting.

## Observed versions

- Exact-target smoke: `@deepseek-ai/dsh@0.1.5-alpha.2` plus packed `@dshline/dshline@0.20.0` — passed.
- Default bootstrap diagnostic: npm `latest` resolved `@deepseek-ai/dsh@0.1.5-rc.1`; the requested registry plugin was `@dshline/dshline@0.20.0` — failed with the known mixed-generation `agent` injection error.

This PR does not change `HARNESS_TARGET`, `HARNESS_COMPAT`, dependency pins, runtime behavior, package publication, PR #190, or Version Packages PR #182. Harness `0.1.5-rc.1` adoption remains a separate migration PR.