### PR TITLE
test(dshline): split live-region bounds matrix into deterministic cases

### DIFF
--- a/packages/dshline/tests/live-region-bounds.spec.ts
+++ b/packages/dshline/tests/live-region-bounds.spec.ts
@@ -50,13 +50,20 @@ const WIDTHS: readonly number[] = [
 /** Terminal heights from a cramped pane to a tall window. */
 const HEIGHTS = [10, 12, 14, 16, 20, 24, 30, 40, 50] as const
 
-/** Composer contents that exercise the empty, one-row, tall and completing frames. */
+/**
+ * Composer contents that exercise the empty, one-row, tall and completing frames.
+ *
+ * Each carries a stable label rather than being a bare string because the
+ * property below is split by presentation state: a failure has to name the state
+ * that broke, and the long-line fixture is two thousand characters of `x` that
+ * would be unreadable in a test name.
+ */
 const CONTENTS = [
-  '',
-  'short',
-  Array.from({ length: 30 }, (_, index) => `line ${String(index)}`).join('\n'),
-  'x'.repeat(2000),
-  '/com',
+  { name: 'empty', value: '' },
+  { name: 'short', value: 'short' },
+  { name: 'multiline', value: Array.from({ length: 30 }, (_, index) => `line ${String(index)}`).join('\n') },
+  { name: 'long-line', value: 'x'.repeat(2000) },
+  { name: 'completion', value: '/com' },
 ] as const
 
 /** What the runner spends its rows on beneath the composer. */
@@ -218,27 +225,33 @@ function violations(ctx: Context, columns: number, rows: number, where: string):
 }
 
 describe('the composed live region', () => {
-  it('draws no row wider than the terminal, and no more rows than it has', async () => {
-    const timer = measuredTurn()
-    const stream = new StreamBuffer()
-    const failures: string[] = []
-    for (const content of CONTENTS) {
+  // One case per presentation state, and the whole width x height matrix inside
+  // each. The invariant is about combination — a view that fits alone can still
+  // be the one that pushes the region over — so the geometry cross stays
+  // exhaustive; what is split out is the state, so no case depends on enough CPU
+  // to approach the generic test timeout and a failure names what varied.
+  for (const content of CONTENTS) {
+    describe(`${content.name} content`, () => {
       for (const streaming of [false, true]) {
-        stream.reset()
-        // An unfinished line long enough to fill the stream region's own bound.
-        if (streaming) stream.push('text', 'y'.repeat(600), 80)
         for (const timing of [false, true]) {
-          const ctx = await window(content, timer, () => timing, stream)
-          for (const rows of HEIGHTS) {
-            for (const columns of WIDTHS) {
-              failures.push(...violations(ctx, columns, rows, `content=${JSON.stringify(content.slice(0, 6))} stream=${String(streaming)} timing=${String(timing)}`))
+          it(`draws no row wider than the terminal and no more rows than it has · streaming ${streaming ? 'on' : 'off'}, timing ${timing ? 'on' : 'off'}`, async () => {
+            const timer = measuredTurn()
+            const stream = new StreamBuffer()
+            // An unfinished line long enough to fill the stream region's own bound.
+            if (streaming) stream.push('text', 'y'.repeat(600), 80)
+            const ctx = await window(content.value, timer, () => timing, stream)
+            const failures: string[] = []
+            for (const rows of HEIGHTS) {
+              for (const columns of WIDTHS) {
+                failures.push(...violations(ctx, columns, rows, `${content.name} streaming=${String(streaming)} timing=${String(timing)}`))
+              }
             }
-          }
+            expect(failures.slice(0, 12), `${String(failures.length)} violations`).toEqual([])
+          })
         }
       }
-    }
-    expect(failures.slice(0, 12), `${String(failures.length)} violations`).toEqual([])
-  })
+    })
+  }
 })
 
 describe('below the shared chrome floor', () => {


### PR DESCRIPTION
## What this changes, and why

`packages/dshline/tests/live-region-bounds.spec.ts` ran its entire matrix — 5 contents × 2 streaming states × 2 timing states × 24 widths × 9 heights = 4,320 full `TuiSlots.compose()` calls — inside one `it(...)`. That made a single correctness test as long as the whole render pipeline it exercises, and it has historically run within a few hundred milliseconds of Vitest's default 5 s timeout; a slower GitHub-hosted runner timed out Node 24 and Node 26 on a commit that passed on rerun.

The timeout was acting as an accidental performance assertion for what is really a correctness/property test. This splits it into one case per presentation state (`content × streaming × timing` = 20 cases) and keeps the complete `WIDTHS × HEIGHTS` cross inside each case. Coverage is identical; per-case wall time is now ~40–120 ms locally, and a failure names the state that broke.

No production code, Vitest config, worker count, global timeout, or renderer output is touched.

## Coverage

For every one of the 20 `content × streaming × timing` states, the test still iterates all 24 widths (`1…12`, `13, 14, 16, 20, 24, 30, 40, 60, 80, 100, 120, 200`) × all 9 heights (`10, 12, 14, 16, 20, 24, 30, 40, 50`), and runs the unchanged `violations()` checks (`displayWidth` row bound, `wrapToWidth` physical-row bound, cursor row/column bounds). Nothing is sampled or dropped.

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm test` pass — the full suite passes except an environment-only `EPERM` opening `/dev/zero` in `foreign-writes.spec.ts`, unrelated to this change and reproducible in isolation (the local file sandbox blocks `/dev/zero`)
- [x] `pnpm security` passes — `pnpm audit` clean; workflow lint clean (`zizmor`, no findings)
- [x] `pnpm run verify-docs` passes — 9 bilingual pairs consistent (no docs touched)
- [x] No changeset — test-only change, which `AGENTS.md` exempts

The "If this touches the terminal" and "If this presents a Harness capability" sections do not apply: no terminal behavior and no Harness capability changes here.

## Verification

- 7 repeated runs of the file: all 20 state cases pass (plus the two below-floor cases); per-case 41–117 ms, whole file ~1.6 s.
- Deliberate mistake: one injected overlong row for the long-line / streaming-on / timing-off state fails exactly that case; the test name and each violation line identify `long-line`, `streaming`, and `timing`. Restored afterward.
