### PR TITLE
refactor(dshline): extract a bounded-surface kernel and capability presenters

### DIFF
--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -89,10 +89,10 @@ import {
   usageInspection,
 } from './usage.ts'
 import { createUsageOverlay } from './usage-overlay.ts'
-import { cacheInspection, cacheTransitionNote, requestHeaderReading, routeContextReading } from './cache/model.ts'
-import { createCacheOverlay } from './cache/overlay.ts'
-import { contextPreview, contextReading, ContextSurveyor, contextPressureTokens } from './context/model.ts'
-import { createContextOverlay } from './context/overlay.ts'
+import { cacheTransitionNote } from './cache/model.ts'
+import { createCachePresenter } from './cache/presenter.ts'
+import { contextReading, ContextSurveyor, contextPressureTokens } from './context/model.ts'
+import { createContextPresenter } from './context/presenter.ts'
 import { compactionNote } from './context/compaction.ts'
 import { bannerLines, composerGutter, composerInner, createComposerView, createStatusView } from './views.ts'
 import type { Window } from './window.ts'
@@ -100,9 +100,10 @@ import { createHarnessWork } from './work/index.ts'
 import { createWorkOverlay } from './work/overlay.ts'
 import { activeWorkCount, workSummary } from './work/model.ts'
 import { SessionProjectionObserver } from './projections/observer.ts'
+import { openSurface } from './surface.ts'
 import { goalReading } from './goals/model.ts'
 import { todoReading, todoSummary } from './todos/model.ts'
-import { createTodoOverlay } from './todos/overlay.ts'
+import { createTodosPresenter } from './todos/presenter.ts'
 import { SkillCatalog } from './skills/catalog.ts'
 import { slashCandidates } from './skills/model.ts'
 import { pendingUserInput } from './steering.ts'
@@ -514,6 +515,35 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     }).catch(report)
   }
 
+  // Capability presenters own their command, their bounded surface, and the
+  // translation from Harness facts to terminal rows. `attachSession` wires each
+  // once and hands it only the readers it needs, so a capability's presentation
+  // can change without this function learning anything new.
+  const todosPresenter = createTodosPresenter({
+    slots: ctx.tuiSlots,
+    snapshot: () => projections.snapshot(),
+  })
+  const cachePresenter = createCachePresenter({
+    slots: ctx.tuiSlots,
+    session: agent.session,
+    snapshot: () => projections.snapshot(),
+  })
+  const contextPresenter = createContextPresenter({
+    slots: ctx.tuiSlots,
+    session: agent.session,
+    snapshot: () => projections.snapshot(),
+    survey: () => surveyor.read(),
+    // The SELECTED route's window, which is what the next request will be
+    // measured against; the projection's own last-recorded capacity is the
+    // fallback for a session whose route metadata never resolved.
+    capacity: () => w.modelInfo.contextWindow,
+    // A live getter, not a snapshot: a scoped composition change while the
+    // overlay is open repaints the footer before the next keystroke.
+    canCompact: compactRegistered,
+    compact: runCompactCommand,
+    invalidate: () => { ctx.tuiSlots.invalidate() },
+  })
+
   const localCommands = new LocalCommandRegistry([
     {
       name: 'image',
@@ -676,65 +706,16 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
         }
         // A bounded live-region overlay like Work and Todos: it disappears on
         // close and never rewrites the transcript underneath it.
-        let dismiss = (): void => {}
-        const overlay = createUsageOverlay({
+        openSurface(ctx.tuiSlots, close => createUsageOverlay({
           inspection: () => usageInspection(projections.snapshot(), usage.reading),
           mode: () => prefs.usageMode,
           chooseDisplay: () => { chooseUsageDisplay() },
-          close: () => dismiss(),
-        })
-        dismiss = ctx.tuiSlots.pushOverlay(overlay)
+          close,
+        }))
       },
     },
-    {
-      name: 'cache',
-      description: "Inspect how this session's prompt cache is behaving",
-      execute: () => {
-        // Read-only, like `/context` and `/todos`: a cache inspector invites an
-        // optimization gesture, and control over a route is not this overlay's
-        // to offer. One bounded live region, closed with esc, transcript intact.
-        let dismiss = (): void => {}
-        const overlay = createCacheOverlay({
-          // One projection cut per paint, the same one `/usage` reads, so the
-          // two inspectors cannot report different buckets for one moment. The
-          // two records beside it are Harness's own accessors, read the same way
-          // — no state of this frontend's own stands behind any figure, and no
-          // fact recorded before the newest header survives into the report.
-          inspection: () => cacheInspection(
-            projections.snapshot(),
-            requestHeaderReading(agent.session),
-            routeContextReading(agent.session),
-          ),
-          close: () => dismiss(),
-        })
-        dismiss = ctx.tuiSlots.pushOverlay(overlay)
-      },
-    },
-    {
-      name: 'context',
-      description: "Inspect what is occupying the model's context right now",
-      execute: () => {
-        // Temporary live-region chrome, like Work: the committed transcript
-        // under it is never rewritten, and closing leaves scrollback intact.
-        let dismiss = (): void => {}
-        const overlay = createContextOverlay({
-          reading: () => contextReading(projections.snapshot()),
-          survey: () => surveyor.read(),
-          preview: seq => contextPreview(agent.session, seq),
-          // The SELECTED route's window, which is what the next request will be
-          // measured against; the projection's own last-recorded capacity is the
-          // fallback for a session whose route metadata never resolved.
-          capacity: () => w.modelInfo.contextWindow,
-          // A live getter, not a snapshot: a scoped composition change while the
-          // overlay is open repaints the footer before the next keystroke.
-          canCompact: compactRegistered,
-          compact: runCompactCommand,
-          close: () => dismiss(),
-          invalidate: () => { ctx.tuiSlots.invalidate() },
-        })
-        dismiss = ctx.tuiSlots.pushOverlay(overlay)
-      },
-    },
+    cachePresenter.command,
+    contextPresenter.command,
     {
       // Named for the key, unlike every other command here, because the key IS
       // the subject: the question a reader has is "what does enter do right
@@ -788,30 +769,15 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
       execute: () => {
         // Like the tool inspector, Work is temporary live-region chrome. It
         // disappears on close and never rewrites the transcript it covered.
-        let dismiss = (): void => {}
-        const overlay = createWorkOverlay({
+        openSurface(ctx.tuiSlots, close => createWorkOverlay({
           snapshot: () => work.snapshot(),
           interrupt: item => work.interrupt(item),
-          close: () => dismiss(),
+          close,
           invalidate: () => { ctx.tuiSlots.invalidate() },
-        })
-        dismiss = ctx.tuiSlots.pushOverlay(overlay)
+        }))
       },
     },
-    {
-      name: 'todos',
-      description: 'Inspect the current Harness todo list',
-      execute: () => {
-        // Opening a temporary terminal overlay is frontend-local, not a
-        // Harness-wide command or any Todo-domain mutation.
-        let dismiss = (): void => {}
-        const overlay = createTodoOverlay({
-          reading: () => todoReading(projections.snapshot()),
-          close: () => dismiss(),
-        })
-        dismiss = ctx.tuiSlots.pushOverlay(overlay)
-      },
-    },
+    todosPresenter.command,
     {
       name: 'setup',
       description: 'Check this installation and walk from a provider to a working model',
@@ -1791,15 +1757,14 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   const openHistorySearch = (): void => {
     completion.invalidate()
     const search = new HistorySearch(history)
-    let dismiss = (): void => {}
-    const overlay = createHistorySearchOverlay({
+    openSurface(ctx.tuiSlots, close => createHistorySearchOverlay({
       search,
       // A resume seeds history from the log the replay is already reading, so
       // `ctrl-r` during one has to say "still arriving" rather than "nothing here".
       loading: () => replaying !== undefined,
       invalidate: () => { ctx.tuiSlots.invalidate() },
       settle: index => {
-        dismiss()
+        close()
         // Who owns the buffer and the arrows next is the same question
         // `routeInputKey` answers per keystroke, so it is answered in the same
         // place: a recalled line owns the arrows until it is edited or
@@ -1810,8 +1775,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
         if (!reopen) return
         completion.refresh().then(draw).catch(report)
       },
-    })
-    dismiss = ctx.tuiSlots.pushOverlay(overlay)
+    }))
     draw()
   }
 
@@ -2007,8 +1971,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
           // `current` is the only mutable part: the overlay moves it through the
           // retained history, and every read below follows it.
           let current = inspectable
-          let dismiss = (): void => {}
-          const overlay = createToolOutputOverlay({
+          openSurface(ctx.tuiSlots, close => createToolOutputOverlay({
             title: 'Tool output',
             // A retained entry is either a completed result or a still-pending
             // call's own content (see `InspectableCard`): the label follows
@@ -2029,10 +1992,9 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
               current = newer
               return true
             },
-            close: () => dismiss(),
+            close,
             invalidate: () => { ctx.tuiSlots.invalidate() },
-          })
-          dismiss = ctx.tuiSlots.pushOverlay(overlay)
+          }))
           return
         }
         // Finished cards are in the terminal's own scrollback and are never

--- a/packages/dshline/src/cache/overlay.ts
+++ b/packages/dshline/src/cache/overlay.ts
@@ -21,27 +21,12 @@
  * @module dshline/cache/overlay
  */
 
-import type { Key } from '@dshline/renderer'
-import {
-  BOX_CHROME_COLUMNS,
-  displayWidth,
-  escapeControls,
-  formatTokens,
-  paint,
-  truncateToWidth,
-  wrapToWidth,
-} from '@dshline/renderer'
-import { chromeWidth, fitFooterHelp, footerBudget, rootFrame } from '../chrome.ts'
+import { escapeControls, formatTokens, paint, truncateToWidth, wrapToWidth } from '@dshline/renderer'
+import { createBoundedSurface } from '../surface.ts'
 import type { TuiOverlay } from '../slots.ts'
 import { formatCacheShare } from '../usage.ts'
 import type { CacheInspection, RequestHeaderReading, RouteContextReading } from './model.ts'
 import { hasCacheReads } from './model.ts'
-
-/** Rows outside the body: the leading blank and the two frame borders. */
-const CACHE_FIXED_ROWS = 3
-
-/** Minimum width whose framed report keeps one physical row per fact. */
-const CACHE_MIN_COLUMNS = BOX_CHROME_COLUMNS + 10
 
 /**
  * Widest label plus its gap, so every value starts in one column.
@@ -88,37 +73,13 @@ export interface CacheOverlaySpec {
  * @returns a live-region overlay that never writes the transcript.
  */
 export function createCacheOverlay(spec: CacheOverlaySpec): TuiOverlay {
-  let closed = false
-  const close = (): void => {
-    if (closed) return
-    closed = true
-    spec.close()
-  }
-  return {
-    render(columns, terminalRows = 24) {
-      const inspection = spec.inspection()
-      const fallback = (): string[] => compactFallback(inspection, columns, terminalRows)
-      if (terminalRows <= CACHE_FIXED_ROWS || columns < CACHE_MIN_COLUMNS) return fallback()
-      const width = chromeWidth(columns)
-      const inner = width - BOX_CHROME_COLUMNS
-      const candidate = [
-        '',
-        ...rootFrame({
-          columns,
-          context: paint('Cache', 'overlay-title'),
-          body: bodyRows(inspection, inner),
-          footer: fitFooterHelp('esc close', footerBudget(columns)),
-        }),
-      ]
-      // The frame wraps what it is given. Count the rows Screen will draw, so a
-      // too-tall report falls back instead of leaking one into scrollback.
-      return physicalRows(candidate, columns).length <= terminalRows ? candidate : fallback()
-    },
-    handleKey(key: Key) {
-      if (key.kind !== 'key') return
-      if (key.name === 'escape' || key.name === 'ctrl-c') close()
-    },
-  }
+  return createBoundedSurface<CacheInspection>({
+    reading: spec.inspection,
+    title: () => 'Cache',
+    body: (inspection, width) => bodyRows(inspection, width),
+    compact: inspection => compactSummary(inspection),
+    close: spec.close,
+  })
 }
 
 /**
@@ -273,28 +234,14 @@ function fact(label: string, value: string, width: number): string {
 }
 
 /**
- * Count the physical rows Screen will draw for a candidate live region.
- * @param lines - candidate logical lines.
- * @param columns - the terminal's width.
- * @returns the physical rows.
- */
-function physicalRows(lines: readonly string[], columns: number): string[] {
-  return lines.flatMap(candidate => wrapToWidth(candidate, Math.max(1, columns)))
-}
-
-/**
- * A closable answer for a terminal too small to hold the frame safely.
+ * The one-row truth about cache reads.
+ *
+ * A share is named only when Harness reported cache reads; otherwise the route's
+ * silence is reported as `unreported` rather than as a zero it never claimed.
  * @param inspection - the current reading.
- * @param columns - the terminal's width.
- * @param rows - the terminal's height.
- * @returns at most one row.
+ * @returns the summary phrase, without the shared close suffix.
  */
-function compactFallback(inspection: CacheInspection, columns: number, rows: number): string[] {
-  if (rows <= 0) return []
+function compactSummary(inspection: CacheInspection): string {
   const share = hasCacheReads(inspection) ? formatCacheShare(inspection.cacheReadShare) : undefined
-  const summary = `cache read ${share ?? 'unreported'} · esc close`
-  // One row carries a whole truthful phrase or none of it: a cut figure is
-  // worse than no figure, and the way out matters more than either.
-  const visible = [summary, 'esc close', 'esc'].find(candidate => displayWidth(candidate) <= columns)
-  return visible === undefined ? [] : [paint(visible, 'overlay-headline')]
+  return `cache read ${share ?? 'unreported'}`
 }

--- a/packages/dshline/src/cache/presenter.ts
+++ b/packages/dshline/src/cache/presenter.ts
@@ -1,0 +1,65 @@
+/**
+ * The `/cache` capability presenter.
+ *
+ * The report reads Harness's cumulative `tokenUsage` projection and the two
+ * latest recorded request accessors; it owns no state of its own and offers no
+ * mutation. This presenter owns the command, the surface, and the translation
+ * from those authorities to a terminal reading, so `attachSession` supplies
+ * only the session and the projection cut.
+ * @module dshline/cache/presenter
+ */
+
+import type { Session } from '@deepseek-ai/dsh-session'
+import type { ProjectionSnapshot } from '@deepseek-ai/dsh-session-projection'
+import type { LocalCommand } from '../local-commands.ts'
+import type { TuiSlots } from '../slots.ts'
+import { openSurface } from '../surface.ts'
+import { cacheInspection, requestHeaderReading, routeContextReading } from './model.ts'
+import { createCacheOverlay } from './overlay.ts'
+
+/** Narrow dependencies the Cache presenter needs from the session runner. */
+export interface CachePresenterDeps {
+  /** Live-region registry that owns the overlay stack. */
+  readonly slots: TuiSlots
+  /** The attached session whose recorded request head the report names. */
+  readonly session: Session
+  /**
+   * The authoritative projection cut, or undefined when the profile mounts no
+   * registry.
+   * @returns the current cut.
+   */
+  readonly snapshot: () => ProjectionSnapshot | undefined
+}
+
+/** The Cache capability as one local command. */
+export interface CachePresenter {
+  /** `/cache` — inspect how this session's prompt cache is behaving. */
+  readonly command: LocalCommand
+}
+
+/**
+ * Build the Cache presenter.
+ * @param deps - the slot registry, the session, and the projection cut reader.
+ * @returns the presenter's local command.
+ */
+export function createCachePresenter(deps: CachePresenterDeps): CachePresenter {
+  return {
+    command: {
+      name: 'cache',
+      description: "Inspect how this session's prompt cache is behaving",
+      execute: () => {
+        openSurface(deps.slots, close => createCacheOverlay({
+          // One projection cut per paint, the same one `/usage` reads, so the two
+          // inspectors cannot report different buckets for one moment. The two
+          // records beside it are Harness's own accessors, read the same way.
+          inspection: () => cacheInspection(
+            deps.snapshot(),
+            requestHeaderReading(deps.session),
+            routeContextReading(deps.session),
+          ),
+          close,
+        }))
+      },
+    },
+  }
+}

--- a/packages/dshline/src/context/overlay.ts
+++ b/packages/dshline/src/context/overlay.ts
@@ -21,7 +21,6 @@ import type { SessionSeq } from '@deepseek-ai/dsh-session'
 import type { Key, Role } from '@dshline/renderer'
 import {
   BOX_CHROME_COLUMNS,
-  displayWidth,
   escapeControls,
   formatTokens,
   paint,
@@ -30,10 +29,12 @@ import {
   truncateToWidth,
   wrapToWidth,
 } from '@dshline/renderer'
-import { chromeWidth, fitFooterHelp, footerBudget, rootFrame } from '../chrome.ts'
+import { chromeWidth } from '../chrome.ts'
 import { FocusRing } from '../focus.ts'
 import { RowViewport } from '../scroll.ts'
 import type { TuiOverlay } from '../slots.ts'
+import { compactRows, frameBounded, SurfaceNotice } from '../surface.ts'
+import type { SurfaceNoticeReading } from '../surface.ts'
 import { pressureBar, pressureStyle } from '../views.ts'
 import type { ContextEntry, ContextPreview, ContextReading, ContextSurvey } from './model.ts'
 
@@ -93,13 +94,6 @@ interface Row {
   readonly open?: Stage
 }
 
-/** A short outcome shown over the view without committing anything. */
-interface Notice {
-  readonly text: string
-  readonly failed: boolean
-  readonly expiresAt: number
-}
-
 /** Inputs the context inspector needs from its owner. */
 export interface ContextOverlaySpec {
   /** The cheap projection reading, read fresh on every paint. */
@@ -143,9 +137,9 @@ export interface ContextOverlaySpec {
 export function createContextOverlay(spec: ContextOverlaySpec): TuiOverlay {
   const viewport = new RowViewport()
   const focus = new FocusRing()
+  const notice = new SurfaceNotice(NOTICE_MS)
   let stage: Stage = { kind: 'overview' }
   let closed = false
-  let notice: Notice | undefined
   let compacting = false
   let ticker: NodeJS.Timeout | undefined
   let tick = 0
@@ -158,10 +152,6 @@ export function createContextOverlay(spec: ContextOverlaySpec): TuiOverlay {
     if (closed) return
     closed = true
     spec.close()
-  }
-  const currentNotice = (): Notice | undefined => {
-    if (notice !== undefined && Date.now() >= notice.expiresAt) notice = undefined
-    return notice
   }
   const build = (width: number, retarget: boolean): readonly Row[] => {
     const survey = spec.survey()
@@ -202,7 +192,7 @@ export function createContextOverlay(spec: ContextOverlaySpec): TuiOverlay {
     // Unref'd, so a running spinner never keeps the process alive on its own.
     ticker ??= setInterval(() => {
       tick += 1
-      if (!compacting && currentNotice() === undefined) {
+      if (!compacting && notice.read() === undefined) {
         stopTicker()
         return
       }
@@ -221,7 +211,7 @@ export function createContextOverlay(spec: ContextOverlaySpec): TuiOverlay {
     compact().then(problem => {
       compacting = false
       if (problem !== undefined) {
-        notice = { text: problem, failed: true, expiresAt: Date.now() + NOTICE_MS }
+        notice.show(problem, true)
       }
       spec.invalidate()
     }, () => {
@@ -235,13 +225,13 @@ export function createContextOverlay(spec: ContextOverlaySpec): TuiOverlay {
   return {
     dispose: stopTicker,
     render(columns, terminalRows = 24) {
-      const activeNotice = currentNotice()
+      const activeNotice = notice.read()
       const width = chromeWidth(columns)
       const inner = width - BOX_CHROME_COLUMNS
       const built = build(inner, true)
       const fallback = (): string[] => {
         fellBack = true
-        return compactFallback(
+        return compactBackstop(
           spec.reading(),
           spec.capacity(),
           columns,
@@ -262,25 +252,22 @@ export function createContextOverlay(spec: ContextOverlaySpec): TuiOverlay {
           if (focusedAt >= viewport.end) viewport.move(focusedAt - viewport.end + 1)
         }
       }
-      const candidate = [
-        '',
-        ...rootFrame({
-          columns,
-          context: paint(stage.kind === 'overview' ? 'Context' : 'Context entry', 'overlay-title'),
-          body: [
-            ...activeNotice === undefined ? [] : [paint(
-              truncateToWidth(escapeControls(activeNotice.text), inner),
-              activeNotice.failed ? 'error' : 'busy',
-            )],
-            ...built.slice(viewport.start, viewport.end).map(row => paintRow(row, focus.current)),
-          ],
-          footer: fitFooterHelp(help(stage, focusedRow(), spec.canCompact()), footerBudget(columns)),
-        }),
-      ]
+      const boundedNotice = notice.row(inner)
       // The frame wraps whatever it is given, including state text a caller may
-      // not have pre-fitted. Count the rows Screen will actually draw; a
-      // too-tall candidate falls back rather than leaking one into scrollback.
-      if (physicalRows(candidate, columns).length > terminalRows) return fallback()
+      // not have pre-fitted. `frameBounded` counts the physical rows Screen will
+      // actually draw; a too-tall candidate falls back rather than leaking one
+      // into scrollback.
+      const candidate = frameBounded({
+        columns,
+        rows: terminalRows,
+        title: stage.kind === 'overview' ? 'Context' : 'Context entry',
+        body: [
+          ...boundedNotice === undefined ? [] : [boundedNotice],
+          ...built.slice(viewport.start, viewport.end).map(row => paintRow(row, focus.current)),
+        ],
+        footer: help(stage, focusedRow(), spec.canCompact()),
+      })
+      if (candidate === undefined) return fallback()
       fellBack = false
       return candidate
     },
@@ -716,16 +703,6 @@ function help(stage: Stage, focused: Row | undefined, canCompact: boolean): stri
 }
 
 /**
- * Count the physical rows Screen will draw for a candidate live region.
- * @param lines - candidate logical lines.
- * @param columns - the terminal's width.
- * @returns the physical rows.
- */
-function physicalRows(lines: readonly string[], columns: number): string[] {
-  return lines.flatMap(candidate => wrapToWidth(candidate, Math.max(1, columns)))
-}
-
-/**
  * A closable answer for a terminal too small to hold the frame safely.
  * @param reading - the cheap projection reading.
  * @param routeCapacity - the selected route's advertised context window.
@@ -735,13 +712,13 @@ function physicalRows(lines: readonly string[], columns: number): string[] {
  * @param notice - a pending outcome, which takes precedence when it failed.
  * @returns at most one row.
  */
-function compactFallback(
+function compactBackstop(
   reading: ContextReading,
   routeCapacity: number | undefined,
   columns: number,
   rows: number,
   compacting: boolean,
-  notice?: Notice,
+  notice: SurfaceNoticeReading | undefined,
 ): string[] {
   if (rows <= 0) return []
   // A failed action survives the geometry fallback that protects scrollback:
@@ -752,30 +729,24 @@ function compactFallback(
   // The framed view puts this above the listing. Keep the same state visible in
   // the one-row backstop; otherwise resizing during a compaction makes it look
   // idle even though the command is still running.
-  const summary = compactSummary(reading, routeCapacity)
-  // One row must carry a whole truthful phrase. `esc cl` says neither what is
-  // on screen nor how to leave it.
-  const visible = [
-    ...(compacting ? ['compacting context · esc close'] : []),
-    summary,
-    'esc close',
-    'esc',
-  ].find(candidate => displayWidth(candidate) <= columns)
-  return visible === undefined ? [] : [paint(visible, 'overlay-headline')]
+  return compactRows([
+    ...compacting ? ['compacting context'] : [],
+    compactSummary(reading, routeCapacity),
+  ], columns)
 }
 
 /**
  * The one-row truth about current context.
  * @param reading - the cheap projection reading.
  * @param routeCapacity - the selected route's advertised context window.
- * @returns the summary phrase, including how to leave.
+ * @returns the summary phrase, without the shared close suffix.
  */
 function compactSummary(reading: ContextReading, routeCapacity: number | undefined): string {
-  if (!reading.projections) return 'Context unavailable · esc close'
-  if (!reading.metered) return 'Context unmetered · esc close'
+  if (!reading.projections) return 'Context unavailable'
+  if (!reading.metered) return 'Context unmetered'
   const occupancy = reading.occupancy
-  if (occupancy === undefined) return 'Context not yet measured · esc close'
+  if (occupancy === undefined) return 'Context not yet measured'
   const capacity = routeCapacity ?? occupancy.capacity
   const total = capacity === undefined ? '' : `/${formatTokens(capacity)}`
-  return `${formatTokens(occupancy.tokens)}${total} · esc close`
+  return `${formatTokens(occupancy.tokens)}${total}`
 }

--- a/packages/dshline/src/context/overlay.ts
+++ b/packages/dshline/src/context/overlay.ts
@@ -33,7 +33,7 @@ import { chromeWidth } from '../chrome.ts'
 import { FocusRing } from '../focus.ts'
 import { RowViewport } from '../scroll.ts'
 import type { TuiOverlay } from '../slots.ts'
-import { compactRows, frameBounded, SurfaceNotice } from '../surface.ts'
+import { compactRows, frameBounded, noticeRow, SurfaceNotice } from '../surface.ts'
 import type { SurfaceNoticeReading } from '../surface.ts'
 import { pressureBar, pressureStyle } from '../views.ts'
 import type { ContextEntry, ContextPreview, ContextReading, ContextSurvey } from './model.ts'
@@ -720,12 +720,12 @@ function compactBackstop(
   compacting: boolean,
   notice: SurfaceNoticeReading | undefined,
 ): string[] {
-  if (rows <= 0) return []
+  // A zero-row or zero-column frame has nowhere to put even one row.
+  if (rows <= 0 || columns <= 0) return []
   // A failed action survives the geometry fallback that protects scrollback:
   // clipping its detail beats making a refused compaction invisible.
-  if (notice?.failed === true) {
-    return [paint(truncateToWidth(escapeControls(notice.text), Math.max(1, columns)), 'error')]
-  }
+  const failed = notice?.failed === true ? noticeRow(notice, columns) : undefined
+  if (failed !== undefined) return [failed]
   // The framed view puts this above the listing. Keep the same state visible in
   // the one-row backstop; otherwise resizing during a compaction makes it look
   // idle even though the command is still running.

--- a/packages/dshline/src/context/presenter.ts
+++ b/packages/dshline/src/context/presenter.ts
@@ -1,0 +1,86 @@
+/**
+ * The `/context` capability presenter.
+ *
+ * The inspector is the hardest bounded surface dshline has: two stages, an
+ * expensive per-node survey asked for only while it is open, a scrollable
+ * listing with selection, and a temporary notice for a refused compaction. All
+ * of that state is presentation-local — the projection and the token meter stay
+ * the authorities — so it belongs to a presenter rather than to the session
+ * runner. `attachSession` supplies the session, the projection cut, and the
+ * registered `/compact` dispatch, and knows nothing else about the frame.
+ * @module dshline/context/presenter
+ */
+
+import type { Session } from '@deepseek-ai/dsh-session'
+import type { ProjectionSnapshot } from '@deepseek-ai/dsh-session-projection'
+import type { LocalCommand } from '../local-commands.ts'
+import type { TuiSlots } from '../slots.ts'
+import { openSurface } from '../surface.ts'
+import { contextPreview, contextReading } from './model.ts'
+import type { ContextSurvey } from './model.ts'
+import { createContextOverlay } from './overlay.ts'
+
+/** Narrow dependencies the Context presenter needs from the session runner. */
+export interface ContextPresenterDeps {
+  /** Live-region registry that owns the overlay stack. */
+  readonly slots: TuiSlots
+  /** The attached session whose surface is surveyed and previewed. */
+  readonly session: Session
+  /**
+   * The cheap projection cut, or undefined when the profile mounts no registry.
+   * @returns the current cut.
+   */
+  readonly snapshot: () => ProjectionSnapshot | undefined
+  /** Expensive per-node survey; the surveyor decides when to remeasure. */
+  readonly survey: () => ContextSurvey
+  /** The selected route's advertised context window. */
+  readonly capacity: () => number | undefined
+  /**
+   * Whether the running agent currently has a registered `/compact`.
+   *
+   * A live getter, not a snapshot: a scoped composition change while the
+   * overlay is open must not leave the footer advertising a command that no
+   * longer resolves.
+   * @returns whether the command is currently available.
+   */
+  readonly canCompact: () => boolean
+  /**
+   * Run the REGISTERED Harness `/compact` command.
+   * @returns a message when the request failed, else nothing.
+   */
+  readonly compact: () => Promise<string | undefined>
+  /** Redraw after a keystroke or a settled compaction. */
+  readonly invalidate: () => void
+}
+
+/** The Context capability as one local command. */
+export interface ContextPresenter {
+  /** `/context` — inspect what is occupying the model's context right now. */
+  readonly command: LocalCommand
+}
+
+/**
+ * Build the Context presenter.
+ * @param deps - readers, the optional compaction command, and overlay controls.
+ * @returns the presenter's local command.
+ */
+export function createContextPresenter(deps: ContextPresenterDeps): ContextPresenter {
+  return {
+    command: {
+      name: 'context',
+      description: "Inspect what is occupying the model's context right now",
+      execute: () => {
+        openSurface(deps.slots, close => createContextOverlay({
+          reading: () => contextReading(deps.snapshot()),
+          survey: deps.survey,
+          preview: seq => contextPreview(deps.session, seq),
+          capacity: deps.capacity,
+          canCompact: deps.canCompact,
+          compact: deps.compact,
+          close,
+          invalidate: deps.invalidate,
+        }))
+      },
+    },
+  }
+}

--- a/packages/dshline/src/surface.ts
+++ b/packages/dshline/src/surface.ts
@@ -1,0 +1,300 @@
+/**
+ * The bounded-surface kernel: the terminal mechanics every live-region
+ * inspector shares, kept apart from the capability it presents.
+ *
+ * An overlay owns feature state — what it is looking at, what a key means — and
+ * this module owns what makes that fit a terminal: the fixed chrome rows, the
+ * content width and capacity, the physical-row check against Screen's wrapping,
+ * the one-row backstop for a terminal too small to frame, an owned temporary
+ * notice, and the close handshake with `TuiSlots`.
+ *
+ * Before this module each of the seventeen bounded surfaces re-derived all of
+ * it, so a frame-geometry change had to be made in seventeen files and the
+ * notice lifetime had drifted to four values with no owner. Nothing here knows
+ * a domain: a surface reads a value and returns rows.
+ *
+ * This is internal presentation vocabulary, not a plugin SDK. It is deliberately
+ * not exported from the package entry, and a surface whose layout is not one of
+ * the shapes here stays free to keep its own `render` and use the helpers.
+ * @module dshline/surface
+ */
+
+import type { Key, Role } from '@dshline/renderer'
+import {
+  BOX_CHROME_COLUMNS,
+  displayWidth,
+  escapeControls,
+  paint,
+  truncateToWidth,
+  wrapToWidth,
+} from '@dshline/renderer'
+import { chromeWidth, fitFooterHelp, footerBudget, rootFrame } from './chrome.ts'
+import type { TuiOverlay } from './slots.ts'
+
+/** Rows outside a framed body: the leading blank and the two frame borders. */
+export const SURFACE_FIXED_ROWS = 3
+
+/** Narrowest terminal whose framed surface keeps one physical row per fact. */
+export const SURFACE_MIN_COLUMNS = BOX_CHROME_COLUMNS + 10
+
+/** The one role a geometry backstop is allowed to use, shared so it stays one decision. */
+const COMPACT_ROLE: Role = 'overlay-headline'
+
+/**
+ * Count the physical rows `Screen` draws for candidate logical lines.
+ *
+ * A logical row wider than the terminal is wrapped into several physical rows,
+ * and the live region must never exceed the screen — a row scrolled off cannot
+ * be climbed back to and erased. Every surface that budgets against height needs
+ * this same count, which is why it lives here rather than once per surface.
+ * @param lines - candidate logical lines.
+ * @param columns - the terminal's width.
+ * @returns one entry per physical row.
+ */
+export function physicalRows(lines: readonly string[], columns: number): string[] {
+  return lines.flatMap(line => wrapToWidth(line, Math.max(1, columns)))
+}
+
+/**
+ * The one-row backstop for a terminal too small to frame.
+ *
+ * Every candidate is a WHOLE truthful phrase. A cut phrase says something the
+ * reader cannot act on — `esc cl` names neither the state nor the way out — so
+ * the ladder tries the most specific summary first and falls back to the bare
+ * escape. An empty result is the honest answer when not even `esc` fits.
+ * @param phrases - summary phrases, most specific first; one phrase is common.
+ * @param columns - the terminal's width.
+ * @returns at most one painted row.
+ */
+export function compactRows(phrases: string | readonly string[], columns: number): string[] {
+  const ordered = typeof phrases === 'string' ? [phrases] : phrases
+  const visible = [
+    ...ordered.map(phrase => `${phrase} · esc close`),
+    'esc close',
+    'esc',
+  ].find(candidate => displayWidth(candidate) <= columns)
+  return visible === undefined ? [] : [paint(visible, COMPACT_ROLE)]
+}
+
+/** One active temporary outcome. */
+export interface SurfaceNoticeReading {
+  /** Untrusted message text; escaped when drawn. */
+  readonly text: string
+  /** Whether the outcome failed, which colours it and lets it win the geometry fallback. */
+  readonly failed: boolean
+}
+
+/**
+ * Draw one notice reading as a bounded row.
+ *
+ * Escaping happens before styling: a message can quote a path or a provider
+ * error, so it is untrusted text that must not add rows or operate the terminal.
+ * @param reading - the active reading, or undefined when there is none.
+ * @param columns - display columns available.
+ * @returns the painted row, or undefined while no notice is active.
+ */
+export function noticeRow(reading: SurfaceNoticeReading | undefined, columns: number): string | undefined {
+  if (reading === undefined) return undefined
+  return paint(
+    truncateToWidth(escapeControls(reading.text), Math.max(1, columns)),
+    reading.failed ? 'error' : 'busy',
+  )
+}
+
+/**
+ * A temporary outcome owned by exactly one surface.
+ *
+ * The lifetime is the surface's own choice rather than a shared constant: a
+ * refused compaction and a discovery failure are not the same event, and the
+ * copies of `NOTICE_MS` this replaced had already drifted to four values. An
+ * expired notice is retired by the next {@link SurfaceNotice.read}, so clearing
+ * one costs no timer.
+ */
+export class SurfaceNotice {
+  private state: { reading: SurfaceNoticeReading; expiresAt: number } | undefined
+
+  /**
+   * @param lifetimeMs - how long a shown notice stays readable.
+   */
+  constructor(private readonly lifetimeMs: number) {}
+
+  /**
+   * Replace any current notice with a new one, restarting its lifetime.
+   * @param text - untrusted message text.
+   * @param failed - whether the outcome failed.
+   */
+  show(text: string, failed = false): void {
+    this.state = { reading: { text, failed }, expiresAt: Date.now() + this.lifetimeMs }
+  }
+
+  /**
+   * Read the active notice, retiring it once its lifetime has passed.
+   * @param now - current wall-clock instant; injectable for tests.
+   * @returns the active reading, or undefined once retired.
+   */
+  read(now = Date.now()): SurfaceNoticeReading | undefined {
+    if (this.state !== undefined && now >= this.state.expiresAt) this.state = undefined
+    return this.state?.reading
+  }
+
+  /**
+   * One bounded row for the active notice.
+   * @param columns - display columns available.
+   * @returns the painted row, or undefined while no notice is active.
+   */
+  row(columns: number): string | undefined {
+    return noticeRow(this.read(), columns)
+  }
+}
+
+/** Inputs one framed bounded surface needs from its presenter. */
+export interface BoundedSurfaceSpec<S> {
+  /** The presenter's own state, read fresh on every paint. */
+  readonly reading: () => S
+  /** Right-hand frame label for the current reading. */
+  readonly title: (reading: S) => string
+  /**
+   * Body rows for a reading.
+   * @param reading - current state.
+   * @param width - display columns inside the frame.
+   * @param capacity - body rows the current geometry can show, excluding the
+   *   frame's fixed rows and an active notice.
+   */
+  readonly body: (reading: S, width: number, capacity: number) => readonly string[]
+  /** Whole-phrase backstop summaries, most specific first. */
+  readonly compact: (reading: S) => string | readonly string[]
+  /** Footer help; defaults to `esc close`. */
+  readonly footer?: (reading: S) => string
+  /** Optional temporary outcome, given its own reserved row while active. */
+  readonly notice?: SurfaceNotice
+  /**
+   * Feature keys, after the shared close handling. The surface owns the
+   * keyboard while it is mounted, so a key it does not close on is delivered
+   * here whether or not the presenter acts on it.
+   * @param key - the decoded keystroke.
+   * @param reading - the current reading.
+   */
+  readonly onKey?: (key: Key, reading: S) => void
+  /** Remove this temporary surface. */
+  readonly close: () => void
+  /** Release presenter-owned resources such as a heartbeat. */
+  readonly dispose?: () => void
+  /** Rows outside the body; defaults to {@link SURFACE_FIXED_ROWS}. */
+  readonly fixedRows?: number
+  /** Minimum terminal width; defaults to {@link SURFACE_MIN_COLUMNS}. */
+  readonly minColumns?: number
+}
+
+/**
+ * Frame one bounded body, or report that it does not fit.
+ *
+ * The frame wraps whatever it is given, so the physical candidate — not the
+ * logical row count — decides. A body that does not fit returns `undefined` and
+ * the caller substitutes its geometry backstop rather than leaking a row into
+ * scrollback.
+ * @param options - terminal geometry, frame title, body rows, and optional footer.
+ * @returns the framed rows, or undefined when they do not fit.
+ */
+export function frameBounded(options: {
+  readonly columns: number
+  readonly rows: number
+  readonly title: string
+  readonly body: readonly string[]
+  readonly footer?: string
+}): string[] | undefined {
+  const candidate = [
+    '',
+    ...rootFrame({
+      columns: options.columns,
+      context: paint(options.title, 'overlay-title'),
+      body: options.body,
+      footer: fitFooterHelp(options.footer ?? 'esc close', footerBudget(options.columns)),
+    }),
+  ]
+  return physicalRows(candidate, options.columns).length <= options.rows ? candidate : undefined
+}
+
+/**
+ * Create one framed bounded surface over a presenter's reading.
+ *
+ * The surface owns the close guard, the geometry, the shared escape keys, and
+ * the notice row; the presenter owns what the rows say and what its own keys
+ * mean. Escape and ctrl-c always close, and nothing else quits.
+ * @param spec - the presenter's reading, rows, keys, and close control.
+ * @returns a live-region overlay that never writes the transcript.
+ */
+export function createBoundedSurface<S>(spec: BoundedSurfaceSpec<S>): TuiOverlay {
+  const fixedRows = spec.fixedRows ?? SURFACE_FIXED_ROWS
+  const minColumns = spec.minColumns ?? SURFACE_MIN_COLUMNS
+  let closed = false
+  const close = (): void => {
+    if (closed) return
+    closed = true
+    spec.close()
+  }
+  const overlay: TuiOverlay = {
+    render(columns, terminalRows = 24) {
+      const reading = spec.reading()
+      const activeNotice = spec.notice?.read()
+      const width = chromeWidth(columns)
+      const inner = width - BOX_CHROME_COLUMNS
+      // Bound the notice to the frame's inner width, not the terminal's: a
+      // notice that wraps would spend a second row the capacity below has not
+      // budgeted, and the frame would fall back instead of showing it.
+      const boundedNotice = noticeRow(activeNotice, inner)
+      const capacity = terminalRows - fixedRows - (boundedNotice === undefined ? 0 : 1)
+      const fallback = (): string[] => {
+        // A zero-row live region is the one geometry that must draw nothing at
+        // all: even the `esc` backstop would be a row the caller cannot show.
+        if (terminalRows <= 0) return []
+        return activeNotice?.failed === true && boundedNotice !== undefined
+          ? [boundedNotice]
+          : compactRows(spec.compact(reading), columns)
+      }
+      if (terminalRows <= fixedRows || columns < minColumns || capacity <= 0) return fallback()
+      return frameBounded({
+        columns,
+        rows: terminalRows,
+        title: spec.title(reading),
+        body: [
+          ...boundedNotice === undefined ? [] : [boundedNotice],
+          ...spec.body(reading, inner, capacity),
+        ],
+        ...spec.footer === undefined ? {} : { footer: spec.footer(reading) },
+      }) ?? fallback()
+    },
+    handleKey(key: Key) {
+      if (closed) return
+      if (key.kind === 'key' && (key.name === 'escape' || key.name === 'ctrl-c')) {
+        close()
+        return
+      }
+      // Read only when a presenter actually wants the key: a reading can build
+      // rows, and a surface with no feature keys should not pay for one.
+      if (spec.onKey !== undefined) spec.onKey(key, spec.reading())
+    },
+  }
+  if (spec.dispose !== undefined) overlay.dispose = spec.dispose
+  return overlay
+}
+
+/**
+ * Open one overlay and return its dismisser.
+ *
+ * A surface closes itself by calling the callback it was handed, but the
+ * dismisser only exists after `pushOverlay` returns, so every call site used to
+ * forward-declare one and remember to assign it. Resolving that handshake here
+ * removes the same four lines from every opener.
+ * @param slots - the live-region registry that owns the overlay stack.
+ * @param create - builds the overlay, given the callback that closes it.
+ * @returns a function that removes the overlay; safe to call more than once.
+ */
+export function openSurface(
+  slots: { pushOverlay(overlay: TuiOverlay): () => void },
+  create: (close: () => void) => TuiOverlay,
+): () => void {
+  let dismiss: () => void = () => {}
+  const overlay = create(() => { dismiss() })
+  dismiss = slots.pushOverlay(overlay)
+  return () => { dismiss() }
+}

--- a/packages/dshline/src/surface.ts
+++ b/packages/dshline/src/surface.ts
@@ -68,11 +68,14 @@ export function physicalRows(lines: readonly string[], columns: number): string[
  */
 export function compactRows(phrases: string | readonly string[], columns: number): string[] {
   const ordered = typeof phrases === 'string' ? [phrases] : phrases
+  // Phrases are plain text from a presenter: the kernel escapes them before
+  // measuring and before styling, so an embedded control cannot add a row or
+  // operate the terminal, and the fit is measured against what is displayed.
   const visible = [
     ...ordered.map(phrase => `${phrase} · esc close`),
     'esc close',
     'esc',
-  ].find(candidate => displayWidth(candidate) <= columns)
+  ].map(escapeControls).find(candidate => displayWidth(candidate) <= columns)
   return visible === undefined ? [] : [paint(visible, COMPACT_ROLE)]
 }
 
@@ -91,12 +94,16 @@ export interface SurfaceNoticeReading {
  * error, so it is untrusted text that must not add rows or operate the terminal.
  * @param reading - the active reading, or undefined when there is none.
  * @param columns - display columns available.
- * @returns the painted row, or undefined while no notice is active.
+ * @returns the painted row, or undefined while no notice is active or when the
+ *   terminal has no columns to put it in.
  */
 export function noticeRow(reading: SurfaceNoticeReading | undefined, columns: number): string | undefined {
-  if (reading === undefined) return undefined
+  // A zero-column frame has nowhere to put a row: `truncateToWidth` would be
+  // asked to invent a column, and even an empty painted string emits an escape.
+  // Return nothing rather than a row the terminal cannot show.
+  if (reading === undefined || columns <= 0) return undefined
   return paint(
-    truncateToWidth(escapeControls(reading.text), Math.max(1, columns)),
+    truncateToWidth(escapeControls(reading.text), columns),
     reading.failed ? 'error' : 'busy',
   )
 }
@@ -106,9 +113,16 @@ export function noticeRow(reading: SurfaceNoticeReading | undefined, columns: nu
  *
  * The lifetime is the surface's own choice rather than a shared constant: a
  * refused compaction and a discovery failure are not the same event, and the
- * copies of `NOTICE_MS` this replaced had already drifted to four values. An
- * expired notice is retired by the next {@link SurfaceNotice.read}, so clearing
- * one costs no timer.
+ * copies of `NOTICE_MS` this replaced had already drifted to four values.
+ *
+ * Expiration is LAZY: an expired notice is retired by the next
+ * {@link SurfaceNotice.read}, so clearing one costs no timer. This type
+ * therefore does not schedule a redraw, and a surface that shows a notice owns
+ * invalidation: it redraws when {@link SurfaceNotice.show} is called and keeps
+ * redrawing until {@link SurfaceNotice.read} returns undefined, or the notice
+ * simply stays on screen until the next unrelated paint. Context does both
+ * through the ticker it already had; no second consumer needs timing today, so
+ * no scheduler lives here.
  */
 export class SurfaceNotice {
   private state: { reading: SurfaceNoticeReading; expiresAt: number } | undefined
@@ -165,7 +179,12 @@ export interface BoundedSurfaceSpec<S> {
   readonly compact: (reading: S) => string | readonly string[]
   /** Footer help; defaults to `esc close`. */
   readonly footer?: (reading: S) => string
-  /** Optional temporary outcome, given its own reserved row while active. */
+  /**
+   * Optional temporary outcome, given its own reserved row while active.
+   *
+   * The surface redraws only when its owner asks; see {@link SurfaceNotice} for
+   * who owns invalidation around expiry.
+   */
   readonly notice?: SurfaceNotice
   /**
    * Feature keys, after the shared close handling. The surface owns the
@@ -192,6 +211,10 @@ export interface BoundedSurfaceSpec<S> {
  * logical row count — decides. A body that does not fit returns `undefined` and
  * the caller substitutes its geometry backstop rather than leaking a row into
  * scrollback.
+ *
+ * The title and footer are PLAIN, untrusted text and the kernel escapes them
+ * before `paint`; passing already-styled text here would lose its colour. Body
+ * rows are the presenter's own terminal rows and must already be safe.
  * @param options - terminal geometry, frame title, body rows, and optional footer.
  * @returns the framed rows, or undefined when they do not fit.
  */
@@ -206,9 +229,9 @@ export function frameBounded(options: {
     '',
     ...rootFrame({
       columns: options.columns,
-      context: paint(options.title, 'overlay-title'),
+      context: paint(escapeControls(options.title), 'overlay-title'),
       body: options.body,
-      footer: fitFooterHelp(options.footer ?? 'esc close', footerBudget(options.columns)),
+      footer: fitFooterHelp(escapeControls(options.footer ?? 'esc close'), footerBudget(options.columns)),
     }),
   ]
   return physicalRows(candidate, options.columns).length <= options.rows ? candidate : undefined
@@ -244,12 +267,14 @@ export function createBoundedSurface<S>(spec: BoundedSurfaceSpec<S>): TuiOverlay
       const boundedNotice = noticeRow(activeNotice, inner)
       const capacity = terminalRows - fixedRows - (boundedNotice === undefined ? 0 : 1)
       const fallback = (): string[] => {
-        // A zero-row live region is the one geometry that must draw nothing at
-        // all: even the `esc` backstop would be a row the caller cannot show.
-        if (terminalRows <= 0) return []
-        return activeNotice?.failed === true && boundedNotice !== undefined
-          ? [boundedNotice]
-          : compactRows(spec.compact(reading), columns)
+        // A zero-row or zero-column live region must draw nothing at all: even
+        // the `esc` backstop would be a row the caller cannot show.
+        if (terminalRows <= 0 || columns <= 0) return []
+        // The backstop is bounded by the TERMINAL, not by the frame's inner
+        // width: on a terminal too narrow to frame, a failed notice still wins
+        // over the summary, but only within the columns that exist.
+        const failed = activeNotice?.failed === true ? noticeRow(activeNotice, columns) : undefined
+        return failed === undefined ? compactRows(spec.compact(reading), columns) : [failed]
       }
       if (terminalRows <= fixedRows || columns < minColumns || capacity <= 0) return fallback()
       return frameBounded({
@@ -282,9 +307,11 @@ export function createBoundedSurface<S>(spec: BoundedSurfaceSpec<S>): TuiOverlay
  * Open one overlay and return its dismisser.
  *
  * A surface closes itself by calling the callback it was handed, but the
- * dismisser only exists after `pushOverlay` returns, so every call site used to
- * forward-declare one and remember to assign it. Resolving that handshake here
- * removes the same four lines from every opener.
+ * dismisser only exists after `pushOverlay` returns, and `TuiSlots` calls the
+ * overlay's `mounted()` before that. A close requested from `create` or from
+ * `mounted()` therefore arrives before there is anything to call, so it is
+ * remembered and applied the moment mounting returns. Closing is idempotent:
+ * the first request removes the overlay once, and later ones are no-ops.
  * @param slots - the live-region registry that owns the overlay stack.
  * @param create - builds the overlay, given the callback that closes it.
  * @returns a function that removes the overlay; safe to call more than once.
@@ -293,8 +320,18 @@ export function openSurface(
   slots: { pushOverlay(overlay: TuiOverlay): () => void },
   create: (close: () => void) => TuiOverlay,
 ): () => void {
-  let dismiss: () => void = () => {}
-  const overlay = create(() => { dismiss() })
-  dismiss = slots.pushOverlay(overlay)
-  return () => { dismiss() }
+  let disposer: (() => void) | undefined
+  let closed = false
+  const close = (): void => {
+    if (closed) return
+    closed = true
+    disposer?.()
+  }
+  const overlay = create(close)
+  const remove = slots.pushOverlay(overlay)
+  // A close that arrived before this point already set `closed`, so the overlay
+  // must come down now instead of being remembered as the disposer.
+  if (closed) remove()
+  else disposer = remove
+  return close
 }

--- a/packages/dshline/src/todos/overlay.ts
+++ b/packages/dshline/src/todos/overlay.ts
@@ -1,23 +1,9 @@
 /** Bounded read-only terminal presentation of Harness Todo snapshots. */
 
-import type { Key } from '@dshline/renderer'
-import {
-  BOX_CHROME_COLUMNS,
-  displayWidth,
-  escapeControls,
-  paint,
-  truncateToWidth,
-  wrapToWidth,
-} from '@dshline/renderer'
-import { chromeWidth, fitFooterHelp, footerBudget, rootFrame } from '../chrome.ts'
+import { escapeControls, paint, truncateToWidth } from '@dshline/renderer'
+import { createBoundedSurface } from '../surface.ts'
 import type { TuiOverlay } from '../slots.ts'
 import type { TodoReading } from './model.ts'
-
-/** Leading blank and two frame borders outside normal Todo content. */
-const TODO_FIXED_ROWS = 3
-
-/** Smallest width whose framed Todo list can remain one physical row per item. */
-const TODO_MIN_COLUMNS = BOX_CHROME_COLUMNS + 10
 
 /** Inputs the read-only Todo overlay needs from the runner. */
 export interface TodoOverlaySpec {
@@ -33,43 +19,13 @@ export interface TodoOverlaySpec {
  * @returns a live-region overlay that never writes the transcript.
  */
 export function createTodoOverlay(spec: TodoOverlaySpec): TuiOverlay {
-  let closed = false
-  const close = (): void => {
-    if (closed) return
-    closed = true
-    spec.close()
-  }
-  return {
-    render(columns, terminalRows = 24) {
-      const reading = spec.reading()
-      if (terminalRows <= TODO_FIXED_ROWS || columns < TODO_MIN_COLUMNS) {
-        return compactFallback(reading, columns, terminalRows)
-      }
-      const width = chromeWidth(columns)
-      const inner = width - BOX_CHROME_COLUMNS
-      const capacity = terminalRows - TODO_FIXED_ROWS
-      if (capacity <= 0) return compactFallback(reading, columns, terminalRows)
-      const content = contentRows(reading, inner, capacity)
-      const frame = [
-        '',
-        ...rootFrame({
-          columns,
-          context: paint('Todos', 'overlay-title'),
-          body: content,
-          footer: fitFooterHelp('esc close', footerBudget(columns)),
-        }),
-      ]
-      // Frame labels and escape-safe text are still logical lines. Screen wraps
-      // those lines, so verify the physical candidate rather than assuming it fits.
-      return physicalRows(frame, columns).length <= terminalRows
-        ? frame
-        : compactFallback(reading, columns, terminalRows)
-    },
-    handleKey(key: Key) {
-      if (key.kind !== 'key') return
-      if (key.name === 'escape' || key.name === 'ctrl-c') close()
-    },
-  }
+  return createBoundedSurface<TodoReading>({
+    reading: spec.reading,
+    title: () => 'Todos',
+    body: (reading, width, capacity) => contentRows(reading, width, capacity),
+    compact: reading => compactSummary(reading),
+    close: spec.close,
+  })
 }
 
 /** Turn a small projection state into as many bounded one-row list entries as fit. */
@@ -111,35 +67,20 @@ function safeTodoContent(content: string): string {
   return escapeControls(content).replaceAll('\n', '^J')
 }
 
-/** Count the physical rows Screen will draw for a candidate live region. */
-function physicalRows(lines: readonly string[], columns: number): string[] {
-  return lines.flatMap(line => wrapToWidth(line, Math.max(1, columns)))
-}
-
-/** A closable answer for a terminal too small to safely draw the frame. */
-function compactFallback(reading: TodoReading, columns: number, rows: number): string[] {
-  if (rows <= 0) return []
-  const summary = compactSummary(reading)
-  // A compact fallback has one row, so it must choose a whole truthful phrase.
-  // Cutting `esc close` into `esc cl` says neither what happened nor how to leave.
-  const visible = [summary, 'esc close', 'esc'].find(candidate => displayWidth(candidate) <= columns)
-  return visible === undefined ? [] : [paint(visible, 'overlay-headline')]
-}
-
 /** Describe the current projection reading without exposing any model-authored text. */
 function compactSummary(reading: TodoReading): string {
   switch (reading.kind) {
     case 'projections-unavailable':
-      return 'Todos unavailable · esc close'
+      return 'Todos unavailable'
     case 'unregistered':
-      return 'Todo unavailable · esc close'
+      return 'Todo unavailable'
     case 'none':
-      return 'No active todos · esc close'
+      return 'No active todos'
     case 'empty':
-      return 'Todo list empty · esc close'
+      return 'Todo list empty'
     case 'list': {
       const completed = reading.items.filter(item => item.status === 'completed').length
-      return `Todos ${String(completed)}/${String(reading.items.length)} · esc close`
+      return `Todos ${String(completed)}/${String(reading.items.length)}`
     }
   }
 }

--- a/packages/dshline/src/todos/presenter.ts
+++ b/packages/dshline/src/todos/presenter.ts
@@ -1,0 +1,55 @@
+/**
+ * The `/todos` capability presenter.
+ *
+ * Opening a temporary terminal overlay is frontend-local, not a Harness-wide
+ * command and not a Todo-domain mutation, so this presenter owns the command,
+ * the surface, and the translation from the authoritative projection cut to a
+ * terminal reading. The Harness `todos` projection stays the state authority;
+ * `attachSession` supplies only the cut and the slot registry.
+ * @module dshline/todos/presenter
+ */
+
+import type { ProjectionSnapshot } from '@deepseek-ai/dsh-session-projection'
+import type { LocalCommand } from '../local-commands.ts'
+import type { TuiSlots } from '../slots.ts'
+import { openSurface } from '../surface.ts'
+import { todoReading } from './model.ts'
+import { createTodoOverlay } from './overlay.ts'
+
+/** Narrow dependencies the Todos presenter needs from the session runner. */
+export interface TodosPresenterDeps {
+  /** Live-region registry that owns the overlay stack. */
+  readonly slots: TuiSlots
+  /**
+   * The authoritative projection cut, or undefined when the profile mounts no
+   * registry.
+   * @returns the current cut.
+   */
+  readonly snapshot: () => ProjectionSnapshot | undefined
+}
+
+/** The Todos capability as one local command. */
+export interface TodosPresenter {
+  /** `/todos` — inspect the current Harness todo list. */
+  readonly command: LocalCommand
+}
+
+/**
+ * Build the Todos presenter.
+ * @param deps - the slot registry and the projection cut reader.
+ * @returns the presenter's local command.
+ */
+export function createTodosPresenter(deps: TodosPresenterDeps): TodosPresenter {
+  return {
+    command: {
+      name: 'todos',
+      description: 'Inspect the current Harness todo list',
+      execute: () => {
+        openSurface(deps.slots, close => createTodoOverlay({
+          reading: () => todoReading(deps.snapshot()),
+          close,
+        }))
+      },
+    },
+  }
+}

--- a/packages/dshline/tests/surface.spec.ts
+++ b/packages/dshline/tests/surface.spec.ts
@@ -10,11 +10,13 @@
  */
 
 import { describe, expect, it, vi } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
 import type { Key } from '@dshline/renderer'
-import { BOX_CHROME_COLUMNS, paint, Screen, stripAnsi, wrapToWidth } from '@dshline/renderer'
+import { BOX_CHROME_COLUMNS, displayWidth, paint, Screen, stripAnsi, wrapToWidth } from '@dshline/renderer'
 import { createEmulator } from '../../../tests/emulator.ts'
 import { chromeWidth } from '../src/chrome.ts'
-import type { TuiOverlay, TuiSlots } from '../src/slots.ts'
+import { TuiSlots } from '../src/slots.ts'
+import type { TuiOverlay } from '../src/slots.ts'
 import {
   compactRows,
   createBoundedSurface,
@@ -111,20 +113,54 @@ describe('createBoundedSurface', () => {
     expect(seen).toEqual({ width: chromeWidth(40) - BOX_CHROME_COLUMNS, capacity: 8 - SURFACE_FIXED_ROWS })
   })
 
-  it('never draws more physical rows than the live region was given', () => {
-    const surface = createBoundedSurface({
+  it('never draws beyond its row or display-column budget, including at zero columns', () => {
+    const notice = new SurfaceNotice(1_000)
+    const plain = createBoundedSurface({
       reading: () => ['one', 'two', 'three', 'four', 'five', 'six', 'seven'],
       title: () => 'Probe',
       body: (reading, width, capacity) => reading.slice(0, capacity).map(row => row.slice(0, width)),
       compact: () => 'Probe compact summary',
       close: () => {},
     })
-    for (const columns of [2, 6, 20, 40, 80, 132]) {
-      for (const rows of [0, 1, 2, 3, 4, 8, 24]) {
-        const lines = surface.render(columns, rows)
-        expect(physicalRows(lines, columns).length, `${String(columns)}x${String(rows)}`).toBeLessThanOrEqual(rows)
+    const withNotice = createBoundedSurface({
+      reading: () => ['one', 'two', 'three', 'four', 'five', 'six', 'seven'],
+      title: () => 'Probe',
+      body: (reading, width, capacity) => reading.slice(0, capacity).map(row => row.slice(0, width)),
+      compact: () => 'Probe compact summary',
+      notice,
+      close: () => {},
+    })
+    notice.show('a failed action message long enough to need truncating', true)
+    for (const surface of [plain, withNotice]) {
+      for (const columns of [0, 1, 2, 6, 20, 40, 80, 132]) {
+        for (const rows of [0, 1, 2, 3, 4, 8, 24]) {
+          const lines = surface.render(columns, rows)
+          const at = `${String(columns)}x${String(rows)}`
+          expect(physicalRows(lines, columns).length, `rows ${at}`).toBeLessThanOrEqual(rows)
+          for (const line of lines) {
+            expect(displayWidth(line), `columns ${at}`).toBeLessThanOrEqual(columns)
+          }
+        }
       }
     }
+  })
+
+  it('never invents a display column when the terminal has none', () => {
+    const notice = new SurfaceNotice(1_000)
+    notice.show('a refused compaction', true)
+    const surface = createBoundedSurface({
+      reading: () => 0,
+      title: () => 'Probe',
+      body: () => ['body'],
+      compact: () => 'Probe',
+      notice,
+      close: () => {},
+    })
+    expect(surface.render(0, 8)).toEqual([])
+    expect(surface.render(1, 8).every(line => displayWidth(line) <= 1)).toBe(true)
+    expect(noticeRow(notice.read(), 0)).toBeUndefined()
+    expect(notice.row(0)).toBeUndefined()
+    expect(noticeRow(notice.read(), 1)).toBeDefined()
   })
 
   it('degrades to one whole phrase on a terminal too small to frame', () => {
@@ -214,26 +250,52 @@ describe('createBoundedSurface', () => {
 })
 
 describe('openSurface', () => {
-  it('resolves the close handshake with the dismisser the registry returned', () => {
-    let dismissals = 0
-    const overlay: TuiOverlay = { render: () => [], handleKey: () => {} }
-    let captured: (() => void) | undefined
-    const dismiss = openSurface(
-      { pushOverlay: () => () => { dismissals += 1 } },
-      close => { captured = close; return overlay },
-    )
-    captured?.()
-    expect(dismissals).toBe(1)
+  it('applies a close requested before the disposer exists, and disposes exactly once', () => {
+    const slots = new TuiSlots(new Context())
+    const dispose = vi.fn()
+    const dismiss = openSurface(slots, close => {
+      // `pushOverlay` has not returned its disposer yet, which is exactly the
+      // window a synchronous close has to survive.
+      close()
+      return { render: () => ['pre-mount'], handleKey: () => {}, dispose }
+    })
+    expect(slots.activeOverlay).toBeUndefined()
+    expect(slots.compose(40, 8).lines).not.toContain('pre-mount')
+    expect(dispose).toHaveBeenCalledTimes(1)
     dismiss()
-    expect(dismissals).toBe(2)
+    dismiss()
+    expect(dispose).toHaveBeenCalledTimes(1)
   })
 
-  it('survives a surface that closes before it was mounted', () => {
-    const overlay: TuiOverlay = { render: () => [], handleKey: () => {} }
-    expect(() => openSurface(
-      { pushOverlay: () => () => {} },
-      close => { close(); return overlay },
-    )).not.toThrow()
+  it('applies a close requested from mounted(), which TuiSlots calls before returning', () => {
+    const slots = new TuiSlots(new Context())
+    const dispose = vi.fn()
+    openSurface(slots, close => ({
+      render: () => ['from-mounted'],
+      handleKey: () => {},
+      mounted: () => { close() },
+      dispose,
+    }))
+    expect(slots.activeOverlay).toBeUndefined()
+    expect(slots.compose(40, 8).lines).not.toContain('from-mounted')
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes a mounted surface once and ignores repeated dismissal', () => {
+    const slots = new TuiSlots(new Context())
+    const dispose = vi.fn()
+    const dismiss = openSurface(slots, () => ({
+      render: () => ['mounted'],
+      handleKey: () => {},
+      dispose,
+    }))
+    expect(slots.compose(40, 8).lines).toContain('mounted')
+    dismiss()
+    expect(slots.activeOverlay).toBeUndefined()
+    expect(slots.compose(40, 8).lines).not.toContain('mounted')
+    expect(dispose).toHaveBeenCalledTimes(1)
+    dismiss()
+    expect(dispose).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/dshline/tests/surface.spec.ts
+++ b/packages/dshline/tests/surface.spec.ts
@@ -1,0 +1,327 @@
+/**
+ * Tests for the bounded-surface kernel and the presenters built on it.
+ *
+ * The properties under test are the ones each surface used to re-derive: that a
+ * live region never exceeds the rows it was given, that a terminal too small to
+ * frame still says one whole thing, that a temporary notice is owned with an
+ * explicit lifetime and can win the geometry backstop, that close is idempotent
+ * and returns the keyboard, and that a presenter command mounts exactly one
+ * surface and dismisses it.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import type { Key } from '@dshline/renderer'
+import { BOX_CHROME_COLUMNS, paint, Screen, stripAnsi, wrapToWidth } from '@dshline/renderer'
+import { createEmulator } from '../../../tests/emulator.ts'
+import { chromeWidth } from '../src/chrome.ts'
+import type { TuiOverlay, TuiSlots } from '../src/slots.ts'
+import {
+  compactRows,
+  createBoundedSurface,
+  frameBounded,
+  noticeRow,
+  openSurface,
+  physicalRows,
+  SurfaceNotice,
+  SURFACE_FIXED_ROWS,
+} from '../src/surface.ts'
+import { createTodosPresenter } from '../src/todos/presenter.ts'
+import { createCachePresenter } from '../src/cache/presenter.ts'
+import { createContextPresenter } from '../src/context/presenter.ts'
+
+/** A live-region registry that records what a presenter mounts. */
+function recordingSlots(): { slots: TuiSlots; mounted: TuiOverlay[]; dismissals: () => number } {
+  const mounted: TuiOverlay[] = []
+  let dismissals = 0
+  const slots = {
+    pushOverlay(overlay: TuiOverlay) {
+      mounted.push(overlay)
+      return () => { dismissals += 1 }
+    },
+  } as unknown as TuiSlots
+  return { slots, mounted, dismissals: () => dismissals }
+}
+
+/** A one-key surface for key-routing tests. */
+function key(name: string): Key {
+  return { kind: 'key', name } as Key
+}
+
+describe('physicalRows', () => {
+  it('counts the rows Screen wraps and ignores escape sequences', () => {
+    expect(physicalRows(['abc', 'x'.repeat(10)], 4)).toHaveLength(4)
+    expect(physicalRows([paint('abc', 'error')], 3)).toHaveLength(1)
+  })
+})
+
+describe('compactRows', () => {
+  it('prefers the whole summary, then the whole way out, then nothing', () => {
+    expect(compactRows(['State'], 40).map(stripAnsi)).toEqual(['State · esc close'])
+    expect(compactRows(['A very long state'], 9).map(stripAnsi)).toEqual(['esc close'])
+    expect(compactRows(['A very long state'], 3).map(stripAnsi)).toEqual(['esc'])
+    expect(compactRows(['A very long state'], 2)).toEqual([])
+  })
+
+  it('tries the most specific phrase first', () => {
+    const narrow = compactRows(['compacting context', '12k/1M'], 22).map(stripAnsi)
+    expect(narrow).toEqual(['12k/1M · esc close'])
+  })
+})
+
+describe('SurfaceNotice', () => {
+  it('retires a notice once its own lifetime passes', () => {
+    const notice = new SurfaceNotice(1_000)
+    notice.show('failed to compact')
+    expect(notice.read()).toEqual({ text: 'failed to compact', failed: false })
+    expect(notice.read(Date.now() + 2_000)).toBeUndefined()
+    expect(notice.read()).toBeUndefined()
+  })
+
+  it('escapes untrusted text before styling it', () => {
+    const notice = new SurfaceNotice(1_000)
+    notice.show('a\u001b[2Jb', true)
+    const row = notice.row(40) ?? ''
+    expect(stripAnsi(row)).toContain('a^[[2Jb')
+    expect(noticeRow(undefined, 40)).toBeUndefined()
+  })
+})
+
+describe('frameBounded', () => {
+  it('frames content that fits and refuses content that does not', () => {
+    const fits = frameBounded({ columns: 60, rows: 6, title: 'Probe', body: ['one'] })
+    expect(fits?.map(stripAnsi).join('\n')).toContain('one')
+    expect(frameBounded({ columns: 60, rows: 3, title: 'Probe', body: ['one'] })).toBeUndefined()
+  })
+})
+
+describe('createBoundedSurface', () => {
+  it('hands the presenter the inner width and the capacity left after fixed rows', () => {
+    let seen: { width: number; capacity: number } | undefined
+    const surface = createBoundedSurface({
+      reading: () => ['a', 'b', 'c', 'd', 'e'] as const,
+      title: () => 'Probe',
+      body: (reading, width, capacity) => {
+        seen = { width, capacity }
+        return reading.slice(0, capacity)
+      },
+      compact: () => 'Probe',
+      close: () => {},
+    })
+    surface.render(40, 8)
+    expect(seen).toEqual({ width: chromeWidth(40) - BOX_CHROME_COLUMNS, capacity: 8 - SURFACE_FIXED_ROWS })
+  })
+
+  it('never draws more physical rows than the live region was given', () => {
+    const surface = createBoundedSurface({
+      reading: () => ['one', 'two', 'three', 'four', 'five', 'six', 'seven'],
+      title: () => 'Probe',
+      body: (reading, width, capacity) => reading.slice(0, capacity).map(row => row.slice(0, width)),
+      compact: () => 'Probe compact summary',
+      close: () => {},
+    })
+    for (const columns of [2, 6, 20, 40, 80, 132]) {
+      for (const rows of [0, 1, 2, 3, 4, 8, 24]) {
+        const lines = surface.render(columns, rows)
+        expect(physicalRows(lines, columns).length, `${String(columns)}x${String(rows)}`).toBeLessThanOrEqual(rows)
+      }
+    }
+  })
+
+  it('degrades to one whole phrase on a terminal too small to frame', () => {
+    const surface = createBoundedSurface({
+      reading: () => 0,
+      title: () => 'Probe',
+      body: () => ['body'],
+      compact: () => 'Probe state',
+      close: () => {},
+    })
+    expect(surface.render(80, 3).map(stripAnsi)).toEqual(['Probe state · esc close'])
+    expect(surface.render(8, 3).map(stripAnsi)).toEqual(['esc'])
+    expect(surface.render(2, 3)).toEqual([])
+    expect(surface.render(80, 0)).toEqual([])
+  })
+
+  it('reserves a row for an active notice and drops it once retired', () => {
+    const notice = new SurfaceNotice(1_000)
+    const surface = createBoundedSurface({
+      reading: () => 0,
+      title: () => 'Probe',
+      body: (_reading, _width, capacity) => Array.from({ length: capacity }, (_, index) => `row ${String(index)}`),
+      compact: () => 'Probe',
+      notice,
+      close: () => {},
+    })
+    const before = physicalRows(surface.render(60, 8), 60).length
+    notice.show('a problem')
+    const during = physicalRows(surface.render(60, 8), 60).length
+    expect(during).toBe(before)
+    expect(surface.render(60, 8).map(stripAnsi).join('\n')).toContain('a problem')
+  })
+
+  it('lets a failed notice win the geometry backstop', () => {
+    const notice = new SurfaceNotice(1_000)
+    notice.show('compaction refused', true)
+    const surface = createBoundedSurface({
+      reading: () => 0,
+      title: () => 'Probe',
+      body: () => ['body'],
+      compact: () => 'Probe state',
+      notice,
+      close: () => {},
+    })
+    const row = surface.render(60, 3).map(stripAnsi).join('\n')
+    expect(row).toContain('compaction refused')
+    expect(row).not.toContain('esc close')
+  })
+
+  it('closes once on escape or ctrl-c and still routes other keys', () => {
+    const onKey = vi.fn()
+    let closes = 0
+    const surface = createBoundedSurface({
+      reading: () => 0,
+      title: () => 'Probe',
+      body: () => [],
+      compact: () => 'Probe',
+      onKey,
+      close: () => { closes += 1 },
+    })
+    surface.handleKey(key('ctrl-d'))
+    surface.handleKey({ kind: 'text', text: 'x' })
+    expect(closes).toBe(0)
+    expect(onKey).toHaveBeenCalledTimes(2)
+    surface.handleKey(key('escape'))
+    expect(closes).toBe(1)
+    surface.handleKey(key('ctrl-c'))
+    expect(closes).toBe(1)
+    // No feature key reaches the presenter once the surface is closed.
+    surface.handleKey(key('enter'))
+    expect(onKey).toHaveBeenCalledTimes(2)
+  })
+
+  it('forwards dispose so a presenter-owned heartbeat is released', () => {
+    const dispose = vi.fn()
+    const surface = createBoundedSurface({
+      reading: () => 0,
+      title: () => 'Probe',
+      body: () => [],
+      compact: () => 'Probe',
+      close: () => {},
+      dispose,
+    })
+    surface.dispose?.()
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('openSurface', () => {
+  it('resolves the close handshake with the dismisser the registry returned', () => {
+    let dismissals = 0
+    const overlay: TuiOverlay = { render: () => [], handleKey: () => {} }
+    let captured: (() => void) | undefined
+    const dismiss = openSurface(
+      { pushOverlay: () => () => { dismissals += 1 } },
+      close => { captured = close; return overlay },
+    )
+    captured?.()
+    expect(dismissals).toBe(1)
+    dismiss()
+    expect(dismissals).toBe(2)
+  })
+
+  it('survives a surface that closes before it was mounted', () => {
+    const overlay: TuiOverlay = { render: () => [], handleKey: () => {} }
+    expect(() => openSurface(
+      { pushOverlay: () => () => {} },
+      close => { close(); return overlay },
+    )).not.toThrow()
+  })
+})
+
+describe('migrated capability presenters', () => {
+  it('mounts the Todo surface from the authoritative snapshot and dismisses it on close', () => {
+    const registry = recordingSlots()
+    const presenter = createTodosPresenter({
+      slots: registry.slots,
+      snapshot: () => ({
+        asOfSeq: -1,
+        values: { todos: [{ content: 'ship it', status: 'pending' }] },
+      }) as never,
+    })
+    expect(presenter.command.name).toBe('todos')
+    presenter.command.execute('')
+    expect(registry.mounted).toHaveLength(1)
+    expect(registry.mounted[0]?.render(60, 8).map(stripAnsi).join('\n')).toContain('○ ship it')
+    registry.mounted[0]?.handleKey(key('escape'))
+    expect(registry.dismissals()).toBe(1)
+    expect(registry.mounted).toHaveLength(1)
+  })
+
+  it('mounts the Cache surface without the runner building the reading', () => {
+    const registry = recordingSlots()
+    const presenter = createCachePresenter({
+      slots: registry.slots,
+      session: {} as never,
+      snapshot: () => undefined,
+    })
+    expect(presenter.command.name).toBe('cache')
+    presenter.command.execute('')
+    expect(registry.mounted).toHaveLength(1)
+    registry.mounted[0]?.handleKey(key('escape'))
+    expect(registry.dismissals()).toBe(1)
+  })
+
+  it('mounts the Context surface with its survey and compaction deps', () => {
+    const registry = recordingSlots()
+    const presenter = createContextPresenter({
+      slots: registry.slots,
+      session: {} as never,
+      snapshot: () => undefined,
+      survey: () => ({ available: false, surfaceTokens: 0, nodes: 0, entries: [] }),
+      capacity: () => undefined,
+      canCompact: () => false,
+      compact: () => Promise.resolve(undefined),
+      invalidate: () => {},
+    })
+    expect(presenter.command.name).toBe('context')
+    presenter.command.execute('')
+    expect(registry.mounted).toHaveLength(1)
+    expect(registry.mounted[0]?.render(60, 8).map(stripAnsi).join('\n')).toContain('Context')
+    registry.mounted[0]?.handleKey(key('escape'))
+    expect(registry.dismissals()).toBe(1)
+  })
+})
+
+describe('the bounded surface over committed scrollback', () => {
+  it('never rewrites finished transcript rows', async () => {
+    const emulator = createEmulator(60, 12)
+    const screen = new Screen(emulator.target)
+    screen.commit(['committed transcript row'])
+    const before = await emulator.scrollback()
+    const surface = createBoundedSurface({
+      reading: () => 0,
+      title: () => 'Probe',
+      body: () => ['live body'],
+      compact: () => 'Probe',
+      close: () => { screen.setLive(['composer', 'status']) },
+    })
+    screen.setLive(surface.render(60, 12))
+    surface.handleKey(key('escape'))
+    const after = await emulator.scrollback()
+    expect(after.filter(row => row.includes('committed transcript row')))
+      .toEqual(before.filter(row => row.includes('committed transcript row')))
+    expect(after.join('\n')).not.toContain('live body')
+    expect(after.join('\n')).not.toContain('Probe')
+  })
+
+  it('keeps a wrapped logical row inside the budget it was given', () => {
+    const surface = createBoundedSurface({
+      reading: () => '审查😀'.repeat(30),
+      title: () => 'Probe',
+      body: reading => [reading],
+      compact: () => 'Probe',
+      close: () => {},
+    })
+    const lines = surface.render(24, 6)
+    expect(lines.flatMap(line => wrapToWidth(line, 24)).length).toBeLessThanOrEqual(6)
+  })
+})


### PR DESCRIPTION
## What this changes, and why

Every bounded live-region surface in this frontend re-derived the same terminal mechanics: the fixed chrome rows, the inner width and capacity, the physical-row fit check against Screen's wrapping, the one-row whole-phrase backstop, an expiring notice, and the close handshake with `TuiSlots`. `physicalRows` had **seventeen** definitions, `compactFallback` **sixteen**, and the notice lifetime had drifted to **four different values** with no owner — so a frame-geometry change or a notice fix had to be made in every one of them.

This adds `packages/dshline/src/surface.ts`, the internal kernel those surfaces share. It owns terminal mechanics only: a surface supplies its reading, its rows, its compact phrases, and its keys.

- `createBoundedSurface` — the common framed document;
- `frameBounded` / `compactRows` / `SurfaceNotice` — helpers for a surface with its own stage machine;
- `openSurface` — resolves the dismiss handshake every opener forward-declared by hand.

Three capabilities move onto it as **capability presenters**, so `attachSession()` wires a narrow dependency set instead of assembling a surface:

| Capability | Shape exercised | Change |
|---|---|---|
| **todos** | simple bounded list | overlay rewritten on the factory; `todos/presenter.ts` owns the command |
| **cache** | bounded report | overlay rewritten; `cache/presenter.ts` now owns the reading construction (`cacheInspection` / `requestHeaderReading` / `routeContextReading` left `attachment.ts`) |
| **context** | async survey + list-detail + viewport/selection + notice | overlay adopts the kernel helpers and `SurfaceNotice`; `context/presenter.ts` owns the command |

Deletions: `physicalRows` 17 → 15 definitions, `compactFallback` 16 → 13, four dismiss handshakes removed from `attachment.ts` (`openSurface` now used at seven sites), and context's local `Notice` interface and inline expiry replaced by `SurfaceNotice`. `attachSession()` is ~39 lines shorter; the point is not the line count but that the three capabilities' readers, overlay assembly, and close handshake are no longer its business.

This is deliberately incremental — two smaller capabilities and one complex one, not a rewrite. The renderer is untouched and stays dependency-free.

### Review hardening (second commit)

An external review of the new kernel found three real defects, all fixed in `3eb86f6` and proven by deliberate-mistake checks:

1. **`openSurface` lost a close requested before it had the disposer.** `TuiSlots.pushOverlay` calls the overlay's `mounted()` before returning, so a `close()` from `create` or from `mounted()` ran against a no-op and the overlay stayed mounted. The handshake now remembers a pre-mount close and applies it the moment mounting returns; disposal still happens exactly once and repeated close stays harmless. Latent today — no current opener closes before mounting — but the helper's contract was wrong.
2. **`noticeRow` invented a column with `Math.max(1, columns)`,** so a failed notice could emit one display column on a zero-column terminal. It now returns nothing when there is no width, and the surface's backstop bounds the failed-notice row to the terminal rather than the frame's inner width. Context's geometry backstop had the same `Math.max(1, columns)` and now shares `noticeRow`.
3. **The kernel painted `compactRows` phrases and `frameBounded` titles/footers directly.** They are plain presenter text, so the kernel now escapes them before measuring and styling; the TSDoc states the contract unambiguously — title and footer are plain untrusted text, body rows are the presenter's already-safe rows.

`SurfaceNotice` expiration is now documented as lazy and caller-invalidated: it schedules no redraw, and context's existing ticker remains the only thing redrawing while a notice is active. No second consumer exists, so no scheduler was added.

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm test` pass
- [x] `pnpm security` passes — the dependency and workflow checks CI runs
- [x] `pnpm run verify-docs` passes — no bilingual pair is touched
- [x] A changeset is included, or nothing under `packages/` changed

`tsc -b` (build + typecheck) and the full suite were run locally; `node tools/lint-workflows.mjs` and `node tools/verify-translation-pairing.mjs` pass. The `pnpm audit` half of `pnpm security` is delegated to CI here: pnpm's dependency-status check aborts in this non-TTY environment and would force a full reinstall. This is an internal-only refactor with no user-visible behavior change, so per CONTRIBUTING.md no changeset is required.

## If this touches the terminal

- [x] Text is made safe **before** color is applied, never after
- [x] Every write goes through `Screen`; committed scrollback is not rewritten
- [x] Widths are measured in display columns, and every cut agrees with `displayWidth`
- [x] A new `ctrl` shortcut works in both the legacy and kitty keyboard formats
- [x] Checked at a narrow width, and after a resize

Terminal and OS this was run in: automated frame emulation only (`@xterm/headless`), across widths **0, 1, 2, 6, 20, 40, 80, 132** and row budgets **0–24**, asserting both the physical-row budget and the display-column budget for every row, including a case with an active failed notice. No manual terminal session for this change.

## If this presents a Harness capability

- [x] It reads a standard `ctx.*` surface, not a provider API or rendered output
- [x] It keeps no second database, state machine, or persistence format
- [x] A profile without the capability still starts; the view is unavailable rather than fatal
- [x] Any action it offers has the owning seam's lifecycle and authorization behind it

The presenters read the authoritative projection cut (`ctx.sessionProjections`), `Session.requestHeader()` / `requestContext()`, and the registered `/compact` dispatch; none of them folds or caches domain state.

## Verification

- `tsc -b` — clean.
- Full suite — **3310 passed, 22 skipped, 0 failed** (169/170 files; the one skip is the opt-in Codex e2e). Migrated specs unchanged and green: `todos` (14), `cache-inspector` (36), `context-overlay` (24), `context-frames` (3). Converted call sites green: `usage` (60), `usage-inspector` (45), `work` (43), `work-navigation` (16), `history-search` (28), `tool-output` (24).
- New `tests/surface.spec.ts` (22 tests): the row and display-column budget across widths 0–132 and rows 0–24, the whole-phrase backstop ladder, notice reservation/expiry/escaping and failed-notice precedence, the zero-column notice contract, idempotent close with no post-close key handling, `dispose` forwarding, three `openSurface` lifecycle tests against the **real** `TuiSlots` registry, all three presenters mounting and dismissing exactly one surface, and that a bounded surface never rewrites committed scrollback.
- Deliberate-mistake checks per CONTRIBUTING.md: restoring the old `openSurface` makes *applies a close requested before the disposer exists, and disposes exactly once* and *applies a close requested from mounted()* fail by name; restoring `Math.max(1, columns)` makes *never invents a display column when the terminal has none* fail by name.

One unrelated spec (`foreign-writes.spec.ts`) initially failed with `EPERM opening /dev/zero` under the workspace sandbox and passed with wider access, confirming it was environmental rather than a regression.
