### PR TITLE
perf(dshline): make long composer drafts fast and navigable

### DIFF
--- a/.changeset/long-composer-drafts-fast.md
+++ b/.changeset/long-composer-drafts-fast.md
@@ -1,0 +1,12 @@
+---
+'@dshline/dshline': patch
+---
+
+Make very large pasted prompts fast and navigable. Laying the composer's draft
+out is now a single forward pass over one snapshot of the buffer instead of a
+per-line loop that re-derived the whole buffer for every line, which made a
+5,000-line draft take seconds per `↑` and seconds more for the redraw. The
+composer view also reuses one layout between its `render` and `cursor` calls, so
+a frame no longer wraps the draft twice. A draft still grows from one row to the
+same hard cap and then scrolls, and the frame title now names the direction of
+what is hidden (`↑ 27` / `↓ 4`) instead of a single `+N rows` count.

--- a/packages/dshline/src/views.ts
+++ b/packages/dshline/src/views.ts
@@ -178,6 +178,24 @@ export function createComposerView(
   const escapedLabel = escapeControls(label)
 
   /**
+   * A layout result kept for one (document, cursor, width) triple.
+   *
+   * `TuiSlots.compose` asks a view for `render()` and then `cursor()` with the
+   * same geometry and the same composer state, and both need the wrapped rows —
+   * without this the whole buffer is laid out twice per frame. The key holds the
+   * TEXT and the cursor POSITION, not just one of them: the cursor's row and
+   * column are part of what is cached, so keying on the text alone would hand a
+   * stale placement to the first frame after a cursor move. A cursor move that
+   * does not also re-render therefore misses, which is correct — what the entry
+   * reuses is the wrap of an unchanged document for the pair that shares a frame.
+   * One entry, because a frame uses one geometry and a map keyed by width would
+   * grow without bound across a resize.
+   */
+  let memo:
+    | { text: string; columns: number; at: number; rows: readonly string[]; row: number; column: number }
+    | undefined
+
+  /**
    * Every rendered row of the buffer, and which of them holds the cursor.
    *
    * Rows are CHUNKED at the width rather than wrapped at spaces, and that choice is
@@ -199,7 +217,13 @@ export function createComposerView(
    * @returns the rows and the cursor's row and column within them.
    */
   const layout = (columns: number): { rows: readonly string[]; row: number; column: number } => {
+    const text = composer.value
+    const at = composer.position
+    if (memo !== undefined && memo.text === text && memo.columns === columns && memo.at === at) {
+      return { rows: memo.rows, row: memo.row, column: memo.column }
+    }
     const found = layoutComposer(composer, composerInner(columns), line => composerGutter(line, columns))
+    memo = { text, columns, at, rows: found.rows, row: found.cursorRow, column: found.cursorColumn }
     return { rows: found.rows, row: found.cursorRow, column: found.cursorColumn }
   }
 
@@ -208,19 +232,44 @@ export function createComposerView(
    * @param all - every wrapped row of the buffer.
    * @param row - the cursor's row within them.
    * @param maximum - most content rows the current live-region budget permits.
-   * @returns the visible rows and how many were scrolled past above them.
+   * @returns the visible rows, how many were scrolled past above them, and how
+   *   many remain below — the two figures the overflow indicator reports.
    */
   const window = (
     all: readonly string[],
     row: number,
     maximum = COMPOSER_ROWS,
-  ): { rows: readonly string[]; offset: number } => {
+  ): { rows: readonly string[]; offset: number; below: number } => {
     const visible = Math.max(1, Math.min(COMPOSER_ROWS, maximum))
-    if (all.length <= visible) return { rows: all, offset: 0 }
+    if (all.length <= visible) return { rows: all, offset: 0, below: 0 }
     // Keep the cursor's row in view, preferring to show what follows it: a person
     // pasting or typing is working at the end.
     const offset = Math.min(all.length - visible, Math.max(0, row - visible + 1))
-    return { rows: all.slice(offset, offset + visible), offset }
+    return { rows: all.slice(offset, offset + visible), offset, below: all.length - offset - visible }
+  }
+
+  /**
+   * The frame title, with an honest count of what the viewport hides.
+   *
+   * The old title said only `+37 rows`, which cannot tell a reader whether the
+   * cursor is near the start of a paste or stranded at its end — the two cases
+   * want opposite arrows. A direction is only named when there is something that
+   * way, so a draft scrolled to its top reads as the plain workspace name and
+   * `↑` visibly means history. The string is handed to `rootFrame`, whose border
+   * arithmetic truncates from the RIGHT, so `↑` is written first: the upward
+   * direction is the one that falls through to history, and it is the reading a
+   * narrow terminal can least afford to lose. Both are shown whenever they fit.
+   * @param hiddenAbove - rows scrolled off the top of the viewport.
+   * @param hiddenBelow - rows the viewport does not reach beneath it.
+   * @returns the painted title for the frame's top border.
+   */
+  const frameTitle = (hiddenAbove: number, hiddenBelow: number): string => {
+    const label = paint(escapedLabel, 'composer-title')
+    const parts: string[] = []
+    if (hiddenAbove > 0) parts.push(`↑ ${String(hiddenAbove)}`)
+    if (hiddenBelow > 0) parts.push(`↓ ${String(hiddenBelow)}`)
+    if (parts.length === 0) return label
+    return `${label} ${paint(parts.join(' '), 'muted')}`
   }
 
   /**
@@ -257,14 +306,16 @@ export function createComposerView(
 
   /**
    * The composer laid out directly against the terminal's width, with no
-   * frame around it. See {@link layout} for the framed equivalent.
+   * frame around it.
+   *
+   * `composerInner` already collapses to the physical width below the chrome
+   * floor, so this is the same layout the framed branch builds; going through
+   * {@link layout} is what shares ONE computation between the fallback's render
+   * and its cursor placement instead of laying the buffer out twice.
    * @param columns - the terminal's current width.
    * @returns the rows and the cursor's row and column within them.
    */
-  const narrowLayout = (columns: number): { rows: readonly string[]; row: number; column: number } => {
-    const found = layoutComposer(composer, composerInner(columns), line => composerGutter(line, columns))
-    return { rows: found.rows, row: found.cursorRow, column: found.cursorColumn }
-  }
+  const narrowLayout = layout
 
   /** Rows outside the composer's own content in the fallback: no borders, just the optional separator. */
   const NARROW_FIXED_ROWS = 1
@@ -311,13 +362,10 @@ export function createComposerView(
       // The timer and status are persistent when enabled, so a tall paste gives
       // up composer history rather than pushing either below the physical screen.
       const shown = window(rows, row, contentBudget(terminalRows))
-      const hidden = rows.length - shown.rows.length
       const framed = rootFrame({
         width: composerFrameWidth(columns),
         columns,
-        context: hidden > 0
-          ? `${paint(escapedLabel, 'composer-title')} ${paint(`+${String(hidden)} rows`, 'muted')}`
-          : paint(escapedLabel, 'composer-title'),
+        context: frameTitle(shown.offset, shown.below),
         body: shown.rows,
       })
       // The same shed rule as the empty frame, so the cursor's own arithmetic in
@@ -328,6 +376,10 @@ export function createComposerView(
       if (columns < CHROME_MIN_COLUMNS) {
         const { rows: every, row, column } = narrowLayout(columns)
         const shown = window(every, row, narrowContentBudget(rows))
+        // No frame is drawn here, so the layout's own column is already the
+        // terminal column: it counts the gutter, and adding the framed branch's
+        // border would push the caret two cells past a terminal that may not even
+        // have two columns.
         return { row: narrowContentRowOffset(rows) + row - shown.offset, column }
       }
       if (composer.isEmpty) return { row: contentRowOffset(rows), column: 2 + displayWidth(PROMPT) }

--- a/packages/dshline/tests/timing-frames.spec.ts
+++ b/packages/dshline/tests/timing-frames.spec.ts
@@ -297,8 +297,9 @@ describe('the timing live panel on a real terminal', () => {
     frame.draw()
     expect(frame.screen.height).toBeLessThanOrEqual(5)
     const joined = (await visible(frame.emulator)).join('\n')
-    // Scrolled, not lost: the elision count says what the window gave up.
-    expect(joined).toContain('+29 rows')
+    // Scrolled, not lost: the elision count names the direction the window gave
+    // up, so a reader knows `↑` reaches the rest of the paste.
+    expect(joined).toContain('↑ 29')
     expect(joined).toContain('no turn measured yet')
     expect(joined).toContain('ready')
   })

--- a/packages/dshline/tests/views.spec.ts
+++ b/packages/dshline/tests/views.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { Composer, displayWidth, Screen, stripAnsi } from '@dshline/renderer'
 import { createEmulator } from '../../../tests/emulator.ts'
 import type { ComposerHint, StatusState } from '../src/views.ts'
-import { composerHintRow, composerInner, createComposerView, createStatusView } from '../src/views.ts'
+import { composerGutter, composerHintRow, composerInner, createComposerView, createStatusView } from '../src/views.ts'
 
 /** A terminal width whose inner content area is a round number of columns. */
 const COLUMNS = 40
@@ -163,12 +163,44 @@ describe('a composer taller than the terminal', () => {
   it('scrolls to keep the cursor visible, and says how much is hidden', async () => {
     const composer = typed(Array.from({ length: 40 }, (_, i) => `line ${String(i)}`).join('\n'))
     const { cursor, rows } = await drawn(composer)
-    // The cursor is at the end, so the end is what is shown.
+    // The cursor is at the end, so the end is what is shown, and the title names
+    // the DIRECTION of what is hidden rather than a bare count: a reader can tell
+    // they are at the bottom and that `↑` reaches the rest.
     expect(rows.join('\n')).toContain('line 39')
     expect(rows.join('\n')).not.toContain('line 0 ')
-    expect(rows[1]).toContain('rows')
+    expect(rows[1]).toContain('↑ 30')
+    expect(rows[1]).not.toContain('↓')
     expect(cursor.row).toBeGreaterThan(0)
     expect(cursor.row).toBeLessThan(rows.length)
+  })
+
+  it('does not serve a stale layout after the draft is edited', async () => {
+    // The view memoizes one layout between render() and cursor(). A `set()` that
+    // changes the text while leaving the cursor at the SAME offset is the case a
+    // key that forgot the text would get wrong: the cursor offset alone would not
+    // invalidate the entry, so the next frame would draw the previous draft.
+    const composer = typed('short')
+    const view = createComposerView(composer, '/w/repo')
+    expect(stripAnsi(view.render(40, 24).join('\n'))).toContain('short')
+    composer.set('other')
+    expect(composer.position).toBe(5)
+    const after = stripAnsi(view.render(40, 24).join('\n'))
+    expect(after).toContain('other')
+    expect(after).not.toContain('short')
+  })
+
+  it('does not serve a stale layout after the width changes', async () => {
+    // The cursor offset is identical at both widths, so only the width key can
+    // invalidate the entry. At 12 columns the 26-character draft wraps to seven
+    // rows and the cursor lands on row 5 at drawn column 6; the wide layout's own
+    // placement (row 2, column 30) is what a memo that ignored the width returns,
+    // and column 30 is not even a cell the narrow frame has.
+    const composer = typed('abcdefghijklmnopqrstuvwxyz')
+    const view = createComposerView(composer, '/w/repo')
+    view.render(40, 24)
+    const narrow = view.render(12, 24)
+    expect(narrow.filter(row => row !== '')).toHaveLength(6)
+    expect(view.cursor?.(12, 24)).toEqual({ row: 5, column: 6 })
   })
 
   it('reports the cursor relative to the visible window', async () => {
@@ -183,7 +215,9 @@ describe('a composer taller than the terminal', () => {
     const { rows } = await drawn(composer)
     expect(rows.join('\n')).toContain('one')
     expect(rows.join('\n')).toContain('three')
-    expect(rows[1]).not.toContain('rows')
+    // Nothing is hidden, so there is no direction to report.
+    expect(rows[1]).not.toContain('↑')
+    expect(rows[1]).not.toContain('↓')
   })
 })
 
@@ -1008,5 +1042,46 @@ describe('the status line', () => {
     const line = status({ compacting: true }, 16)
     expect(line).toContain('compacting')
     expect(displayWidth(line)).toBeLessThanOrEqual(16)
+  })
+})
+
+describe('the composer viewport follows the cursor both ways', () => {
+  it('scrolls the window upward as the cursor climbs', async () => {
+    const composer = typed(Array.from({ length: 40 }, (_, i) => `line ${String(i)}`).join('\n'))
+    const view = createComposerView(composer, '/w/repo')
+    const top = () => view.render(40, 24).join('\n')
+    expect(top()).toContain('line 39')
+    // Climb most of the way up; the window must show earlier lines, not stay put.
+    for (let i = 0; i < 35; i += 1) composer.moveUp(composerInner(40), (line: number) => composerGutter(line, 40))
+    const after = top()
+    expect(after).toContain('line 4')
+    expect(after).not.toContain('line 39')
+    // And the cursor's own row is inside the drawn window.
+    const placement = view.cursor?.(40, 24)
+    expect(placement?.row).toBeGreaterThan(0)
+    expect(placement?.row).toBeLessThan(view.render(40, 24).length)
+  })
+})
+
+describe('a very large pasted prompt', () => {
+  it('stays a bounded viewport and keeps the cursor on the drawn text', async () => {
+    // The pathological case this change is about: thousands of lines pasted at
+    // once. The live region must stay capped, and the cursor must still land on
+    // the character a person sees.
+    const composer = typed(Array.from({ length: 3000 }, (_, i) => `pasted line ${String(i)}`).join('\n'))
+    const emulator = createEmulator(COLUMNS, 24)
+    const screen = new Screen(emulator.target)
+    const view = createComposerView(composer, '/w/repo')
+    const rows = view.render(COLUMNS, 24)
+    const placement = view.cursor?.(COLUMNS, 24)
+    expect(rows.filter(row => row !== '')).toHaveLength(COMPOSER_FRAME_ROWS)
+    expect(rows.join('\n')).toContain('pasted line 2999')
+    const cell = await emulator.cell(placement?.column ?? 0, placement?.row ?? 0)
+    screen.setLive(rows, placement)
+    expect(screen.height).toBeLessThanOrEqual(24)
+    // The cursor sits on the line it would overwrite next, which is the end of
+    // the buffer — a cell that is part of the final line's text region.
+    expect(stripAnsi(rows[placement?.row ?? 0] ?? '')).toContain('pasted line 2999')
+    expect(cell).toBeDefined()
   })
 })

--- a/packages/renderer/src/composer-layout.ts
+++ b/packages/renderer/src/composer-layout.ts
@@ -13,51 +13,22 @@
 import type { Composer } from './composer.ts'
 import { codePointWidth, displayWidth } from './width.ts'
 
-/** One visual row: its text, and where its text begins in the buffer. */
+/**
+ * One visual row, kept with what a caller needs to map a placement back to a
+ * buffer offset.
+ *
+ * `text` is the row WITHOUT its gutter, because a row's own text is what the
+ * offset arithmetic is measured against; the gutter is prepended when the row is
+ * drawn. Keeping the two apart is what lets one forward pass build both the
+ * drawn row and its mapping.
+ */
 interface RowChunk {
-  /** The rendered row, gutter included on the logical line's first row. */
-  readonly row: string
+  /** The row's own characters, gutter excluded. */
+  readonly text: string
   /** Buffer offset (code points) of this row's first text character. */
   readonly start: number
-  /** Code points of the gutter at the start of this row (0 on wrapped rows). */
-  readonly gutterChars: number
-}
-
-/**
- * Visual rows of one logical line, chunked at `width`.
- *
- * The gutter is prepended only to the first row and the wrapped continuation
- * rows continue flush, which is exactly how `chunkToWidth` renders them — a
- * deliberate re-use of the same break rule rather than a second wrapping
- * algorithm. `start` is what lets a caller map a row back to a buffer offset.
- * @param line - the logical line's text, without newlines.
- * @param gutter - the line's leading gutter (prompt for the first, indent after).
- * @param width - display-column budget per visual row.
- * @returns the rows, each with its buffer start and gutter count.
- */
-function chunkLine(line: string, gutter: string, width: number): RowChunk[] {
-  const budget = Math.max(1, width)
-  const out: RowChunk[] = []
-  let row = gutter
-  let used = displayWidth(gutter)
-  let start = 0
-  let gutterChars = [...gutter].length
-  let textPos = 0
-  for (const char of line) {
-    const charWidth = codePointWidth(char.codePointAt(0) ?? 0)
-    if (used + charWidth > budget) {
-      out.push({ row, start, gutterChars })
-      row = ''
-      used = 0
-      start = textPos
-      gutterChars = 0
-    }
-    row += char
-    used += charWidth
-    textPos += 1
-  }
-  out.push({ row, start, gutterChars })
-  return out
+  /** Display columns this row's gutter spends before its text begins. */
+  readonly gutterWidth: number
 }
 
 /**
@@ -70,8 +41,9 @@ export interface ComposerLayout {
   /** The visual row the cursor sits on. */
   readonly cursorRow: number
   /**
-   * The cursor's display column within its row, including any gutter, which is
-   * the value the renderer adds its own border offset to.
+   * The cursor's display column on the DRAWN line, its gutter included. The
+   * renderer adds only the frame's own border cells when it places the terminal
+   * cursor, because the gutter is part of the line's text area.
    */
   readonly cursorColumn: number
   /**
@@ -79,6 +51,11 @@ export interface ComposerLayout {
    * a display `column`. The row is clamped to the layout; moving to the end of a
    * row yields the start of the next row's text, and an out-of-range column
    * yields the row's own end.
+   *
+   * `column` is measured exactly as {@link ComposerLayout.cursorColumn} is — on
+   * the DRAWN line, gutter included — so the two are exact inverses and the
+   * column a vertical move LEAVES is the column it arrives at. A gutter's own
+   * cells are not navigable, so aiming inside it lands at the text's start.
    * @param row - the target visual row, clamped to a real row.
    * @param column - the display column to aim at, measured as {@link cursorColumn} is.
    * @returns the buffer offset to set the cursor to.
@@ -89,9 +66,15 @@ export interface ComposerLayout {
 /**
  * Lay out a composer's buffer into visual rows.
  *
- * The cursor's row is derived from a chunk of the text BEFORE it alone, which is
- * prefix-consistent: the rows of a prefix are the first rows of the finished
- * line, so the cursor lands where the same text drawn in place would put it.
+ * ONE forward pass over a single snapshot of the buffer produces every row, the
+ * cursor's placement, and each row's buffer offset together. That is a
+ * correctness property as much as a performance one: the earlier shape asked the
+ * composer for whole-buffer derived forms (`lines`, `cursorLine`,
+ * `lineBeforeCursor`, `value`) from inside a per-line loop, so a draft of L lines
+ * and N code points cost O(N·L) — thousands of full joins and rescans for one
+ * `↑` press. Each row here is built from the characters as they arrive and the
+ * cursor is placed from the count accumulated at its own character, so nothing is
+ * re-derived and the cost is O(N) whatever the line structure.
  * @param composer - the buffer being edited.
  * @param width - display-column budget per visual row, including the gutter.
  * @param gutter - the gutter for a logical line, styled by which line it is.
@@ -102,68 +85,192 @@ export function layoutComposer(
   width: number,
   gutter: (line: number) => string,
 ): ComposerLayout {
+  const budget = Math.max(1, width)
+  // ONE reading of the buffer: the value is joined once and split into code
+  // points once, and every later decision reads this array rather than asking the
+  // composer again.
+  const chars = [...composer.value]
+  const cursor = composer.position
   const chunks: RowChunk[] = []
+  /** The drawn rows, built in step with `chunks` so neither is derived twice. */
+  const rows: string[] = []
+  /** Index of the row currently being built. */
+  let rowIndex = 0
   let cursorRow = 0
   let cursorColumn = 0
-  // Buffer offset (in code points) of the start of the line currently being laid
-  // out. Each line's chunks carry offsets relative to that line, so the absolute
-  // offset is added here — without it, movement into a later line aimed at the
-  // wrong part of the buffer.
-  let lineStart = 0
-  composer.lines.forEach((line, lineIndex) => {
-    const lineGutter = gutter(lineIndex)
-    const lineChunks = chunkLine(line, lineGutter, width)
-    if (lineIndex === composer.cursorLine) {
-      const prefix = chunkLine(composer.lineBeforeCursor, lineGutter, width)
-      const last = prefix.at(-1)
-      cursorRow = chunks.length + prefix.length - 1
-      cursorColumn = last === undefined ? displayWidth(lineGutter) : displayWidth(last.row)
-      // A prefix that exactly fills its row leaves the cursor one column past the
-      // last cell, which would sit on the frame's border. It belongs at the start
-      // of the next row, as it would in any editor.
-      if (cursorColumn >= width) {
-        cursorRow += 1
-        cursorColumn = 0
+  /** Whether the loop placed the cursor at its own character. */
+  let cursorPlaced = false
+  /** The gutter width of the row most recently flushed, for the end cursor. */
+  let lastGutterWidth = 0
+  let lineIndex = 0
+  let gutterText = gutter(0)
+  let gutterWidth = displayWidth(gutterText)
+
+  /** The current row's characters, gutter excluded. */
+  let text = ''
+  /** Display columns the current row's TEXT occupies. */
+  let used = 0
+  /** Buffer offset (code points) where the current row's text begins. */
+  let textStart = 0
+  // The gutter is spent FIRST, so it is reserved out of the row's width before
+  // the first character is placed. Wrapping the text against the whole width
+  // instead lets the prompt's two columns ride on top of a full row, which is
+  // exactly how a `› ` line came out two columns too long. A gutter as wide as
+  // the row leaves ZERO for text, which is why this floors at zero and not one:
+  // flooring at one emitted the gutter plus a character past the terminal's edge.
+  let textBudget = Math.max(0, budget - gutterWidth)
+
+  /**
+   * Finish the row under construction.
+   *
+   * A wrapped continuation row carries no gutter, so it gets the WHOLE width — a
+   * reset to `budget`, not to the first row's gutter-reduced budget. Getting that
+   * wrong shrank every row but the first by the prompt's width, which is the kind
+   * of bug a single-row screenshot never shows. The caller resets the budget again
+   * when the break was a newline and a fresh logical line's gutter applies.
+   */
+  const breakRow = (): void => {
+    rows.push(`${gutterText}${text}`)
+    chunks.push({ text, start: textStart, gutterWidth })
+    lastGutterWidth = gutterWidth
+    rowIndex += 1
+    gutterText = ''
+    gutterWidth = 0
+    text = ''
+    used = 0
+    textStart = 0
+    textBudget = budget
+  }
+
+  for (let index = 0; index < chars.length; index += 1) {
+    const char = chars[index] ?? ''
+    if (char === '\n') {
+      breakRow()
+      lineIndex += 1
+      gutterText = gutter(lineIndex)
+      gutterWidth = displayWidth(gutterText)
+      textBudget = Math.max(0, budget - gutterWidth)
+      textStart = index + 1
+      // A cursor resting AT a line start has no character of its own to trigger
+      // the placement below: the newline it follows is not part of the next row,
+      // and the loop moves on. Without this it stayed unplaced and the buffer-end
+      // fallback put it on the LAST row — the caret was drawn on the wrong line,
+      // and `↑` from it stepped into the wrong one.
+      if (index + 1 === cursor) {
+        cursorPlaced = true
+        cursorRow = rowIndex
+        cursorColumn = gutterWidth
       }
+      continue
     }
-    for (const chunk of lineChunks) {
-      chunks.push({ ...chunk, start: lineStart + chunk.start })
+    const charWidth = codePointWidth(char.codePointAt(0) ?? 0)
+    if (used + charWidth > textBudget) {
+      if (text.length > 0) {
+        // The row is full: wrap the text onto the next row.
+        breakRow()
+        textStart = index
+      } else if (gutterText !== '') {
+        // The gutter alone fills the width, so there is no room for any text
+        // beside it. Retire the gutter's own row and retry this character at the
+        // full width, which is what keeps a one-column terminal to one column.
+        breakRow()
+        textStart = index
+      }
+      // Otherwise the row is empty and the character is simply wider than the
+      // terminal: it is emitted alone, which is the only way a two-column glyph
+      // can appear at all in a one-column space.
     }
-    lineStart += [...line].length
-    if (lineIndex < composer.lines.length - 1) lineStart += 1 // the newline
-  })
-  // Keep an exact-width final insertion row even after the cursor moves away
-  // from it. Creating it only while the cursor was at the end made `↑` remove
-  // the row from the next layout, so `↓` could never return to the same end
-  // position. Only the final logical line can own this latent insertion point;
-  // adding one before an explicit newline would invent a visible blank line.
-  const last = chunks.at(-1)
-  if (last !== undefined && displayWidth(last.row) >= Math.max(1, width)) {
-    chunks.push({ row: '', start: [...composer.value].length, gutterChars: 0 })
+    text += char
+    used += charWidth
+    if (index + 1 !== cursor) continue
+    // The cursor sits just past this character, and its column is the width
+    // accumulated AT it — never the finished row's width. Those differ wherever
+    // the cursor is before the row's end, and using the row's width is what put a
+    // cursor at the buffer's start onto the row after the one it belonged to.
+    // The gutter counts, because the column is a cell on the DRAWN line.
+    cursorPlaced = true
+    cursorRow = rowIndex
+    cursorColumn = gutterWidth + used
+    // A row that filled its budget exactly rolls the cursor on to the next row at
+    // column zero. Position zero never reaches here (no character places it), so
+    // conflating "row is full" with "buffer end" cannot move the start cursor.
+    // At the buffer's end the next row is not built yet, so the insertion row
+    // added below is what makes the rolled position addressable.
+    if (cursorColumn >= budget) {
+      cursorRow += 1
+      cursorColumn = 0
+    }
   }
-  // A cursor that rolled past the last row needs a row to sit on, or placement
-  // arithmetic has nothing to clamp to. An editor shows the same empty row.
-  if (cursorRow >= chunks.length) {
-    chunks.push({ row: '', start: composer.position, gutterChars: 0 })
+
+  // Position zero has no character of its own to place it during the loop, and it
+  // is emphatically not the buffer's end: on a full first row the two are the
+  // same column, and conflating them put the start cursor on the end's row.
+  if (!cursorPlaced && cursor === 0) {
+    cursorPlaced = true
+    cursorRow = 0
+    cursorColumn = gutterWidth
   }
+
+  // The final line is flushed even when it is empty, so a buffer that ends in a
+  // newline keeps the blank row it drew for it. Whether it filled its budget is
+  // captured first: `breakRow` resets the counters the check needs.
+  const finalRowFull = used >= textBudget && text.length > 0
+  breakRow()
+
+  // A cursor still unplaced sits at the buffer's very end — an empty buffer, or
+  // one ending in a newline whose last row is the blank one. Its column is the
+  // text it has passed on that row, which for both cases is zero; the column is
+  // a cell on the drawn line, so the row's own gutter is the base.
+  if (!cursorPlaced && cursor >= chars.length) {
+    cursorRow = rowIndex - 1
+    cursorColumn = lastGutterWidth + (cursor - textStart)
+    // The buffer's end on a row that is exactly full is the one position the row
+    // cannot represent apart from the next row's start, so the end cursor rolls
+    // onto the insertion row the flush added below.
+    if (cursorColumn >= budget) {
+      cursorRow += 1
+      cursorColumn = 0
+    }
+  }
+
+  // A final row that filled its budget exactly leaves the buffer's end on a
+  // boundary the row cannot distinguish from the next row's start. One empty
+  // insertion row makes that position addressable from both directions, so `↑`
+  // from it lands on the last real row and `↓` returns. It must be present
+  // however the cursor moved: adding it only while the cursor sat at the end is
+  // what made `↑` remove the row and strand the cursor with no way back down.
+  // Only the buffer's end gets it — after an explicit newline the final row is
+  // already the blank one.
+  if (finalRowFull) {
+    chunks.push({ text: '', start: chars.length, gutterWidth: 0 })
+    rows.push('')
+  }
+  // A layout with no row at all has nothing for placement arithmetic to clamp to.
+  if (rows.length === 0) {
+    rows.push('')
+    chunks.push({ text: '', start: cursor, gutterWidth: 0 })
+  }
+
   return {
-    get rows() {
-      return chunks.map(chunk => chunk.row)
-    },
+    rows,
     cursorRow,
     cursorColumn,
     positionAt(row, column) {
       const targetRow = Math.max(0, Math.min(row, chunks.length - 1))
-      const chunk = chunks[targetRow] ?? { row: '', start: composer.position, gutterChars: 0 }
-      let used = 0
+      const chunk = chunks[targetRow] ?? { text: '', start: cursor, gutterWidth: 0 }
+      // The column is a cell on the DRAWN line, so the row's gutter is spent
+      // before the text begins: a column inside the gutter aims at the text's
+      // start, and a column past the text clamps to the row's own end.
+      const textColumn = Math.max(0, column - chunk.gutterWidth)
+      let usedColumn = 0
       let index = 0
-      for (const char of chunk.row) {
+      for (const char of chunk.text) {
         const charWidth = codePointWidth(char.codePointAt(0) ?? 0)
-        if (used + charWidth > column) break
-        used += charWidth
+        if (usedColumn + charWidth > textColumn) break
+        usedColumn += charWidth
         index += 1
       }
-      return chunk.start + Math.max(0, index - chunk.gutterChars)
+      return chunk.start + index
     },
   }
 }

--- a/packages/renderer/src/composer-layout.ts
+++ b/packages/renderer/src/composer-layout.ts
@@ -145,8 +145,21 @@ export function layoutComposer(
   for (let index = 0; index < chars.length; index += 1) {
     const char = chars[index] ?? ''
     if (char === '\n') {
+      // A logical line that filled its budget exactly puts the cursor before the
+      // newline on a boundary the finished row cannot represent: `positionAt` on
+      // that row's end and on the NEXT row's start are both the offset after the
+      // newline. One empty boundary row between them keeps "before the newline"
+      // distinct from "after the newline", exactly as the insertion row after a
+      // full FINAL row keeps the buffer's end addressable. Without it the cursor
+      // before the newline reported the offset after it, and `↑` crossed the line.
+      const lineFilled = used >= textBudget && text.length > 0
       breakRow()
       lineIndex += 1
+      if (lineFilled) {
+        chunks.push({ text: '', start: index, gutterWidth: 0 })
+        rows.push('')
+        rowIndex += 1
+      }
       gutterText = gutter(lineIndex)
       gutterWidth = displayWidth(gutterText)
       textBudget = Math.max(0, budget - gutterWidth)

--- a/packages/renderer/tests/composer-layout.spec.ts
+++ b/packages/renderer/tests/composer-layout.spec.ts
@@ -32,10 +32,12 @@ describe('layoutComposer()', () => {
     const composer = new Composer()
     composer.set('first line\nsecond line\nthird line')
     const layout = layoutComposer(composer, 80, GUTTER)
-    // Each logical line is one visual row here; aiming past the first row's end
-    // lands at its end (offset 10), and the second row starts after the newline.
+    // Each logical line is one visual row here. The column is a cell on the DRAWN
+    // line, so the two-column gutter comes first: a column past the first row's
+    // drawn end clamps to offset 10, and on the second row (which starts at 11)
+    // five drawn columns leave the gutter and reach three characters in.
     expect(layout.positionAt(0, 14)).toBe(10)
-    expect(layout.positionAt(1, 24)).toBe(22) // line 1 starts at 10 + newline + 11 chars
+    expect(layout.positionAt(1, 5)).toBe(14)
   })
 
   it('clamps an out-of-range column to the end of its own row, not beyond', () => {
@@ -43,7 +45,7 @@ describe('layoutComposer()', () => {
     composer.set('short\nthirteen-char')
     const layout = layoutComposer(composer, 80, GUTTER)
     // Aiming far past the short first row lands at its end (offset 5), and a
-    // later row keeps its own start — column 3 on row 1 is its own +1.
+    // later row keeps its own start — column 5 on row 1 is its own +5.
     expect(layout.positionAt(0, 999)).toBe(5)
     expect(layout.positionAt(1, 5)).toBe(9)
   })
@@ -61,9 +63,11 @@ describe('layoutComposer()', () => {
     composer.set('标准标准')
     const layout = layoutComposer(composer, 6, GUTTER)
     expect(layout.rows).toEqual(['› 标准', '标准'])
-    // Content budget is two wide characters per row. Aiming four columns down the
-    // top row lands after the first wide character — two columns in.
+    // The column is on the DRAWN line: cell 4 (two cells of gutter, then one
+    // wide character's two cells) falls after the first wide character, which is
+    // text offset 1. Aiming inside the gutter stays at the row's start.
     expect(layout.positionAt(0, 4)).toBe(1)
+    expect(layout.positionAt(0, 1)).toBe(0)
   })
 
   it('keeps an exact-width trailing row reachable after moving away from it', () => {

--- a/packages/renderer/tests/composer-scale.spec.ts
+++ b/packages/renderer/tests/composer-scale.spec.ts
@@ -1,0 +1,262 @@
+/**
+ * The composer's layout at the sizes that used to be pathological.
+ *
+ * The old implementation asked the composer for whole-buffer derived forms
+ * (`lines`, `cursorLine`, `lineBeforeCursor`) from inside a per-line loop, so a
+ * draft of L lines and N code points cost O(N·L). These tests pin the behaviour
+ * that must survive the single-pass rewrite — Unicode, explicit newlines,
+ * exact-width rows, preferred columns — and the STRUCTURAL property that made it
+ * fast, which is checked by observation rather than a wall-clock threshold.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Composer } from '../src/composer.ts'
+import { layoutComposer } from '../src/composer-layout.ts'
+
+const GUTTER = (line: number): string => (line === 0 ? '› ' : '  ')
+
+/**
+ * A composer that records how its whole-buffer getters are used.
+ *
+ * The layout is allowed to read `value` once and `position` once to take its
+ * snapshot. It is never allowed to reach for `lines`, `lineBeforeCursor`, or
+ * `cursorLine`: those are the getters that join, split, or rescan the entire
+ * buffer, and calling them from inside the traversal is exactly what made the
+ * old layout quadratic. Asserting zero calls is stronger than timing, and it
+ * cannot flake.
+ */
+class AuditedComposer extends Composer {
+  /** Names of the whole-buffer derived getters read since {@link reset}. */
+  readonly derivedReads: string[] = []
+  /** Times the snapshot getters were read since {@link reset}. */
+  valueReads = 0
+  positionReads = 0
+
+  /** Begin a fresh observation window. */
+  reset(): void {
+    this.derivedReads.length = 0
+    this.valueReads = 0
+    this.positionReads = 0
+  }
+
+  override get value(): string {
+    this.valueReads += 1
+    return super.value
+  }
+
+  override get position(): number {
+    this.positionReads += 1
+    return super.position
+  }
+
+  override get lines(): string[] {
+    this.derivedReads.push('lines')
+    return super.lines
+  }
+
+  override get cursorLine(): number {
+    this.derivedReads.push('cursorLine')
+    return super.cursorLine
+  }
+
+  override get lineBeforeCursor(): string {
+    this.derivedReads.push('lineBeforeCursor')
+    return super.lineBeforeCursor
+  }
+}
+
+describe('layout at scale', () => {
+  it('lays thousands of lines out and places the cursor at the end', () => {
+    const lines = Array.from({ length: 5000 }, (_, i) => `row ${String(i)}`)
+    const composer = new Composer()
+    composer.set(lines.join('\n'))
+
+    const layout = layoutComposer(composer, 80, GUTTER)
+    // Every line is short enough to wrap onto exactly one visual row, and the
+    // final row is short, so there is no insertion row: one row per line.
+    expect(layout.rows).toHaveLength(5000)
+    expect(layout.cursorRow).toBe(4999)
+    expect(layout.positionAt(layout.cursorRow, layout.cursorColumn)).toBe(composer.position)
+  })
+
+  it('lays a very long single line out into one row per width', () => {
+    const composer = new Composer()
+    composer.set('a'.repeat(100_000))
+    const layout = layoutComposer(composer, 80, GUTTER)
+    // The first row reserves the `› ` gutter (78 text columns); every wrapped
+    // continuation row then gets the whole 80. 78 + 1_249 x 80 = 99_998, so 1_250
+    // rows remain: the 1_250th is the partial `aa` tail, and the end cursor sits
+    // at its drawn column rather than on an insertion row (the row is not full).
+    expect(layout.rows).toHaveLength(1251)
+    expect(layout.cursorRow).toBe(layout.rows.length - 1)
+    expect(layout.cursorColumn).toBe(2)
+    expect(layout.positionAt(layout.cursorRow, layout.cursorColumn)).toBe(100_000)
+  })
+
+  it('takes its snapshot from the buffer once and never re-derives it per line', () => {
+    const lines = Array.from({ length: 500 }, (_, i) => `row ${String(i)}`)
+    const composer = new AuditedComposer()
+    composer.set(lines.join('\n'))
+    composer.reset()
+
+    layoutComposer(composer, 80, GUTTER)
+
+    // The whole cost of the layout is one join and one position read. Any per-line
+    // re-derivation shows up here as a growing count, so the assertion is the
+    // regression guard the wall-clock benchmark cannot be in CI.
+    expect(composer.valueReads).toBe(1)
+    expect(composer.positionReads).toBe(1)
+    expect(composer.derivedReads).toEqual([])
+  })
+
+  it('does not re-derive the buffer while moving the cursor', () => {
+    const lines = Array.from({ length: 500 }, (_, i) => `row ${String(i)}`)
+    const composer = new AuditedComposer()
+    composer.set(lines.join('\n'))
+    composer.reset()
+
+    composer.moveUp(80, GUTTER)
+    composer.moveDown(80, GUTTER)
+
+    // A vertical move is one layout, and one layout is one snapshot.
+    expect(composer.valueReads).toBe(2)
+    expect(composer.positionReads).toBe(2)
+    expect(composer.derivedReads).toEqual([])
+  })
+})
+
+describe('layout across line structure', () => {
+  it('places a cursor at the start of a line after an explicit newline', () => {
+    // A cursor resting on a newline's far side has no character of its own to
+    // trigger placement. It used to stay unplaced and be mistaken for the buffer's
+    // end, which drew the caret on the last line and made `↑` step into the wrong
+    // one. This is reachable by one Left from just after a line's first character.
+    const width = 80
+    // Offsets 2 and 4 are the starts of the second and third lines; the third is
+    // also the buffer's end, so it exercises the fallback too.
+    for (const [at, row] of [[2, 1], [4, 2]] as const) {
+      const composer = new Composer()
+      composer.set('a\nb\nc')
+      while (composer.position > at) composer.handle({ kind: 'key', name: 'left' })
+      const layout = layoutComposer(composer, width, GUTTER)
+      expect(layout.cursorRow, `offset ${String(at)}`).toBe(row)
+      expect(layout.cursorColumn, `offset ${String(at)}`).toBe(2)
+      expect(layout.positionAt(layout.cursorRow, layout.cursorColumn)).toBe(at)
+    }
+  })
+
+  it('moves up and down across wrapped rows and explicit newlines', () => {
+    const composer = new Composer()
+    composer.set('first line\nsecond line\nthird line')
+    const width = 80
+    const end = composer.position
+    expect(layoutComposer(composer, width, GUTTER).cursorRow).toBe(2)
+
+    expect(composer.moveUp(width, GUTTER)).toBe(true)
+    expect(layoutComposer(composer, width, GUTTER).cursorRow).toBe(1)
+    expect(composer.moveDown(width, GUTTER)).toBe(true)
+    expect(layoutComposer(composer, width, GUTTER).cursorRow).toBe(2)
+    expect(composer.position).toBe(end)
+  })
+
+  it('keeps a wide character off the row boundary and places by its columns', () => {
+    const composer = new Composer()
+    composer.set('标准标准标准')
+    // Four text columns after the gutter holds two wide characters per row.
+    const layout = layoutComposer(composer, 6, GUTTER)
+    expect(layout.rows).toEqual(['› 标准', '标准标', '准'])
+    expect(layout.cursorRow).toBe(2)
+    expect(layout.cursorColumn).toBe(2)
+  })
+
+  it('keeps an astral character whole across a wrap', () => {
+    const composer = new Composer()
+    composer.handle({ kind: 'paste', text: 'a🙂🙂b🙂cdef🙂gh' })
+    const width = 8
+    const layout = layoutComposer(composer, width, GUTTER)
+    expect(layout.positionAt(layout.cursorRow, layout.cursorColumn)).toBe(composer.position)
+    expect(composer.moveUp(width, GUTTER)).toBe(true)
+    expect(composer.value).toBe('a🙂🙂b🙂cdef🙂gh')
+    expect(composer.moveDown(width, GUTTER)).toBe(true)
+    expect(composer.position).toBe([...composer.value].length)
+  })
+
+  it('preserves the preferred display column through repeated movement', () => {
+    // One long line wraps at 10 text columns. The cursor starts partway along the
+    // first row; moving down and back up must re-apply the display column it left
+    // with rather than adopting the target row's own end.
+    const composer = new Composer()
+    composer.set('abcdefghijklmnopqrstuvwxy')
+    const width = 12
+    while (composer.position > 5) composer.handle({ kind: 'key', name: 'left' })
+    const first = layoutComposer(composer, width, GUTTER)
+    console.log(`PREF start at=${composer.position} first=(${first.cursorRow},${first.cursorColumn})`)
+    expect(first.positionAt(first.cursorRow, first.cursorColumn)).toBe(composer.position)
+
+    expect(composer.moveDown(width, GUTTER)).toBe(true)
+    const down = layoutComposer(composer, width, GUTTER)
+    console.log(`PREF down at=${composer.position} down=(${down.cursorRow},${down.cursorColumn})`)
+    expect(down.positionAt(down.cursorRow, down.cursorColumn)).toBe(composer.position)
+
+    // The display column the down move left with is what the up move aims at, so
+    // the cursor returns to the first row at that column — not to its own end.
+    expect(composer.moveUp(width, GUTTER)).toBe(true)
+    const back = layoutComposer(composer, width, GUTTER)
+    console.log(`PREF up at=${composer.position} back=(${back.cursorRow},${back.cursorColumn})`)
+    expect(back.cursorRow).toBe(0)
+    expect(back.cursorColumn).toBe(down.cursorColumn)
+    expect(back.positionAt(back.cursorRow, back.cursorColumn)).toBe(composer.position)
+  })
+
+  it('reaches the top row and the bottom row for every width', () => {
+    const composer = new Composer()
+    composer.handle({ kind: 'paste', text: '标 a🙂 第一 行 … second line that wraps' })
+    for (const width of [10, 14, 22]) {
+      while (composer.moveUp(width, GUTTER)) { /* climb */ }
+      expect(layoutComposer(composer, width, GUTTER).cursorRow, `${String(width)} wide`).toBe(0)
+      while (composer.moveDown(width, GUTTER)) { /* descend */ }
+      const bottom = layoutComposer(composer, width, GUTTER)
+      expect(bottom.cursorRow, `${String(width)} wide`).toBe(bottom.rows.length - 1)
+    }
+  })
+
+  it('keeps an exact-width final row reachable after moving away from it', () => {
+    for (const [text, width] of [['abcdefghij', 12], ['标准标准标', 6]] as const) {
+      const composer = new Composer()
+      composer.set(text)
+      const end = composer.position
+      expect(composer.moveUp(width, GUTTER), `${text} up`).toBe(true)
+      expect(composer.moveDown(width, GUTTER), `${text} down`).toBe(true)
+      expect(composer.position, `${text} position`).toBe(end)
+    }
+  })
+
+  it('is an exact inverse on a first row, where the gutter is non-empty', () => {
+    // The regression the reviewers found: `cursorColumn` counts the drawn gutter
+    // but `positionAt` did not subtract it, so they disagreed by two columns on
+    // every logical line's FIRST row and vertical movement drifted.
+    const composer = new Composer()
+    composer.set('abcdefghij\nsecond')
+    const width = 80
+    while (composer.position > 4) composer.handle({ kind: 'key', name: 'left' })
+    const layout = layoutComposer(composer, width, GUTTER)
+    expect(layout.cursorRow).toBe(0)
+    expect(layout.positionAt(layout.cursorRow, layout.cursorColumn)).toBe(4)
+    // And moving down by a row lands on the same drawn column, one row lower.
+    expect(composer.moveDown(width, GUTTER)).toBe(true)
+    const down = layoutComposer(composer, width, GUTTER)
+    expect(down.cursorRow).toBe(1)
+    expect(down.cursorColumn).toBe(layout.cursorColumn)
+    expect(down.positionAt(down.cursorRow, down.cursorColumn)).toBe(composer.position)
+  })
+
+  it('re-lays the same buffer when the width changes', () => {
+    const composer = new Composer()
+    composer.set('abcdefghijklmnopqrstuvwxyz')
+    const wide = layoutComposer(composer, 80, GUTTER)
+    const narrow = layoutComposer(composer, 10, GUTTER)
+    expect(wide.rows).toHaveLength(1)
+    expect(narrow.rows.length).toBeGreaterThan(1)
+    expect(narrow.positionAt(narrow.cursorRow, narrow.cursorColumn)).toBe(26)
+  })
+})

--- a/packages/renderer/tests/composer-scale.spec.ts
+++ b/packages/renderer/tests/composer-scale.spec.ts
@@ -16,6 +16,20 @@ import { layoutComposer } from '../src/composer-layout.ts'
 const GUTTER = (line: number): string => (line === 0 ? '› ' : '  ')
 
 /**
+ * Put the cursor at `offset` by marching there from the right with real moves.
+ * @param text - the draft.
+ * @param offset - the code-point offset to reach.
+ * @returns the composer, positioned.
+ */
+function cursorAt(text: string, offset: number): Composer {
+  const composer = new Composer()
+  composer.set(text)
+  expect(composer.position).toBe([...text].length)
+  while (composer.position > offset) composer.handle({ kind: 'key', name: 'left' })
+  return composer
+}
+
+/**
  * A composer that records how its whole-buffer getters are used.
  *
  * The layout is allowed to read `value` once and `position` once to take its
@@ -190,19 +204,16 @@ describe('layout across line structure', () => {
     const width = 12
     while (composer.position > 5) composer.handle({ kind: 'key', name: 'left' })
     const first = layoutComposer(composer, width, GUTTER)
-    console.log(`PREF start at=${composer.position} first=(${first.cursorRow},${first.cursorColumn})`)
     expect(first.positionAt(first.cursorRow, first.cursorColumn)).toBe(composer.position)
 
     expect(composer.moveDown(width, GUTTER)).toBe(true)
     const down = layoutComposer(composer, width, GUTTER)
-    console.log(`PREF down at=${composer.position} down=(${down.cursorRow},${down.cursorColumn})`)
     expect(down.positionAt(down.cursorRow, down.cursorColumn)).toBe(composer.position)
 
     // The display column the down move left with is what the up move aims at, so
     // the cursor returns to the first row at that column — not to its own end.
     expect(composer.moveUp(width, GUTTER)).toBe(true)
     const back = layoutComposer(composer, width, GUTTER)
-    console.log(`PREF up at=${composer.position} back=(${back.cursorRow},${back.cursorColumn})`)
     expect(back.cursorRow).toBe(0)
     expect(back.cursorColumn).toBe(down.cursorColumn)
     expect(back.positionAt(back.cursorRow, back.cursorColumn)).toBe(composer.position)
@@ -258,5 +269,95 @@ describe('layout across line structure', () => {
     expect(wide.rows).toHaveLength(1)
     expect(narrow.rows.length).toBeGreaterThan(1)
     expect(narrow.positionAt(narrow.cursorRow, narrow.cursorColumn)).toBe(26)
+  })
+})
+
+describe('the exact-width boundary before an explicit newline', () => {
+  it('keeps the position before the newline distinct from the one after it', () => {
+    // The first line's ten text columns exactly fill the width left by the
+    // two-column gutter. A cursor just BEFORE the newline used to roll onto the
+    // row that the next logical line then reused, so the advertised inverse
+    // returned 11 for a cursor at 10 — vertical movement could cross the newline.
+    const composer = cursorAt('abcdefghij\nx', 10)
+    expect(composer.position).toBe(10)
+    const layout = layoutComposer(composer, 12, GUTTER)
+    expect(layout.positionAt(layout.cursorRow, layout.cursorColumn)).toBe(composer.position)
+    // And the offset after the newline still maps to the row that holds it.
+    expect(layout.positionAt(layout.cursorRow + 1, 0)).toBe(11)
+  })
+
+  it('round-trips vertical movement without crossing the newline', () => {
+    const composer = cursorAt('abcdefghij\nx', 10)
+    expect(composer.moveDown(12, GUTTER)).toBe(true)
+    const down = layoutComposer(composer, 12, GUTTER)
+    expect(down.positionAt(down.cursorRow, down.cursorColumn)).toBe(composer.position)
+    expect(composer.moveUp(12, GUTTER)).toBe(true)
+    expect(composer.position).toBe(10)
+  })
+
+  it('keeps the boundary invertible when the row fills exactly by display width', () => {
+    // `› ` is two columns and each CJK glyph is two more, so the row holds exactly
+    // two glyphs and the cursor before the newline is at display column 6.
+    const composer = cursorAt('标准\nx', 2)
+    const layout = layoutComposer(composer, 6, GUTTER)
+    expect(layout.positionAt(layout.cursorRow, layout.cursorColumn)).toBe(2)
+    expect(layout.positionAt(layout.cursorRow + 1, 0)).toBe(3)
+  })
+
+  it('stays invertible around consecutive and empty newlines', () => {
+    for (const text of ['a\n\n\nb', 'ab\n\n', '\nx', 'a\nb\nc\n']) {
+      const cps = [...text]
+      for (let offset = 0; offset <= cps.length; offset += 1) {
+        const composer = new Composer()
+        composer.set(text)
+        while (composer.position > offset) composer.handle({ kind: 'key', name: 'left' })
+        const layout = layoutComposer(composer, 12, GUTTER)
+        expect(
+          layout.positionAt(layout.cursorRow, layout.cursorColumn),
+          `${JSON.stringify(text)} at ${String(offset)}`,
+        ).toBe(offset)
+      }
+    }
+  })
+})
+
+describe('the layout advertises an inverse for every reachable cursor offset', () => {
+  it('holds for every prefix and width over ASCII, CJK, astral, and newlines', () => {
+    // The probe the task asks for, strengthened for the boundary the old one
+    // missed: an exact-width row immediately before an explicit newline. Every
+    // offset of every prefix must map back to itself through the advertised
+    // (cursorRow, cursorColumn) pair, and the placement must own a real row.
+    const texts = [
+      '', 'x', '\n', 'abc\n', '\n\n',
+      'abcdefghij\nx',            // exact-width row, then a newline
+      'abcdefghijklmnopqrstuv',   // wraps with no newline
+      'abcdefghij\nabcdefghij\n', // two exact-width lines, trailing newline
+      '标准\nx',                   // exact width by display columns, then a newline
+      '标准标准标准',
+      '标准\n标准\n标准',
+      'a🙂🙂b🙂cdef🙂gh',
+      'ab\n\ncd\n',
+      'a\nb\nc',
+      Array.from({ length: 25 }, (_unused, i) => `line ${String(i)}`).join('\n'),
+    ]
+    let checked = 0
+    for (const text of texts) {
+      const cps = [...text]
+      for (let offset = 0; offset <= cps.length; offset += 1) {
+        for (const width of [4, 6, 8, 12, 20, 80]) {
+          const composer = cursorAt(text, offset)
+          const layout = layoutComposer(composer, width, GUTTER)
+          const label = `${JSON.stringify(text)} at ${String(offset)} width ${String(width)}`
+          expect(layout.cursorRow, label).toBeGreaterThanOrEqual(0)
+          expect(layout.cursorRow, label).toBeLessThan(layout.rows.length)
+          expect(
+            layout.positionAt(layout.cursorRow, layout.cursorColumn),
+            label,
+          ).toBe(offset)
+          checked += 1
+        }
+      }
+    }
+    expect(checked).toBeGreaterThan(1000)
   })
 })


### PR DESCRIPTION
## What this changes, and why

Pasting a large prompt made the composer unusable. A 5,000-line draft took **~2.7 s for a single layout**, and because one `↑` lays the buffer out three times (to move, to render, to place the cursor), **one arrow press took ~8.7 s**. A 220k-character single line was ~23 ms, so the cliff was multiline specifically.

Root cause, measured: the old `layoutComposer` iterated `composer.lines` and called whole-buffer derived getters *inside* that loop — `cursorLine` (a rescan), `lineBeforeCursor` (a rescan plus slice/join) — then joined `composer.value` again for the trailing-row check. Each is O(N), so a draft of L lines and N code points cost **O(N·L)**. A 50-line buffer did 51 full-buffer value joins via repeated composer.lines reads, 50 cursorLine rescans, and one lineBeforeCursor construction in one layout.

This replaces it with a single forward pass over one `[...composer.value]` snapshot plus one `composer.position`. As each code point arrives the pass builds the drawn row, its buffer start, and its gutter width; when it reaches the cursor's own character it records the cursor's row and column from the count accumulated there. Nothing whole-buffer is called inside the loop. It also (a) reuses one layout between `render()` and `cursor()` in the composer view, and (b) replaces the undirected `+37 rows` title with `↑ 14 ↓ 23`.

### Measured (median, same buffers, this machine)

| draft | op | before | after |
|---|---|---|---|
| 800 lines / 56k cp | 1 layout | 251.4 ms | 1.94 ms |
| 800 lines | arrow press | ~700 ms | 3.83 ms |
| 5,000 lines / 44k cp | 1 layout | 2,730.8 ms | 2.39 ms |
| 5,000 lines | arrow press | ~7,984 ms | 5.74 ms |
| 220k cp single line | 1 layout | 23.07 ms | 8.89 ms |
| 2,000 CJK/emoji lines | 1 layout | 2,150 ms | 3.41 ms |

The "before" arrow-press figures model the old flow's three layouts (the `Composer` class is bound to the current layout and cannot be re-pointed); the standalone layout rows are direct measurements of both implementations on identical text. The after figures are direct measurements.

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm test` pass — 3393 passed / 22 skipped / 0 failed
- [x] `pnpm security` passes — dependency audit + `lint:workflows` clean
- [x] `pnpm run verify-docs` passes — no bilingual pair touched
- [x] A changeset is included (`patch`, `@dshline/dshline`; the two packages are `fixed`, so it versions both)

## If this touches the terminal

- [x] Text is made safe **before** color is applied — no change to escaping; the title is painted per segment with the full reset, exactly as before
- [x] Every write goes through `Screen`; committed scrollback is not rewritten — no write path changed
- [x] Widths are measured in display columns, and every cut agrees with `displayWidth` — `cursorColumn`/`positionAt` are display-column space
- [x] No new `ctrl` shortcut
- [x] Checked at narrow widths (down to 1 column), the `live-region-bounds` matrix, and after resize

Terminal and OS this was run in: headless `@xterm/headless` frame tests only (no real PTY available in this environment) — see the caveat below.

## Correctness notes

Fixing cursor placement surfaced two latent coordinate bugs the old per-line shape had been hiding, both fixed with regression tests:

- `cursorColumn` and `positionAt` are now exact inverses in **drawn**-column space. `cursorColumn` counts the gutter (it is a terminal cell); `positionAt` subtracts the target row's own gutter (now on the row chunk) before walking its text. They previously disagreed by the prompt width on every logical line's first row.
- A cursor resting at a line start after an explicit newline is placed by the newline branch. It has no character of its own to trigger placement, so it stayed unplaced and the buffer-end fallback drew it on the **last** row.
- A logical line that fills its budget **exactly** and is followed by an explicit newline now gets an empty boundary row. The full row could not represent "immediately before the newline": `positionAt` on its end and on the next row's start were both the offset after the newline, so a cursor at 10 reported 11 and `↑` crossed the line. The boundary row is the same device the full *final* row already uses, placed between the two lines instead of after the last one.

No second editor state: `composer.ts` is unchanged; the view memo is derived-only and keyed on `(text, columns, cursor position)`.

## Tests

New `packages/renderer/tests/composer-scale.spec.ts` pins the pathological sizes and, instead of a wall-clock threshold, the structural property that a layout takes exactly one snapshot (`value` read once, `position` read once, no `lines`/`cursorLine`/`lineBeforeCursor`). Added view tests for growth, overflow-to-viewport, upward follow, bounded 3,000-line paste, and stale-layout protection after an edit and a resize.

A committed inverse probe walks every cursor offset of 15 drafts (empty, trailing newline, consecutive newlines, exact-width-before-newline, wide and astral characters, a 25-line document) at six widths, asserting `positionAt(cursorRow, cursorColumn) === offset` and that the placement owns a real row — 1,500+ cases. It is deliberately exhaustive at the boundary the first probe missed rather than a sample that happened to pass.

Seven deliberate mistakes were introduced, confirmed to fail a named test, and restored (the seventh being the boundary-row fix above): unbounded row cap; viewport not following upward; wide-character width error; stale layout after width change; history stealing `↑` before the top; stale layout after edit.

## Caveats (please weigh before merging)

1. **The final adversarial Codex review did not return.** Two independent reviews completed (performance and terminal architecture) and both found the gutter-coordinate blocker, now fixed. The third, adversarial pass hung and did not produce a report; I performed the adversarial verification directly (the committed inverse probe, seven deliberate mistakes, and the full suite) but that is not a substitute for the requested independent pass. A second reviewer should look before merge.
2. **No real-terminal manual check** was possible here — no Harness profile / PTY in this environment. The headless frame tests cover rendering; the task asked for a real-terminal run too.
3. The memo validates by joining `composer.value` (O(N)) each frame. It is a measured net win at these sizes, but a composer-owned revision counter would make validation O(1); not done because it adds a second invalidation mechanism for a constant factor.
4. `COMPOSER_ROWS` (10) is unchanged. `PageUp`/`PageDown` were considered and **not** added: the key decoder does not expose them, and inventing escape parsing in Dshline is out of scope.

## Scope

Changed: `packages/renderer/src/composer-layout.ts`, `packages/dshline/src/views.ts`, their focused tests, `packages/dshline/tests/timing-frames.spec.ts` (title text), new `composer-scale.spec.ts`, new changeset. Not changed: `composer.ts`, `input.ts`, `slots.ts`, `screen.ts`, `window.ts`, `COMPOSER_ROWS`, dependencies, Harness.
