### PR TITLE
fix(dshline): keep long-draft composer chrome width-stable

### DIFF
--- a/.changeset/long-composer-drafts-fast.md
+++ b/.changeset/long-composer-drafts-fast.md
@@ -9,4 +9,7 @@ per-line loop that re-derived the whole buffer for every line, which made a
 composer view also reuses one layout between its `render` and `cursor` calls, so
 a frame no longer wraps the draft twice. A draft still grows from one row to the
 same hard cap and then scrolls, and the frame title now names the direction of
-what is hidden (`↑ 27` / `↓ 4`) instead of a single `+N rows` count.
+what is hidden (`^ 27` / `v 4`) instead of a single `+N rows` count. The markers
+are ASCII because `↑`/`↓` are East Asian Ambiguous width: a terminal in an
+ambiguous-width mode advances two cells for them where Dshline measures one, so
+the top border wrapped and each redraw left the previous composer frame behind.

--- a/packages/dshline/src/views.ts
+++ b/packages/dshline/src/views.ts
@@ -253,12 +253,23 @@ export function createComposerView(
    *
    * The old title said only `+37 rows`, which cannot tell a reader whether the
    * cursor is near the start of a paste or stranded at its end — the two cases
-   * want opposite arrows. A direction is only named when there is something that
-   * way, so a draft scrolled to its top reads as the plain workspace name and
-   * `↑` visibly means history. The string is handed to `rootFrame`, whose border
-   * arithmetic truncates from the RIGHT, so `↑` is written first: the upward
-   * direction is the one that falls through to history, and it is the reading a
-   * narrow terminal can least afford to lose. Both are shown whenever they fit.
+   * want opposite directions. A direction is only named when there is something
+   * that way, so a draft scrolled to its top reads as the plain workspace name
+   * and `^` visibly means history. The string is handed to `rootFrame`, whose
+   * border arithmetic truncates from the RIGHT, so `^` is written first: the
+   * upward direction is the one that falls through to history, and it is the
+   * reading a narrow terminal can least afford to lose. Both are shown whenever
+   * they fit.
+   *
+   * The markers are ASCII on purpose, not the `↑`/`↓` arrows they replaced.
+   * Those are East Asian Ambiguous width: Dshline measures each as one column,
+   * but a terminal in an ambiguous-width mode advances two, so a title with
+   * both made the top border one physical row taller than the live region
+   * modeled. `Screen` climbs by the rows it drew, so the wrapped row survived
+   * the next erase and every `↑`/`↓` press left another top border behind. A
+   * chrome label is not worth changing the renderer's global width policy for
+   * box drawing and punctuation, so the presentation chooses glyphs whose
+   * width is unambiguous instead.
    * @param hiddenAbove - rows scrolled off the top of the viewport.
    * @param hiddenBelow - rows the viewport does not reach beneath it.
    * @returns the painted title for the frame's top border.
@@ -266,8 +277,8 @@ export function createComposerView(
   const frameTitle = (hiddenAbove: number, hiddenBelow: number): string => {
     const label = paint(escapedLabel, 'composer-title')
     const parts: string[] = []
-    if (hiddenAbove > 0) parts.push(`↑ ${String(hiddenAbove)}`)
-    if (hiddenBelow > 0) parts.push(`↓ ${String(hiddenBelow)}`)
+    if (hiddenAbove > 0) parts.push(`^ ${String(hiddenAbove)}`)
+    if (hiddenBelow > 0) parts.push(`v ${String(hiddenBelow)}`)
     if (parts.length === 0) return label
     return `${label} ${paint(parts.join(' '), 'muted')}`
   }

--- a/packages/dshline/tests/composer-live-region.spec.ts
+++ b/packages/dshline/tests/composer-live-region.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import { Composer, Screen, stripAnsi } from '@dshline/renderer'
+import { createEmulator } from '../../../tests/emulator.ts'
+import { composerGutter, composerInner, createComposerView } from '../src/views.ts'
+
+/**
+ * Regression coverage for PR #201's live-region geometry.
+ *
+ * The composer's dynamic frame title is CHROME: it is drawn and erased inside
+ * the bounded live region, so its physical width must equal the width the
+ * renderer measured. A glyph the terminal advances more cells for than
+ * `displayWidth` does makes the top border wrap, and a wrapped row before the
+ * cursor shifts every row below it — so `Screen.eraseLive` no longer reaches
+ * the row it drew and the PREVIOUS frame survives. These tests run a real
+ * `Screen` against a real `@xterm/headless` terminal whose width provider
+ * deliberately widens the markers, which is the only way a headless test can
+ * see that class of bug at all.
+ */
+
+/** Width wide enough for a normal composer and its title. */
+const COLUMNS = 40
+
+/**
+ * The code points a terminal in ambiguous-width mode might widen. Dshline
+ * measures both as one column, so a frame that uses them is only safe where
+ * the terminal agrees.
+ */
+const DIRECTIONAL_ARROWS = [0x2191, 0x2193] as const
+
+/**
+ * A draft long enough that the composer viewport scrolls: 30 logical lines
+ * against a ten-row viewport, so a moved cursor hides rows on both sides.
+ * @returns the composer, cursor at the end.
+ */
+function longDraft(): Composer {
+  const composer = new Composer()
+  composer.handle({ kind: 'paste', text: Array.from({ length: 30 }, (_, i) => `draft ${String(i).padStart(2, '0')}`).join('\n') })
+  return composer
+}
+
+/**
+ * Move the cursor one visual row, exactly as the input router does.
+ * @param composer - the draft to move within.
+ * @param direction - -1 for `↑`, +1 for `↓`.
+ * @returns whether the composer moved.
+ */
+function step(composer: Composer, direction: 1 | -1): boolean {
+  const width = composerInner(COLUMNS)
+  const gutter = (line: number): string => composerGutter(line, COLUMNS)
+  return direction < 0 ? composer.moveUp(width, gutter) : composer.moveDown(width, gutter)
+}
+
+describe('the composer live region on a terminal that widens the title markers', () => {
+  it('leaves no stale top border when the frame is the whole region', async () => {
+    // Four rows is below the separator's reservation, so the frame's own top
+    // border is the first row the region draws — the case where a wrapped
+    // border is left behind instead of a blank separator, exactly the
+    // accumulated `╭─ dshline …` rows the regression reported.
+    const emulator = createEmulator(COLUMNS, 4, { wideCodePoints: DIRECTIONAL_ARROWS })
+    const screen = new Screen(emulator.target)
+    const composer = longDraft()
+    const view = createComposerView(composer, '/w/repo')
+    const redraw = (): void => {
+      screen.setLive(view.render(COLUMNS, 4), view.cursor?.(COLUMNS, 4))
+    }
+
+    redraw()
+    for (let i = 0; i < 6; i += 1) {
+      expect(step(composer, -1)).toBe(true)
+      redraw()
+    }
+    for (let i = 0; i < 6; i += 1) {
+      expect(step(composer, 1)).toBe(true)
+      redraw()
+    }
+
+    const history = await emulator.scrollback()
+    // One current frame. A second `╭─` row is a previous frame the erase
+    // missed, which is the failure this test exists for.
+    expect(history.filter(row => row.includes('╭─'))).toHaveLength(1)
+    // The bounded live region was not exceeded by the redraws.
+    expect(screen.height).toBeLessThanOrEqual(4)
+    emulator.dispose()
+  })
+
+  it('does not drift the live region down one row per redraw', async () => {
+    // On a full-height terminal the separator absorbs the first wrapped row
+    // instead of the border, but the region still walks down a row per redraw
+    // and eventually scrolls committed output. Redrawing the same composer
+    // states must therefore return the buffer to exactly where it started.
+    const emulator = createEmulator(COLUMNS, 24, { wideCodePoints: DIRECTIONAL_ARROWS })
+    const screen = new Screen(emulator.target)
+    const composer = longDraft()
+    const view = createComposerView(composer, '/w/repo')
+    const redraw = (): void => {
+      screen.setLive(view.render(COLUMNS, 24), view.cursor?.(COLUMNS, 24))
+    }
+
+    redraw()
+    const before = await emulator.scrollback()
+    for (let i = 0; i < 6; i += 1) {
+      expect(step(composer, -1)).toBe(true)
+      redraw()
+    }
+    for (let i = 0; i < 6; i += 1) {
+      expect(step(composer, 1)).toBe(true)
+      redraw()
+    }
+    const after = await emulator.scrollback()
+    expect(after).toEqual(before)
+    expect(after.filter(row => row.includes('╭─'))).toHaveLength(1)
+    emulator.dispose()
+  })
+
+  it('names both hidden directions with width-stable ASCII markers', () => {
+    // A focused policy check beside the end-to-end one: the dynamic chrome may
+    // use any glyph whose width Dshline and the terminal agree on, and for the
+    // direction markers that means ASCII. `stripAnsi` leaves only the visible
+    // title, so this fails by name if the Unicode arrows come back.
+    const composer = longDraft()
+    for (let i = 0; i < 10; i += 1) expect(step(composer, -1)).toBe(true)
+    const view = createComposerView(composer, '/w/repo')
+    const top = stripAnsi(view.render(COLUMNS, 24)[1] ?? '')
+    expect(top).toMatch(/\^ \d+/)
+    expect(top).toMatch(/v \d+/)
+    // The whole arrow block is ambiguous width; none of it belongs in chrome
+    // whose row accounting must be exact.
+    expect(top).not.toMatch(/[\u2190-\u21ff]/u)
+  })
+})

--- a/packages/dshline/tests/timing-frames.spec.ts
+++ b/packages/dshline/tests/timing-frames.spec.ts
@@ -298,8 +298,8 @@ describe('the timing live panel on a real terminal', () => {
     expect(frame.screen.height).toBeLessThanOrEqual(5)
     const joined = (await visible(frame.emulator)).join('\n')
     // Scrolled, not lost: the elision count names the direction the window gave
-    // up, so a reader knows `↑` reaches the rest of the paste.
-    expect(joined).toContain('↑ 29')
+    // up, so a reader knows `^` reaches the rest of the paste.
+    expect(joined).toContain('^ 29')
     expect(joined).toContain('no turn measured yet')
     expect(joined).toContain('ready')
   })

--- a/packages/dshline/tests/views.spec.ts
+++ b/packages/dshline/tests/views.spec.ts
@@ -165,11 +165,11 @@ describe('a composer taller than the terminal', () => {
     const { cursor, rows } = await drawn(composer)
     // The cursor is at the end, so the end is what is shown, and the title names
     // the DIRECTION of what is hidden rather than a bare count: a reader can tell
-    // they are at the bottom and that `↑` reaches the rest.
+    // they are at the bottom and that `^` reaches the rest.
     expect(rows.join('\n')).toContain('line 39')
     expect(rows.join('\n')).not.toContain('line 0 ')
-    expect(rows[1]).toContain('↑ 30')
-    expect(rows[1]).not.toContain('↓')
+    expect(rows[1]).toContain('^ 30')
+    expect(rows[1]).not.toContain('v ')
     expect(cursor.row).toBeGreaterThan(0)
     expect(cursor.row).toBeLessThan(rows.length)
   })
@@ -216,8 +216,8 @@ describe('a composer taller than the terminal', () => {
     expect(rows.join('\n')).toContain('one')
     expect(rows.join('\n')).toContain('three')
     // Nothing is hidden, so there is no direction to report.
-    expect(rows[1]).not.toContain('↑')
-    expect(rows[1]).not.toContain('↓')
+    expect(rows[1]).not.toContain('^ ')
+    expect(rows[1]).not.toContain('v ')
   })
 })
 

--- a/tests/emulator.ts
+++ b/tests/emulator.ts
@@ -27,6 +27,19 @@ interface XtermCell {
   isBold(): number
 }
 
+/**
+ * One Unicode width provider, as xterm accepts it.
+ *
+ * `charProperties` packs the width into the value xterm actually lays cells out
+ * from, and `wcwidth` is the same answer in the form the width helpers read;
+ * both must agree.
+ */
+interface XtermUnicodeProvider {
+  readonly version: string
+  wcwidth(codePoint: number): 0 | 1 | 2
+  charProperties(codePoint: number, preceding: number): number
+}
+
 /** The slice of xterm's API these tests use. */
 interface XtermLike {
   readonly rows: number
@@ -42,7 +55,28 @@ interface XtermLike {
   }
   write(data: string, callback: () => void): void
   resize(columns: number, rows: number): void
+  readonly unicode: {
+    register(provider: XtermUnicodeProvider): void
+    activeVersion: string
+  }
   dispose(): void
+}
+
+/** What a terminal under test does differently from Dshline's width model. */
+export interface EmulatorOptions {
+  /**
+   * Code points this terminal advances TWO cells for while Dshline's
+   * `codePointWidth` measures them as one.
+   *
+   * A real terminal in an ambiguous-width mode widens the glyphs beside the
+   * ones the Unicode East Asian Width property leaves ambiguous, and Dshline
+   * deliberately keeps its own model for the narrow case. Reproducing that
+   * disagreement is the only way to test what a width-critical presentation
+   * must avoid: everything else about this provider is the narrow default, so
+   * the ONLY difference from the terminal the rest of the suite uses is the
+   * listed code points.
+   */
+  readonly wideCodePoints?: readonly number[]
 }
 
 /** Where the terminal left its cursor, in zero-based cells. */
@@ -105,10 +139,33 @@ export interface Emulator {
  * Create an emulator of `columns` by `rows`.
  * @param columns - terminal width.
  * @param rows - terminal height.
+ * @param options - terminal behaviours this test needs to differ from the
+ *   narrow default; omitting them leaves every other spec unchanged.
  * @returns the emulator and its screen target.
  */
-export function createEmulator(columns: number, rows = 24): Emulator {
+export function createEmulator(columns: number, rows = 24, options: EmulatorOptions = {}): Emulator {
   const term = new Terminal({ cols: columns, rows, allowProposedApi: true })
+  const wideCodePoints = new Set(options.wideCodePoints ?? [])
+  if (wideCodePoints.size > 0) {
+    // Replace xterm's width provider ONLY when a test asked for a disagreeing
+    // terminal, so no existing spec's geometry can move. Non-listed code points
+    // keep the narrow answer every other test already relies on: controls take
+    // no cell, everything else one. That is enough for chrome made of ASCII and
+    // box-drawing glyphs, which is all a composer frame is.
+    const widthOf = (codePoint: number): 0 | 1 | 2 => {
+      if (wideCodePoints.has(codePoint)) return 2
+      return codePoint < 0x20 || (codePoint >= 0x7f && codePoint < 0xa0) ? 0 : 1
+    }
+    term.unicode.register({
+      version: 'dshline-test-ambiguous-wide',
+      wcwidth: widthOf,
+      // xterm lays cells out from the packed property, not from `wcwidth`, so
+      // both must carry the same width. The packed shape is xterm's own:
+      // codepoint << 3 | width << 1 | join-flag.
+      charProperties: codePoint => (((codePoint & 0xffffff) << 3) | (widthOf(codePoint) << 1)) >>> 0,
+    })
+    term.unicode.activeVersion = 'dshline-test-ambiguous-wide'
+  }
   // Tracked alongside the terminal so `target.columns()` answers with what the
   // renderer would read from a real terminal after a resize.
   let width = columns


### PR DESCRIPTION
Fixes the live-region regression introduced by #201.

## What a user saw

With a long pasted draft open, repeatedly pressing `↑`/`↓` left old composer top borders stacked on screen, and the live region drifted down a row per redraw until it scrolled committed output.

## Root cause

#201 replaced the ASCII `+N rows` title with `↑ N` / `↓ M`. `U+2191`/`U+2193` are East Asian **Ambiguous** width: `displayWidth()` measures each as one column, but a terminal in an ambiguous-width mode advances two. A title carrying both markers measured `composerFrameWidth(columns) = columns − 1` and drew `columns + 1`, so the top border **physically wrapped one row** while `Screen` still modeled the region as one row shorter. `eraseLive()` climbs by the rows it drew, so it no longer reached the region's first physical row — leaving the previous frame behind and drifting the region.

The single-pass layout (`f8af808`), the render/cursor memo, and the boundary-row fix (`20b9ad8`) were each ruled out by toggling them independently.

## Fix

Presentation layer only (`packages/dshline/src/views.ts`): the direction markers are ASCII `^` / `v`, whose width is unambiguous. Directional information is retained.

Global `displayWidth()` / wcwidth policy is intentionally unchanged — treating every East Asian Ambiguous character as two columns would move geometry for box-drawing, punctuation, and every terminal that keeps ambiguous width narrow, to correct one chrome label.

Not touched: `composer-layout.ts`, `Composer`, `Screen`, `TuiSlots`, `COMPOSER_ROWS`, the memo, input routing, Harness.

## Regression coverage

`packages/dshline/tests/composer-live-region.spec.ts` drives a real `Screen` into `@xterm/headless` and repeats `↑`/`↓` over a 30-line draft, redrawing after every move. `tests/emulator.ts` gained an opt-in `wideCodePoints` Unicode provider so the test can reproduce the exact mismatch (it widens only U+2191/U+2193). The test asserts exactly one composer top border remains, that the buffer does not drift, and that the dynamic title uses only width-stable ASCII markers.

Restoring `↑`/`↓` makes all three tests fail for the intended reason (12 stale borders).

## Verification

- Focused: `composer-live-region`, `views`, `timing-frames`, `live-region-bounds`, `visual-root-frames`, `narrow-root`, `streaming-frames`, `screen`, `composer-layout`, `composer-scale` — 212 passed.
- Full suite: 3401 passed, 22 skipped, 0 failed.
- `pnpm build`, `pnpm typecheck`, `pnpm security`, `pnpm verify-docs` — all green.
- `git diff main...HEAD` contains exactly the six intended files and does not reintroduce any #201 implementation.
