### PR TITLE
fix(dshline): roll back overlays when mounted() throws

### DIFF
--- a/.changeset/roll-back-overlay-on-mount-failure.md
+++ b/.changeset/roll-back-overlay-on-mount-failure.md
@@ -1,0 +1,14 @@
+---
+'@dshline/dshline': patch
+---
+
+Roll back an overlay when its `mounted()` hook throws, so a failed mount no
+longer leaves the overlay owning the live region and input with no disposer
+returned to the caller.
+
+`TuiSlots.pushOverlay()` now removes the exact overlay by identity, disposes it
+once, and invalidates so the previous overlay or the composed slots are
+authoritative again before the mount failure propagates. If the rollback
+disposal also throws, both errors are carried in an `AggregateError`; the failed
+overlay is unregistered either way, and context teardown cannot dispose it a
+second time.

--- a/.changeset/roll-back-overlay-on-mount-failure.md
+++ b/.changeset/roll-back-overlay-on-mount-failure.md
@@ -2,15 +2,16 @@
 '@dshline/dshline': patch
 ---
 
-Roll back a failed overlay registration when its `mounted()` hook throws, so a
-failed mount no longer leaves the overlay owning the live region and input with
-no disposer returned to the caller.
+Roll back a failed overlay registration when its `mounted()` hook or the
+initial redraw it triggers throws, so a failed mount no longer leaves the
+overlay owning the live region and input with no disposer returned to the
+caller.
 
 `TuiSlots.pushOverlay()` now removes the exact overlay by identity, disposes it
 once, and invalidates so the remaining overlay stack or the composed slots are
-authoritative again before the mount failure propagates. The rollback covers
-only the registration `pushOverlay` makes: an overlay the hook pushes itself is
-a separate registration with its own lifecycle. If the rollback disposal or
+authoritative again before the failure propagates. The rollback covers only the
+registration `pushOverlay` makes: an overlay the hook pushes itself is a
+separate registration with its own lifecycle. If the rollback disposal or
 invalidation also throws, the failures are carried together in an
-`AggregateError` with the mount failure first; the failed overlay is
+`AggregateError` with the primary failure first; the failed overlay is
 unregistered either way, and context teardown cannot dispose it a second time.

--- a/.changeset/roll-back-overlay-on-mount-failure.md
+++ b/.changeset/roll-back-overlay-on-mount-failure.md
@@ -2,13 +2,15 @@
 '@dshline/dshline': patch
 ---
 
-Roll back an overlay when its `mounted()` hook throws, so a failed mount no
-longer leaves the overlay owning the live region and input with no disposer
-returned to the caller.
+Roll back a failed overlay registration when its `mounted()` hook throws, so a
+failed mount no longer leaves the overlay owning the live region and input with
+no disposer returned to the caller.
 
 `TuiSlots.pushOverlay()` now removes the exact overlay by identity, disposes it
-once, and invalidates so the previous overlay or the composed slots are
-authoritative again before the mount failure propagates. If the rollback
-disposal also throws, both errors are carried in an `AggregateError`; the failed
-overlay is unregistered either way, and context teardown cannot dispose it a
-second time.
+once, and invalidates so the remaining overlay stack or the composed slots are
+authoritative again before the mount failure propagates. The rollback covers
+only the registration `pushOverlay` makes: an overlay the hook pushes itself is
+a separate registration with its own lifecycle. If the rollback disposal or
+invalidation also throws, the failures are carried together in an
+`AggregateError` with the mount failure first; the failed overlay is
+unregistered either way, and context teardown cannot dispose it a second time.

--- a/packages/dshline/src/slots.ts
+++ b/packages/dshline/src/slots.ts
@@ -146,30 +146,34 @@ export class TuiSlots extends Service {
    * Mount an overlay on top of the stack, taking over rendering and input.
    *
    * The registration this call makes is transactional: a `mounted()` hook that
-   * throws removes this overlay again and disposes it once, so the failed
-   * overlay's registration is rolled back before the failure propagates. Side
-   * effects the hook performs on its own — pushing another overlay, for
-   * instance — are their own registrations and outside this contract. The
-   * overlay is removed by identity BEFORE its disposal runs, so a throwing
-   * disposer cannot leave it registered for teardown to dispose a second time.
+   * throws, or the initial redraw it requests, removes this overlay again and
+   * disposes it once, so the failed overlay's registration is rolled back
+   * before the failure propagates. Side effects the hook performs on its own —
+   * pushing another overlay, for instance — are their own registrations and
+   * outside this contract. The overlay is removed by identity BEFORE its
+   * disposal runs, so a throwing disposer cannot leave it registered for
+   * teardown to dispose a second time.
    * @param overlay - the overlay to mount.
    * @returns the disposer unmounting it; safe to call more than once.
-   * @throws the `mounted()` failure, or an `AggregateError` carrying it with
-   *   any rollback disposal or invalidation failure.
+   * @throws the `mounted()` or initial-invalidation failure, or an
+   *   `AggregateError` carrying it with any rollback disposal or invalidation
+   *   failure.
    */
   pushOverlay(overlay: TuiOverlay): () => void {
     this.overlays.push(overlay)
     try {
       overlay.mounted?.()
-    } catch (mountError: unknown) {
+      this.invalidate()
+    } catch (registrationError: unknown) {
       // Found by identity rather than popped: a `mounted()` hook may have
       // pushed another overlay before throwing, so this one is not assumed to
       // be the last entry. This matches the disposer below.
       const index = this.overlays.indexOf(overlay)
       if (index >= 0) this.overlays.splice(index, 1)
-      // Disposal and invalidation both run even when the other fails, and
-      // neither may displace the mount failure as the one reported first.
-      const failures: unknown[] = [mountError]
+      // Disposal and the rollback invalidation both run even when the other
+      // fails, and neither may displace the registration failure as the one
+      // reported first.
+      const failures: unknown[] = [registrationError]
       try {
         overlay.dispose?.()
       } catch (error: unknown) {
@@ -182,13 +186,12 @@ export class TuiSlots extends Service {
       } catch (error: unknown) {
         failures.push(error)
       }
-      if (failures.length === 1) throw mountError
+      if (failures.length === 1) throw registrationError
       // `SessionScope` rethrows only the first of several teardown failures,
       // but here that would hide a cleanup or redraw failure the rollback ran,
-      // so all are carried, in mount → disposal → invalidation order.
-      throw new AggregateError(failures, 'overlay mount failed, and its rollback also failed')
+      // so all are carried, in primary → disposal → rollback-invalidation order.
+      throw new AggregateError(failures, 'overlay registration failed, and its rollback also failed')
     }
-    this.invalidate()
     return () => {
       const index = this.overlays.indexOf(overlay)
       if (index < 0) return

--- a/packages/dshline/src/slots.ts
+++ b/packages/dshline/src/slots.ts
@@ -144,12 +144,48 @@ export class TuiSlots extends Service {
 
   /**
    * Mount an overlay on top of the stack, taking over rendering and input.
+   *
+   * Mounting is transactional: a `mounted()` that throws removes the overlay
+   * again and disposes it once, so the registry is left exactly as it was. The
+   * overlay is removed by identity BEFORE its disposal runs, so a throwing
+   * disposer cannot leave it registered for teardown to dispose a second time.
    * @param overlay - the overlay to mount.
    * @returns the disposer unmounting it; safe to call more than once.
+   * @throws the `mounted()` failure, or an `AggregateError` carrying it and the
+   *   rollback `dispose()` failure when both throw.
    */
   pushOverlay(overlay: TuiOverlay): () => void {
     this.overlays.push(overlay)
-    overlay.mounted?.()
+    try {
+      overlay.mounted?.()
+    } catch (mountError: unknown) {
+      // Found by identity rather than popped: a `mounted()` hook may have
+      // pushed another overlay before throwing, so this one is not assumed to
+      // be the last entry. This matches the disposer below.
+      const index = this.overlays.indexOf(overlay)
+      if (index >= 0) this.overlays.splice(index, 1)
+      let disposeError: unknown
+      let disposeFailed = false
+      try {
+        overlay.dispose?.()
+      } catch (error: unknown) {
+        disposeFailed = true
+        disposeError = error
+      }
+      // The rollback is complete before the failure propagates, so the runner
+      // redraws from the previous overlay or the composed slots.
+      this.invalidate()
+      if (disposeFailed) {
+        // `SessionScope` rethrows only the first of several teardown failures,
+        // which would hide a cleanup that a failed mount just ran. Both are
+        // carried instead; the mount error stays first as the primary one.
+        throw new AggregateError(
+          [mountError, disposeError],
+          'overlay mount failed, and its rollback disposal also failed',
+        )
+      }
+      throw mountError
+    }
     this.invalidate()
     return () => {
       const index = this.overlays.indexOf(overlay)

--- a/packages/dshline/src/slots.ts
+++ b/packages/dshline/src/slots.ts
@@ -145,14 +145,17 @@ export class TuiSlots extends Service {
   /**
    * Mount an overlay on top of the stack, taking over rendering and input.
    *
-   * Mounting is transactional: a `mounted()` that throws removes the overlay
-   * again and disposes it once, so the registry is left exactly as it was. The
+   * The registration this call makes is transactional: a `mounted()` hook that
+   * throws removes this overlay again and disposes it once, so the failed
+   * overlay's registration is rolled back before the failure propagates. Side
+   * effects the hook performs on its own — pushing another overlay, for
+   * instance — are their own registrations and outside this contract. The
    * overlay is removed by identity BEFORE its disposal runs, so a throwing
    * disposer cannot leave it registered for teardown to dispose a second time.
    * @param overlay - the overlay to mount.
    * @returns the disposer unmounting it; safe to call more than once.
-   * @throws the `mounted()` failure, or an `AggregateError` carrying it and the
-   *   rollback `dispose()` failure when both throw.
+   * @throws the `mounted()` failure, or an `AggregateError` carrying it with
+   *   any rollback disposal or invalidation failure.
    */
   pushOverlay(overlay: TuiOverlay): () => void {
     this.overlays.push(overlay)
@@ -164,27 +167,26 @@ export class TuiSlots extends Service {
       // be the last entry. This matches the disposer below.
       const index = this.overlays.indexOf(overlay)
       if (index >= 0) this.overlays.splice(index, 1)
-      let disposeError: unknown
-      let disposeFailed = false
+      // Disposal and invalidation both run even when the other fails, and
+      // neither may displace the mount failure as the one reported first.
+      const failures: unknown[] = [mountError]
       try {
         overlay.dispose?.()
       } catch (error: unknown) {
-        disposeFailed = true
-        disposeError = error
+        failures.push(error)
       }
-      // The rollback is complete before the failure propagates, so the runner
-      // redraws from the previous overlay or the composed slots.
-      this.invalidate()
-      if (disposeFailed) {
-        // `SessionScope` rethrows only the first of several teardown failures,
-        // which would hide a cleanup that a failed mount just ran. Both are
-        // carried instead; the mount error stays first as the primary one.
-        throw new AggregateError(
-          [mountError, disposeError],
-          'overlay mount failed, and its rollback disposal also failed',
-        )
+      // Invalidate after rollback so the remaining overlay stack or the
+      // composed slots are authoritative again.
+      try {
+        this.invalidate()
+      } catch (error: unknown) {
+        failures.push(error)
       }
-      throw mountError
+      if (failures.length === 1) throw mountError
+      // `SessionScope` rethrows only the first of several teardown failures,
+      // but here that would hide a cleanup or redraw failure the rollback ran,
+      // so all are carried, in mount → disposal → invalidation order.
+      throw new AggregateError(failures, 'overlay mount failed, and its rollback also failed')
     }
     this.invalidate()
     return () => {

--- a/packages/dshline/tests/slots.spec.ts
+++ b/packages/dshline/tests/slots.spec.ts
@@ -4,9 +4,11 @@
  * An overlay owns the whole live region and every keystroke while it is mounted,
  * so a mount that fails must not leave it registered: the caller has been told
  * the mount failed, and a half-mounted overlay would otherwise keep composing
- * rows and consuming input. These tests drive the real registry rather than a
- * fake, because the invariant is about what context teardown and later
- * composition see in the registry's own stack.
+ * rows and consuming input. The rollback covers only the registration
+ * `pushOverlay` itself makes; an overlay a hook pushes on its own is a separate
+ * registration with its own lifecycle. These tests drive the real registry
+ * rather than a fake, because the invariant is about what context teardown and
+ * later composition see in the registry's own stack.
  * @module dshline/tests/slots
  */
 
@@ -63,7 +65,7 @@ describe('TuiSlots.pushOverlay', () => {
     expect(baseDispose).not.toHaveBeenCalled()
   })
 
-  it('invalidates after rollback so the previous region is authoritative', () => {
+  it('invalidates after rollback so the remaining stack is authoritative', () => {
     const ctx = new Context()
     const slots = new TuiSlots(ctx)
     slots.pushOverlay(overlay({ render: () => ['base'] }))
@@ -103,6 +105,42 @@ describe('TuiSlots.pushOverlay', () => {
     expect(slots.compose(40, 8).lines).toEqual(['base'])
   })
 
+  it('rolls back only the failed overlay when mounted() pushes another first', async () => {
+    const ctx = new Context()
+    const slots = new TuiSlots(ctx)
+    const base = overlay({ render: () => ['base'] })
+    slots.pushOverlay(base)
+
+    const nestedDispose = vi.fn()
+    const nested = overlay({ render: () => ['nested'], dispose: nestedDispose })
+    const failedDispose = vi.fn()
+    let dismissNested: (() => void) | undefined
+    const failed = overlay({
+      render: () => ['failed'],
+      mounted: () => {
+        dismissNested = slots.pushOverlay(nested)
+        throw new Error('A failed')
+      },
+      dispose: failedDispose,
+    })
+
+    expect(() => slots.pushOverlay(failed)).toThrow('A failed')
+
+    // A naive `pop()` would have removed B and left A registered; the failed
+    // overlay is removed by identity instead.
+    expect(failedDispose).toHaveBeenCalledTimes(1)
+    expect(slots.activeOverlay).toBe(nested)
+    expect(slots.compose(40, 8).lines).toEqual(['nested'])
+
+    // B is a successful registration and keeps its own lifecycle.
+    dismissNested?.()
+    expect(slots.compose(40, 8).lines).toEqual(['base'])
+    expect(nestedDispose).toHaveBeenCalledTimes(1)
+
+    await ctx.fiber.dispose()
+    expect(failedDispose).toHaveBeenCalledTimes(1)
+  })
+
   it('surfaces both failures and still unregisters when rollback dispose throws', () => {
     const slots = new TuiSlots(new Context())
     const mountFailure = new Error('mount failed')
@@ -121,5 +159,29 @@ describe('TuiSlots.pushOverlay', () => {
     expect((thrown as AggregateError).errors).toEqual([mountFailure, disposeFailure])
     expect(slots.activeOverlay).toBeUndefined()
     expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces an invalidation failure without masking the earlier rollback failures', () => {
+    const ctx = new Context()
+    const slots = new TuiSlots(ctx)
+    const mountFailure = new Error('mount failed')
+    const disposeFailure = new Error('dispose failed')
+    const invalidateFailure = new Error('redraw failed')
+    ctx.on('tui/render', () => { throw invalidateFailure })
+    const bad = overlay({
+      mounted: () => { throw mountFailure },
+      dispose: () => { throw disposeFailure },
+    })
+
+    let thrown: unknown
+    try {
+      slots.pushOverlay(bad)
+    } catch (error: unknown) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError)
+    expect((thrown as AggregateError).errors).toEqual([mountFailure, disposeFailure, invalidateFailure])
+    expect(slots.activeOverlay).toBeUndefined()
   })
 })

--- a/packages/dshline/tests/slots.spec.ts
+++ b/packages/dshline/tests/slots.spec.ts
@@ -161,7 +161,7 @@ describe('TuiSlots.pushOverlay', () => {
     expect(dispose).toHaveBeenCalledTimes(1)
   })
 
-  it('surfaces an invalidation failure without masking the earlier rollback failures', () => {
+  it('surfaces a rollback invalidation failure without masking the earlier failures', () => {
     const ctx = new Context()
     const slots = new TuiSlots(ctx)
     const mountFailure = new Error('mount failed')
@@ -182,6 +182,55 @@ describe('TuiSlots.pushOverlay', () => {
 
     expect(thrown).toBeInstanceOf(AggregateError)
     expect((thrown as AggregateError).errors).toEqual([mountFailure, disposeFailure, invalidateFailure])
+    expect(slots.activeOverlay).toBeUndefined()
+  })
+
+  it('rolls back the registration when the initial redraw throws before the disposer exists', async () => {
+    const ctx = new Context()
+    const slots = new TuiSlots(ctx)
+    const invalidateFailure = new Error('redraw failed')
+    let renders = 0
+    ctx.on('tui/render', () => {
+      renders += 1
+      // Only the initial registration redraw fails; the rollback redraw is the
+      // listener's second call and must still run.
+      if (renders === 1) throw invalidateFailure
+    })
+    const dispose = vi.fn()
+    const view = overlay({ render: () => ['mounted'], dispose })
+
+    expect(() => slots.pushOverlay(view)).toThrow(invalidateFailure)
+    expect(slots.activeOverlay).toBeUndefined()
+    expect(slots.compose(40, 8).lines).not.toContain('mounted')
+    expect(dispose).toHaveBeenCalledTimes(1)
+
+    await ctx.fiber.dispose()
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(renders).toBe(2)
+  })
+
+  it('orders initial-invalidation, disposal, and rollback-invalidation failures', () => {
+    const ctx = new Context()
+    const slots = new TuiSlots(ctx)
+    const initialFailure = new Error('initial redraw failed')
+    const disposeFailure = new Error('dispose failed')
+    const rollbackFailure = new Error('rollback redraw failed')
+    let renders = 0
+    ctx.on('tui/render', () => {
+      renders += 1
+      throw renders === 1 ? initialFailure : rollbackFailure
+    })
+    const bad = overlay({ dispose: () => { throw disposeFailure } })
+
+    let thrown: unknown
+    try {
+      slots.pushOverlay(bad)
+    } catch (error: unknown) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError)
+    expect((thrown as AggregateError).errors).toEqual([initialFailure, disposeFailure, rollbackFailure])
     expect(slots.activeOverlay).toBeUndefined()
   })
 })

--- a/packages/dshline/tests/slots.spec.ts
+++ b/packages/dshline/tests/slots.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * `TuiSlots.pushOverlay` is transactional.
+ *
+ * An overlay owns the whole live region and every keystroke while it is mounted,
+ * so a mount that fails must not leave it registered: the caller has been told
+ * the mount failed, and a half-mounted overlay would otherwise keep composing
+ * rows and consuming input. These tests drive the real registry rather than a
+ * fake, because the invariant is about what context teardown and later
+ * composition see in the registry's own stack.
+ * @module dshline/tests/slots
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import { TuiSlots } from '../src/slots.ts'
+import type { TuiOverlay } from '../src/slots.ts'
+
+/** An overlay that draws one row and answers no keys. */
+function overlay(overrides: Partial<TuiOverlay> = {}): TuiOverlay {
+  return { render: () => ['overlay'], handleKey: () => {}, ...overrides }
+}
+
+describe('TuiSlots.pushOverlay', () => {
+  it('mounts, composes, and disposes a normal overlay exactly once', () => {
+    const slots = new TuiSlots(new Context())
+    const dispose = vi.fn()
+    const view = overlay({ render: () => ['normal'], dispose })
+    const dismiss = slots.pushOverlay(view)
+
+    expect(slots.activeOverlay).toBe(view)
+    expect(slots.compose(40, 8).lines).toEqual(['normal'])
+
+    dismiss()
+    expect(slots.activeOverlay).toBeUndefined()
+    expect(dispose).toHaveBeenCalledTimes(1)
+    dismiss()
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes and disposes an overlay whose mounted() throws', () => {
+    const slots = new TuiSlots(new Context())
+    const failure = new Error('mount failed')
+    const dispose = vi.fn()
+    const bad = overlay({ render: () => ['bad'], mounted: () => { throw failure }, dispose })
+
+    expect(() => slots.pushOverlay(bad)).toThrow(failure)
+    expect(slots.activeOverlay).toBeUndefined()
+    expect(slots.compose(40, 8).lines).not.toContain('bad')
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the previous overlay active when a later mount fails', () => {
+    const slots = new TuiSlots(new Context())
+    const baseDispose = vi.fn()
+    const base = overlay({ render: () => ['base'], dispose: baseDispose })
+    slots.pushOverlay(base)
+
+    expect(() => slots.pushOverlay(overlay({ render: () => ['bad'], mounted: () => { throw new Error('nope') } })))
+      .toThrow('nope')
+
+    expect(slots.activeOverlay).toBe(base)
+    expect(slots.compose(40, 8).lines).toEqual(['base'])
+    expect(baseDispose).not.toHaveBeenCalled()
+  })
+
+  it('invalidates after rollback so the previous region is authoritative', () => {
+    const ctx = new Context()
+    const slots = new TuiSlots(ctx)
+    slots.pushOverlay(overlay({ render: () => ['base'] }))
+    const renders = vi.fn()
+    ctx.on('tui/render', renders)
+
+    expect(() => slots.pushOverlay(overlay({ mounted: () => { throw new Error('x') } }))).toThrow('x')
+    expect(renders).toHaveBeenCalled()
+  })
+
+  it('does not dispose the failed overlay again at context teardown', async () => {
+    const ctx = new Context()
+    const slots = new TuiSlots(ctx)
+    const dispose = vi.fn()
+    const bad = overlay({ mounted: () => { throw new Error('boom') }, dispose })
+
+    expect(() => slots.pushOverlay(bad)).toThrow('boom')
+    expect(dispose).toHaveBeenCalledTimes(1)
+
+    await ctx.fiber.dispose()
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(slots.activeOverlay).toBeUndefined()
+  })
+
+  it('still composes the restored stack after a failed mount', () => {
+    const slots = new TuiSlots(new Context())
+    slots.pushOverlay(overlay({ render: () => ['base'] }))
+    expect(() => slots.pushOverlay(overlay({ mounted: () => { throw new Error('x') } }))).toThrow('x')
+
+    // A later overlay mounts on top of the restored stack...
+    const next = overlay({ render: () => ['next'] })
+    const dismiss = slots.pushOverlay(next)
+    expect(slots.compose(40, 8).lines).toEqual(['next'])
+
+    // ...and taking it down restores the original rather than the failed one.
+    dismiss()
+    expect(slots.compose(40, 8).lines).toEqual(['base'])
+  })
+
+  it('surfaces both failures and still unregisters when rollback dispose throws', () => {
+    const slots = new TuiSlots(new Context())
+    const mountFailure = new Error('mount failed')
+    const disposeFailure = new Error('dispose failed')
+    const dispose = vi.fn(() => { throw disposeFailure })
+    const bad = overlay({ mounted: () => { throw mountFailure }, dispose })
+
+    let thrown: unknown
+    try {
+      slots.pushOverlay(bad)
+    } catch (error: unknown) {
+      thrown = error
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError)
+    expect((thrown as AggregateError).errors).toEqual([mountFailure, disposeFailure])
+    expect(slots.activeOverlay).toBeUndefined()
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Problem

`TuiSlots.pushOverlay()` pushed the overlay, called `mounted()`, and only then returned the disposer. If `mounted()` threw — or, one statement later, if the initial `invalidate()` threw — the overlay stayed in the registry while the caller received no disposer: a half-mounted overlay that still owned the whole live region and every keystroke, and was unreachable from outside because only the top overlay renders and receives keys. Cordis `emit()` runs listeners synchronously, so the initial redraw is a real failure point.

## Fix

**The registration `pushOverlay` makes is transactional across insert, `mounted()`, and the initial `invalidate()`.** When any of those throws:

- the exact overlay is removed from `this.overlays` **by identity** (not by popping — the hook may have pushed another overlay before throwing), matching the existing disposer's lookup;
- `overlay.dispose?.()` runs exactly once for partially initialized resources;
- the overlay is removed **before** disposal runs, so a throwing disposer cannot leave it for context teardown to dispose a second time;
- `invalidate()` runs again so the remaining overlay stack / composed slots are authoritative again;
- the primary failure is propagated, not converted into a successful mount.

Side effects a `mounted()` hook performs on its own — pushing another overlay, for instance — are separate registrations and are **not** rolled back. Only the overlay `pushOverlay` was given is removed.

`openSurface()` needs no change: it already propagates the failure and now observes the registry restored.

## Failure ordering

Disposal and the rollback invalidation both run even if the other throws, and failures are collected in order: **primary (mounted or initial invalidation) → rollback disposal → rollback invalidation**. The primary failure is thrown directly when it is the only failure; otherwise all failures are carried in an `AggregateError` with the primary failure first. No failures are deduplicated: the same `tui/render` listener throwing during both the initial and rollback invalidations is two legitimate failures.

This stays native to Cordis: `emit()` is synchronous and its listener exceptions propagate; `TuiSlots` only reacts to that by rolling back the registration it owns. No event bus, error boundary, emit wrapper, or extra lifecycle state is introduced.

## Tests

`packages/dshline/tests/slots.spec.ts` (11 tests) against the real `TuiSlots` registry:

- normal `pushOverlay()` behavior unchanged and disposal exactly-once;
- a throwing `mounted()` is absent afterward and disposed once;
- previous overlay remains active and composing;
- rollback invalidates;
- teardown does not dispose the failed overlay again;
- restored stack still composes; a later overlay mounts and unmounts;
- nested mount: A pushes B then throws; A removed/disposed once, B stays active, dismissing B restores base;
- rollback disposal throwing preserves both errors;
- rollback invalidation throwing preserves mount → disposal → rollback-invalidation;
- **initial redraw throwing rolls back the registration before the disposer exists** (absent, disposed once, not disposed again at teardown);
- **initial-invalidation → disposal → rollback-invalidation ordering** in one `AggregateError`.

## Verification

- `pnpm build` / `tsc -b` clean.
- Full suite: **3321 passed, 22 skipped**.
- `pnpm verify-docs`, `pnpm lint:workflows`, `tools/harness-target.mjs` clean.
- Deliberate-mistake check: moving the initial `invalidate()` back outside the `try` makes exactly the two new tests fail for the intended reasons (overlay left registered; raw failure instead of `AggregateError`); restored and re-verified.
- Changeset added (patch).
