### PR TITLE
feat(dshline): add Harness-native subagent conversations

### DIFF
--- a/.changeset/subagent-conversations.md
+++ b/.changeset/subagent-conversations.md
@@ -12,7 +12,7 @@ paging older history replaces the window instead of accumulating. A continuable
 child can receive a human follow-up (`m`, queued) or steer (`s`), both through
 Harness's human prompt operation; the message composer scrolls with its cursor
 like the main input. Interrupt stays on `/work`, where an open lifecycle epoch
-proves a turn exists — a durable child's residency is not that proof. A one-shot
+is the stronger premise — a durable child's residency is not proof of a turn. A one-shot
 child is inspectable and read-only, diagnostics are shown honestly, and a profile
 without `ctx.subagents` or `ctx.sessionQuery` still boots with the actions
 unavailable.

--- a/.changeset/subagent-conversations.md
+++ b/.changeset/subagent-conversations.md
@@ -7,9 +7,12 @@ conversation view (`c`, or `/subagents`) built on Harness's durable direct-child
 discovery rather than active lifecycle epochs, so a continuable child stays
 browsable and continuable after its current turn settles. Opening a child reads
 its own session log through `ctx.sessionQuery` without resuming it and renders a
-bounded, paged conversation. A continuable child can receive a human follow-up
-(`m`, queued) or steer (`s`), both through Harness's human prompt operation, and
-an interrupt (`k`) through the same adapter `/work` already used. A one-shot
-child is inspectable and read-only, diagnostics are shown honestly, and a
-profile without `ctx.subagents` or `ctx.sessionQuery` still boots with the
-actions unavailable.
+bounded conversation that retains one page of full event bodies at a time;
+paging older history replaces the window instead of accumulating. A continuable
+child can receive a human follow-up (`m`, queued) or steer (`s`), both through
+Harness's human prompt operation; the message composer scrolls with its cursor
+like the main input. Interrupt stays on `/work`, where an open lifecycle epoch
+proves a turn exists — a durable child's residency is not that proof. A one-shot
+child is inspectable and read-only, diagnostics are shown honestly, and a profile
+without `ctx.subagents` or `ctx.sessionQuery` still boots with the actions
+unavailable.

--- a/.changeset/subagent-conversations.md
+++ b/.changeset/subagent-conversations.md
@@ -1,0 +1,15 @@
+---
+'@dshline/dshline': minor
+---
+
+Add durable subagent conversations. `/work` now hands off to a separate subagent
+conversation view (`c`, or `/subagents`) built on Harness's durable direct-child
+discovery rather than active lifecycle epochs, so a continuable child stays
+browsable and continuable after its current turn settles. Opening a child reads
+its own session log through `ctx.sessionQuery` without resuming it and renders a
+bounded, paged conversation. A continuable child can receive a human follow-up
+(`m`, queued) or steer (`s`), both through Harness's human prompt operation, and
+an interrupt (`k`) through the same adapter `/work` already used. A one-shot
+child is inspectable and read-only, diagnostics are shown honestly, and a
+profile without `ctx.subagents` or `ctx.sessionQuery` still boots with the
+actions unavailable.

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write README.md
-README.md: 2b95bd52bc6e3de65db0fffbbbe77dd21123ebdd
-README.zh.md: 255e3080c57eb373d75138343aeac78b00d97021
+README.md: 01ac209c053666a19b698b2dcc019ffc5c94c152
+README.zh.md: 31b614fb483decd7469dc3d64f4d7084dc8e8f75

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Type `/` to discover the commands and capabilities available in the active Harne
 - `/sessions` — browse and resume Harness sessions
 - `/worktrees` — choose a working directory represented in your Harness session history, then a conversation there or a new one
 - `/work` — inspect workflows, subagents, and jobs
+- `/subagents` — browse this session's durable subagent conversations, inspect one, and continue a continuable child; also reachable with `c` from `/work`
 - `/connect` — configure providers through Harness
 - `/plugins` — browse, search, and customize the running agent's Harness preset composition
 - `/profiles` — browse Harness profiles and the bundles each one composes; install, update, or remove one

--- a/README.zh.md
+++ b/README.zh.md
@@ -71,6 +71,7 @@ dshline 通过标准 Harness 能力进行集成，而不是编写提供方专用
 - `/sessions` — 浏览并恢复 Harness 会话
 - `/worktrees` — 选择你的 Harness 会话历史中有代表的工作目录，然后选择那里的一场对话或开一场新的
 - `/work` — 查看工作流、subagent 与任务
+- `/subagents` — 浏览本会话持久的 subagent 对话、检视其中一个，并继续一个 continuable 子级；也可以在 `/work` 中按 `c` 进入
 - `/connect` — 通过 Harness 配置提供方
 - `/plugins` — 浏览、搜索并定制运行中 agent 的 Harness 预设组合
 - `/profiles` — 浏览 Harness 配置文件及各自组合的 bundle；安装、更新或移除其中之一

--- a/docs/architecture.i18n.yaml
+++ b/docs/architecture.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/architecture.md
-architecture.md: 108bb2e23f6d2e20f8cda982c849bead97edf905
-architecture.zh.md: 4503cc5b0e89f5ba84156c5b9e844fe8ca26bd69
+architecture.md: 28ff5b54dae85148cd3acb8c8527fb65195f629d
+architecture.zh.md: d2cc3415b039d6b709713cc379cde967b28722cc

--- a/docs/architecture.i18n.yaml
+++ b/docs/architecture.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/architecture.md
-architecture.md: 28ff5b54dae85148cd3acb8c8527fb65195f629d
-architecture.zh.md: d2cc3415b039d6b709713cc379cde967b28722cc
+architecture.md: 3ddcf227904d8394f04000a8938141a741ea8b84
+architecture.zh.md: b5c0ced998d413920aa35cfd7027e66ab921f3ae

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -400,6 +400,53 @@ contracts, not a direct dshline integration. Claude Code through
 logical next target, but has not been manually validated. The required path for
 both and future providers is documented in [Provider acceptance](provider-acceptance.md).
 
+## Durable subagent conversations: the fourth adapter
+
+Work represents **open lifecycle epochs**. A continuable subagent is also a
+durable conversation, and the important case is exactly the one an epoch cannot
+show: the child finishes its current turn, its epoch ends, and the user still
+wants to inspect it and send another instruction. Folding that into `HarnessWork`
+would also make `activeWorkCount()` — which gates retiring a session — treat a
+settled child as active work.
+
+So `/subagents` is a second, narrow adapter with its own presenter, keyed by the
+**durable child session id** rather than a lifecycle `runId`:
+
+```
+ctx.subagents.listChildren   → durable direct-child catalog
+ctx.sessionQuery             → one child's bounded session window (no resume)
+ctx.subagents.prompt         → human queue / steer
+ctx.subagents.interrupt      → human interrupt (via HarnessWork.interruptSubagent)
+```
+
+Discovery is `listChildren(parentSessionId)`, whose rows are Harness facts:
+durable id, label, `one-shot` versus `continuable`, session-store residency, and
+whether the child has children. A diagnostic row is kept rather than dropped, so
+a corrupt or unreadable candidate degrades honestly. Opening a child reads its
+own log through `ctx.sessionQuery.listEvents` and a bounded `readEvent` window and
+renders each event with Harness's `extractSessionEventText`; the child is never
+resumed or published to inspect it, and moving the cursor never reads a
+transcript.
+
+A human follow-up is the one place this frontend must be careful about which
+Harness operation it calls. `SubagentRuntime.sendMessage(sender: Agent, …)` is
+**model-authored** adjacent-Agent messaging: it takes an exact live `Agent`
+sender and stamps `agent-message` provenance, so a terminal calling it would
+impersonate the parent Agent. The human path is `ctx.subagents.prompt`, which
+carries a durable parent/child address, a client-minted request identity, human
+`kind: 'user'` provenance, the `queue`/`steer` choice, cold materialization, and
+an accepted `MessageId` receipt. dshline's `HumanSubagentSeam` is a `Pick` of
+`SubagentRuntime` with only `listChildren` and `prompt`, so reaching for
+`sendMessage` fails type-check rather than shipping; a comment- and string-aware
+source scan backstops that against a cast.
+
+Acceptance is Harness's, so the field's `queue` and `steer` mean exactly what
+Harness defines: a queued later turn, or the nearest step (starting a turn when
+the child is idle). The terminal inserts no optimistic row — the message appears
+in the child's transcript only when its own session log records it — and
+interruption routes through the same `HarnessWork.interruptSubagent` adapter the
+active view uses, so there is one human authorization path rather than two.
+
 ## Sessions: one corpus, and two lifetimes
 
 Sessions is the third adapter, and it reads exactly one authority. `ctx.sessionQuery`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -416,17 +416,18 @@ So `/subagents` is a second, narrow adapter with its own presenter, keyed by the
 ctx.subagents.listChildren   → durable direct-child catalog
 ctx.sessionQuery             → one child's bounded session window (no resume)
 ctx.subagents.prompt         → human queue / steer
-ctx.subagents.interrupt      → human interrupt (via HarnessWork.interruptSubagent)
 ```
 
 Discovery is `listChildren(parentSessionId)`, whose rows are Harness facts:
 durable id, label, `one-shot` versus `continuable`, session-store residency, and
 whether the child has children. A diagnostic row is kept rather than dropped, so
 a corrupt or unreadable candidate degrades honestly. Opening a child reads its
-own log through `ctx.sessionQuery.listEvents` and a bounded `readEvent` window and
-renders each event with Harness's `extractSessionEventText`; the child is never
-resumed or published to inspect it, and moving the cursor never reads a
-transcript.
+own log through `ctx.sessionQuery.listEvents` and one bounded `readEvent` window
+and renders each event with Harness's `extractSessionEventText`; the child is
+never resumed or published to inspect it, and moving the cursor never reads a
+transcript. Paging older history **replaces** that window rather than appending
+to it, so the inspector holds at most one page of full event bodies no matter how
+far the reader walks back; the lightweight seq index is metadata, not bodies.
 
 A human follow-up is the one place this frontend must be careful about which
 Harness operation it calls. `SubagentRuntime.sendMessage(sender: Agent, …)` is
@@ -443,9 +444,14 @@ source scan backstops that against a cast.
 Acceptance is Harness's, so the field's `queue` and `steer` mean exactly what
 Harness defines: a queued later turn, or the nearest step (starting a turn when
 the child is idle). The terminal inserts no optimistic row — the message appears
-in the child's transcript only when its own session log records it — and
-interruption routes through the same `HarnessWork.interruptSubagent` adapter the
-active view uses, so there is one human authorization path rather than two.
+in the child's transcript only when its own session log records it.
+
+The durable inspector deliberately offers **no interrupt**. `listChildren()`
+reports session-store residency, not proof that a turn is executing, and
+Harness's `interrupt()` treats an absent or already-settled target as an
+accepted no-op; offering the action here could therefore claim a cancellation
+that never happened. Interrupt stays on `/work`, where an open lifecycle epoch
+is the stronger premise, and through its existing human adapter.
 
 ## Sessions: one corpus, and two lifetimes
 

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -234,14 +234,15 @@ Work 呈现的是**开放的生命周期 epoch**。一个 continuable subagent �
 ctx.subagents.listChildren   → durable direct-child catalog
 ctx.sessionQuery             → one child's bounded session window (no resume)
 ctx.subagents.prompt         → human queue / steer
-ctx.subagents.interrupt      → human interrupt (via HarnessWork.interruptSubagent)
 ```
 
-发现使用 `listChildren(parentSessionId)`，其行都是 Harness 事实：持久 id、label、`one-shot` 还是 `continuable`、会话存储驻留状态，以及该子级是否有子级。diagnostic 行被保留而非丢弃，因此损坏或不可读的候选会诚实降级。打开一个子级会通过 `ctx.sessionQuery.listEvents` 与一个有界的 `readEvent` 窗口读取它自己的日志，并用 Harness 的 `extractSessionEventText` 呈现每个事件；为了检视它，子级绝不会被恢复或发布，移动光标也绝不会读取 transcript。
+发现使用 `listChildren(parentSessionId)`，其行都是 Harness 事实：持久 id、label、`one-shot` 还是 `continuable`、会话存储驻留状态，以及该子级是否有子级。diagnostic 行被保留而非丢弃，因此损坏或不可读的候选会诚实降级。打开一个子级会通过 `ctx.sessionQuery.listEvents` 与一个有界的 `readEvent` 窗口读取它自己的日志，并用 Harness 的 `extractSessionEventText` 呈现每个事件；为了检视它，子级绝不会被恢复或发布，移动光标也绝不会读取 transcript。向前翻页会**替换**该窗口而不是向其追加，因此无论读者回溯多远，检视器最多只保留一页完整事件正文；轻量级的 seq 索引是元数据，不是正文。
 
 人类跟进是本前端必须谨慎选择调用哪个 Harness 操作的唯一之处。`SubagentRuntime.sendMessage(sender: Agent, …)` 是**模型撰写**的相邻 Agent 消息：它接受一个精确的存活 `Agent` 发送者并打上 `agent-message` 来源，所以终端调用它就是在冒充父 Agent。人类路径是 `ctx.subagents.prompt`，它携带持久的父/子地址、由客户端铸造的请求身份、人类 `kind: 'user'` 来源、`queue`/`steer` 选择、冷物化，以及一条被接受的 `MessageId` 回执。dshline 的 `HumanSubagentSeam` 是 `SubagentRuntime` 的一个只含 `listChildren` 与 `prompt` 的 `Pick`，因此伸手去拿 `sendMessage` 会在类型检查阶段失败，而不是被发布出去；一个能识别注释与字符串的源码扫描则为绕过类型转换提供兜底。
 
-接受与否由 Harness 决定，因此 `queue` 与 `steer` 的含义正是 Harness 定义的那样：排入稍后的一轮，或瞄准最近的 step（子级空闲时启动一轮）。终端不插入任何乐观行——消息只有当子级自己的会话日志记录它时才出现在其 transcript 中——而中断经由活动视图所用的同一个 `HarnessWork.interruptSubagent` 适配器，因此人类授权路径只有一条而不是两条。
+接受与否由 Harness 决定，因此 `queue` 与 `steer` 的含义正是 Harness 定义的那样：排入稍后的一轮，或瞄准最近的 step（子级空闲时启动一轮）。终端不插入任何乐观行——消息只有当子级自己的会话日志记录它时才出现在其 transcript 中。
+
+持久检视器刻意**不提供中断**。`listChildren()` 报告的是会话存储驻留状态，而不是某一轮正在执行的证明；Harness 的 `interrupt()` 会把不存在或已结算的目标当作被接受的空操作，因此在这里提供该动作可能宣称一次从未发生的中断。中断保留在 `/work`，那里有一个开放的生命周期 epoch 作为更强的前提，并经由其既有的人类适配器执行。
 
 ## Sessions：一个语料库，两个生命周期
 

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -224,6 +224,25 @@ tool-workflow/* + workflow/*    → Workflows
 
 人工验证的 Codex 提供方是这些通用约定的验收证明，而不是直接的 dshline 集成。通过 `@deepseek-ai/dsh-subagent-claude-code`、`ctx.subagents` 与 `ctx.jobs` 的 Claude Code 是合乎逻辑的下一个目标，但尚未人工验证。两者以及未来提供方的必需路径记录在 [Provider 验收](provider-acceptance.md)。
 
+## 持久 subagent 对话：第四个适配器
+
+Work 呈现的是**开放的生命周期 epoch**。一个 continuable subagent 同时是一场持久对话，而最重要的情形恰恰是 epoch 无法展示的那一个：子级完成当前轮次、它的 epoch 结束，而用户仍想检视它并再发一条指令。把它塞进 `HarnessWork` 还会让 `activeWorkCount()`——那个决定能否让会话退役的闸门——把一个已结算的子级当作活动工作。
+
+因此 `/subagents` 是第二个窄适配器，拥有自己的 presenter，并以**持久子级会话 id** 而非生命周期 `runId` 为键：
+
+```
+ctx.subagents.listChildren   → durable direct-child catalog
+ctx.sessionQuery             → one child's bounded session window (no resume)
+ctx.subagents.prompt         → human queue / steer
+ctx.subagents.interrupt      → human interrupt (via HarnessWork.interruptSubagent)
+```
+
+发现使用 `listChildren(parentSessionId)`，其行都是 Harness 事实：持久 id、label、`one-shot` 还是 `continuable`、会话存储驻留状态，以及该子级是否有子级。diagnostic 行被保留而非丢弃，因此损坏或不可读的候选会诚实降级。打开一个子级会通过 `ctx.sessionQuery.listEvents` 与一个有界的 `readEvent` 窗口读取它自己的日志，并用 Harness 的 `extractSessionEventText` 呈现每个事件；为了检视它，子级绝不会被恢复或发布，移动光标也绝不会读取 transcript。
+
+人类跟进是本前端必须谨慎选择调用哪个 Harness 操作的唯一之处。`SubagentRuntime.sendMessage(sender: Agent, …)` 是**模型撰写**的相邻 Agent 消息：它接受一个精确的存活 `Agent` 发送者并打上 `agent-message` 来源，所以终端调用它就是在冒充父 Agent。人类路径是 `ctx.subagents.prompt`，它携带持久的父/子地址、由客户端铸造的请求身份、人类 `kind: 'user'` 来源、`queue`/`steer` 选择、冷物化，以及一条被接受的 `MessageId` 回执。dshline 的 `HumanSubagentSeam` 是 `SubagentRuntime` 的一个只含 `listChildren` 与 `prompt` 的 `Pick`，因此伸手去拿 `sendMessage` 会在类型检查阶段失败，而不是被发布出去；一个能识别注释与字符串的源码扫描则为绕过类型转换提供兜底。
+
+接受与否由 Harness 决定，因此 `queue` 与 `steer` 的含义正是 Harness 定义的那样：排入稍后的一轮，或瞄准最近的 step（子级空闲时启动一轮）。终端不插入任何乐观行——消息只有当子级自己的会话日志记录它时才出现在其 transcript 中——而中断经由活动视图所用的同一个 `HarnessWork.interruptSubagent` 适配器，因此人类授权路径只有一条而不是两条。
+
 ## Sessions：一个语料库，两个生命周期
 
 Sessions 是第三个适配器，它只读取一个权威。`ctx.sessionQuery` 已经发布一个偏好活动的逻辑语料库，把 `ctx.sessions` 与任何已挂载的持久化合并，因此浏览器列出 `listSessions()` 记录，并用一次批量的 `readTitleSnapshots()` 观察折叠它们的标题。没有会话目录扫描、没有标题缓存、没有第二个索引；前端索引会在任一侧第一次变化时与语料库不一致。

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/usage.md
-usage.md: 884ea0a6efb51fdf90b6e72d3a29862cebfcbe2b
-usage.zh.md: a222f2cc4c5229d38753321528bffd8d9132d929
+usage.md: b3519799b6c96b80c8fa7e0f5d0b6403f62d8df7
+usage.zh.md: fa798a567eee4fd84410722d4dfdceee0138a670

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/usage.md
-usage.md: 90fff00debe609c923ad82085654776eff5a2337
-usage.zh.md: 97410cf363f9c58b05864ae630ecdcd175dfa3fd
+usage.md: 884ea0a6efb51fdf90b6e72d3a29862cebfcbe2b
+usage.zh.md: a222f2cc4c5229d38753321528bffd8d9132d929

--- a/docs/usage.i18n.yaml
+++ b/docs/usage.i18n.yaml
@@ -2,5 +2,5 @@
 # as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-docs --write docs/usage.md
-usage.md: b3519799b6c96b80c8fa7e0f5d0b6403f62d8df7
-usage.zh.md: fa798a567eee4fd84410722d4dfdceee0138a670
+usage.md: 6d48e665f58b804a69a969a453522e767588b444
+usage.zh.md: 616d43b463e0407ed51c7958f69f0db7e7579188

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,7 +121,7 @@ The search covers this session's input only: your prompts and slash commands, th
 
 A long or multiline prompt is previewed around the line that matched, rather than by its first line, so you can see why a result is in the list. Pressing `ctrl-r` while a session is still being reopened is fine: the search says the history is still loading, and whatever you have typed resolves against it the moment it lands.
 
-Reopening a session restores the history the saved log recorded: every prompt and every resolved slash command whose input was recorded. The commands this interface handles itself (`/image`, `/model`, `/reasoning`, `/usage`, `/timing`, `/enter`, `/new`, `/clear`, `/sessions`, `/worktrees`, `/work`, `/todos`, `/turns`, `/skills`, `/exit`, `/quit`) and mistyped commands are remembered while the session is open but are not written to the session log, so they are not restored after a resume.
+Reopening a session restores the history the saved log recorded: every prompt and every resolved slash command whose input was recorded. The commands this interface handles itself (`/image`, `/model`, `/reasoning`, `/usage`, `/timing`, `/enter`, `/new`, `/clear`, `/sessions`, `/worktrees`, `/work`, `/subagents`, `/todos`, `/turns`, `/skills`, `/exit`, `/quit`) and mistyped commands are remembered while the session is open but are not written to the session log, so they are not restored after a resume.
 
 ### Queue or steer
 
@@ -198,6 +198,7 @@ Type `/` to see the commands your agent actually has. They come from two places.
 | `/enter` | What plain `enter` does while a turn is running: `queue` or `steer`; bare asks. See [Queue or steer](#queue-or-steer) |
 | `/theme` | Choose the colour palette. Takes a name (`/theme ember`) or opens a picker |
 | `/work` | Open a bounded live view of active Harness workflows, subagents, and jobs |
+| `/subagents` | Browse this session's durable subagent conversations, inspect one without resuming it, and continue a continuable child. Also reachable with `c` from `/work` |
 | `/context` | Open a bounded view of what is occupying the model's context, and the largest entries in it |
 | `/cache` | Open a bounded read-only view of this session's provider cache accounting and the latest request header Harness recorded |
 | `/new` | Start a fresh session in the current workspace; the previous one remains reopenable when the active Harness profile provides session persistence |
@@ -920,6 +921,18 @@ workflow run has no control here at all, because `ctx.workflowEngine` hands a
 run handle only to the caller that started it. The status line's `work` segment
 counts what this overlay shows, so a child presented under its workflow is not
 also counted as a loose subagent there.
+
+Durable subagent conversations are a separate view from active work. `/work`
+lists only open lifecycle epochs, and a continuable child's epoch ends when it
+settles — so `/subagents`, or `c` from `/work`, opens Harness's durable
+direct-child discovery instead. Each row is a fact Harness published: the child
+id, its label, `one-shot` or `continuable`, session-store residency, and whether
+it has children. Opening one reads that child's own session log through
+`ctx.sessionQuery` without resuming the child, and a continuable child can
+receive a human follow-up (`m`), a steer (`s`), or an interrupt (`k`). A
+one-shot child is inspectable and read-only. Follow-up and steer use Harness's
+human prompt operation, so acceptance is Harness's own; the message appears in
+the child's transcript only when its session log says so.
 
 A row's mark says how much dshline actually knows about it:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -929,10 +929,11 @@ direct-child discovery instead. Each row is a fact Harness published: the child
 id, its label, `one-shot` or `continuable`, session-store residency, and whether
 it has children. Opening one reads that child's own session log through
 `ctx.sessionQuery` without resuming the child, and a continuable child can
-receive a human follow-up (`m`), a steer (`s`), or an interrupt (`k`). A
-one-shot child is inspectable and read-only. Follow-up and steer use Harness's
-human prompt operation, so acceptance is Harness's own; the message appears in
-the child's transcript only when its session log says so.
+receive a human follow-up (`m`) or a steer (`s`). A one-shot child is
+inspectable and read-only. Follow-up and steer use Harness's human prompt
+operation, so acceptance is Harness's own; the message appears in the child's
+transcript only when its session log says so. Interrupt stays on `/work`, where
+an open lifecycle epoch proves there is a turn to cancel.
 
 A row's mark says how much dshline actually knows about it:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -933,7 +933,7 @@ receive a human follow-up (`m`) or a steer (`s`). A one-shot child is
 inspectable and read-only. Follow-up and steer use Harness's human prompt
 operation, so acceptance is Harness's own; the message appears in the child's
 transcript only when its session log says so. Interrupt stays on `/work`, where
-an open lifecycle epoch proves there is a turn to cancel.
+an open lifecycle epoch is the stronger premise.
 
 A row's mark says how much dshline actually knows about it:
 

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -637,7 +637,7 @@ No Harness session corpus is mounted in this profile.
 
 工作流、subagent 与任务保持独立分区，因为它们是彼此独立的 Harness 权威，而 dshline 不猜测两条能力记录描述同一个操作。它确实展示的那一条关系是发布出来的，而不是猜的：工作流成员携带它启动的 subagent 的 `childId`，因此那个子级出现在它的工作流之下，而不是在扁平的 Subagents 分区里第二次出现。任务仅限检视/状态；取消仍通过 Harness `job_kill` 供模型使用。工作流运行在这里完全没有控制手段，因为 `ctx.workflowEngine` 只把运行句柄交给启动它的调用方。状态行的 `work` 片段统计的正是这个浮层所显示的内容，因此呈现在工作流之下的子级不会在那里再被算作一个游离的 subagent。
 
-持久 subagent 对话是与活动工作分开的视图。`/work` 只列出开放的生命周期 epoch，而一个 continuable 子级的 epoch 会在它结算时结束——因此 `/subagents`（或在 `/work` 中按 `c`）打开的是 Harness 的持久直接子级发现。每一行都是 Harness 发布的事实：子级 id、其 label、`one-shot` 还是 `continuable`、会话存储驻留状态，以及它是否有子级。打开其中一个会通过 `ctx.sessionQuery` 读取该子级自己的会话日志，而不恢复该子级；continuable 子级可以接收人类跟进（`m`）、steer（`s`）或中断（`k`）。one-shot 子级可检视且只读。跟进与 steer 使用 Harness 的人类提示操作，因此接受与否由 Harness 自己决定；消息只有当子级的会话日志如此记录时才出现在其 transcript（文本记录）中。
+持久 subagent 对话是与活动工作分开的视图。`/work` 只列出开放的生命周期 epoch，而一个 continuable 子级的 epoch 会在它结算时结束——因此 `/subagents`（或在 `/work` 中按 `c`）打开的是 Harness 的持久直接子级发现。每一行都是 Harness 发布的事实：子级 id、其 label、`one-shot` 还是 `continuable`、会话存储驻留状态，以及它是否有子级。打开其中一个会通过 `ctx.sessionQuery` 读取该子级自己的会话日志，而不恢复该子级；continuable 子级可以接收人类跟进（`m`）或 steer（`s`）。one-shot 子级可检视且只读。跟进与 steer 使用 Harness 的人类提示操作，因此接受与否由 Harness 自己决定；消息只有当子级的会话日志如此记录时才出现在其 transcript（文本记录）中。中断保留在 `/work`，那里一个开放的生命周期 epoch 证明存在可取消的一轮。
 
 行的标记说明 dshline 对它到底知道多少：
 

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -121,7 +121,7 @@ export DSH_HARNESS=~/path/to/deepseek-harness
 
 长提示或多行提示会围绕匹配到的那一行预览，而不是只显示第一行，于是你能看出一条结果为什么在列表里。会话还在重新打开时按 `ctrl-r` 也没问题：搜索会说明历史仍在加载，你已经输入的内容会在历史到达的那一刻立即解析。
 
-重新打开会话会恢复保存的日志记录下的历史：每一条提示与每一条输入被记录的已解决斜杠命令。本界面自己处理的命令（`/image`、`/model`、`/reasoning`、`/usage`、`/timing`、`/enter`、`/new`、`/clear`、`/sessions`、`/worktrees`、`/work`、`/todos`、`/turns`、`/skills`、`/exit`、`/quit`）与打错的命令在会话打开期间被记住，但不会写入会话日志，因此恢复后不会重现。
+重新打开会话会恢复保存的日志记录下的历史：每一条提示与每一条输入被记录的已解决斜杠命令。本界面自己处理的命令（`/image`、`/model`、`/reasoning`、`/usage`、`/timing`、`/enter`、`/new`、`/clear`、`/sessions`、`/worktrees`、`/work`、`/subagents`、`/todos`、`/turns`、`/skills`、`/exit`、`/quit`）与打错的命令在会话打开期间被记住，但不会写入会话日志，因此恢复后不会重现。
 
 ### 排队还是导向
 
@@ -184,6 +184,7 @@ export DSH_HARNESS=~/path/to/deepseek-harness
 | `/enter` | 一轮正在运行时普通 `enter` 的行为：`queue` 或 `steer`；裸命令则询问。见[排队还是导向](#排队还是导向) |
 | `/theme` | 选择颜色配色。接受一个名字（`/theme ember`）或打开选择器 |
 | `/work` | 打开活动 Harness 工作流、subagent 与任务的有界实时视图 |
+| `/subagents` | 浏览本会话持久的 subagent 对话，在不恢复子级的情况下检视其中一个，并继续一个 continuable 子级。也可以在 `/work` 中按 `c` 进入 |
 | `/context` | 打开一个有界视图，显示是什么在占用模型的上下文，以及其中最大的条目 |
 | `/cache` | 打开一个有界只读视图，显示本会话的提供方缓存计量，以及 Harness 记录的最新请求头 |
 | `/new` | 在当前工作区开始一个全新会话；当前激活的 Harness 配置文件提供会话持久化时，上一个会话仍可重新打开 |
@@ -635,6 +636,8 @@ No Harness session corpus is mounted in this profile.
 `/work` 打开一个临时有界浮层：dshline 对本会话中 Harness 正在运行什么的实时视图。配置文件挂载了通用 Harness `ctx.jobs` 与 `ctx.subagents` 能力时，它读取它们，再加上 `workflow` 工具写入本会话自己日志的工作流（workflow）记录；这两项能力都没有的配置文件仍然启动，浮层说明 Work 不可用。它绝不切换屏幕或重写会话记录，因此关闭它回到同一个原生终端滚动缓冲区。
 
 工作流、subagent 与任务保持独立分区，因为它们是彼此独立的 Harness 权威，而 dshline 不猜测两条能力记录描述同一个操作。它确实展示的那一条关系是发布出来的，而不是猜的：工作流成员携带它启动的 subagent 的 `childId`，因此那个子级出现在它的工作流之下，而不是在扁平的 Subagents 分区里第二次出现。任务仅限检视/状态；取消仍通过 Harness `job_kill` 供模型使用。工作流运行在这里完全没有控制手段，因为 `ctx.workflowEngine` 只把运行句柄交给启动它的调用方。状态行的 `work` 片段统计的正是这个浮层所显示的内容，因此呈现在工作流之下的子级不会在那里再被算作一个游离的 subagent。
+
+持久 subagent 对话是与活动工作分开的视图。`/work` 只列出开放的生命周期 epoch，而一个 continuable 子级的 epoch 会在它结算时结束——因此 `/subagents`（或在 `/work` 中按 `c`）打开的是 Harness 的持久直接子级发现。每一行都是 Harness 发布的事实：子级 id、其 label、`one-shot` 还是 `continuable`、会话存储驻留状态，以及它是否有子级。打开其中一个会通过 `ctx.sessionQuery` 读取该子级自己的会话日志，而不恢复该子级；continuable 子级可以接收人类跟进（`m`）、steer（`s`）或中断（`k`）。one-shot 子级可检视且只读。跟进与 steer 使用 Harness 的人类提示操作，因此接受与否由 Harness 自己决定；消息只有当子级的会话日志如此记录时才出现在其 transcript（文本记录）中。
 
 行的标记说明 dshline 对它到底知道多少：
 

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -637,7 +637,7 @@ No Harness session corpus is mounted in this profile.
 
 工作流、subagent 与任务保持独立分区，因为它们是彼此独立的 Harness 权威，而 dshline 不猜测两条能力记录描述同一个操作。它确实展示的那一条关系是发布出来的，而不是猜的：工作流成员携带它启动的 subagent 的 `childId`，因此那个子级出现在它的工作流之下，而不是在扁平的 Subagents 分区里第二次出现。任务仅限检视/状态；取消仍通过 Harness `job_kill` 供模型使用。工作流运行在这里完全没有控制手段，因为 `ctx.workflowEngine` 只把运行句柄交给启动它的调用方。状态行的 `work` 片段统计的正是这个浮层所显示的内容，因此呈现在工作流之下的子级不会在那里再被算作一个游离的 subagent。
 
-持久 subagent 对话是与活动工作分开的视图。`/work` 只列出开放的生命周期 epoch，而一个 continuable 子级的 epoch 会在它结算时结束——因此 `/subagents`（或在 `/work` 中按 `c`）打开的是 Harness 的持久直接子级发现。每一行都是 Harness 发布的事实：子级 id、其 label、`one-shot` 还是 `continuable`、会话存储驻留状态，以及它是否有子级。打开其中一个会通过 `ctx.sessionQuery` 读取该子级自己的会话日志，而不恢复该子级；continuable 子级可以接收人类跟进（`m`）或 steer（`s`）。one-shot 子级可检视且只读。跟进与 steer 使用 Harness 的人类提示操作，因此接受与否由 Harness 自己决定；消息只有当子级的会话日志如此记录时才出现在其 transcript（文本记录）中。中断保留在 `/work`，那里一个开放的生命周期 epoch 证明存在可取消的一轮。
+持久 subagent 对话是与活动工作分开的视图。`/work` 只列出开放的生命周期 epoch，而一个 continuable 子级的 epoch 会在它结算时结束——因此 `/subagents`（或在 `/work` 中按 `c`）打开的是 Harness 的持久直接子级发现。每一行都是 Harness 发布的事实：子级 id、其 label、`one-shot` 还是 `continuable`、会话存储驻留状态，以及它是否有子级。打开其中一个会通过 `ctx.sessionQuery` 读取该子级自己的会话日志，而不恢复该子级；continuable 子级可以接收人类跟进（`m`）或 steer（`s`）。one-shot 子级可检视且只读。跟进与 steer 使用 Harness 的人类提示操作，因此接受与否由 Harness 自己决定；消息只有当子级的会话日志如此记录时才出现在其 transcript（文本记录）中。中断保留在 `/work`，那里一个开放的生命周期 epoch 是更强的前提。
 
 行的标记说明 dshline 对它到底知道多少：
 

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -100,6 +100,7 @@ import type { Window } from './window.ts'
 import { createHarnessWork } from './work/index.ts'
 import { createWorkOverlay } from './work/overlay.ts'
 import { activeWorkCount, workSummary } from './work/model.ts'
+import { createSubagentsPresenter } from './subagents/presenter.ts'
 import { SessionProjectionObserver } from './projections/observer.ts'
 import { openSurface } from './surface.ts'
 import { goalReading } from './goals/model.ts'
@@ -277,6 +278,37 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   // snapshots; it neither starts work nor owns its output cursor.
   const work = createHarnessWork(ctx, agent, () => { ctx.tuiSlots.invalidate() })
   scope.own(() => { work.dispose() })
+  // Durable subagent conversations are a SEPARATE presenter from active Work:
+  // Work owns open lifecycle epochs keyed by `runId`, while a settled
+  // continuable child is still a durable conversation. This presenter reads the
+  // generic subagent and session-query seams, and interruption is delegated to
+  // `work.interruptSubagent` so the terminal keeps one human interrupt path.
+  const subagents = ctx.get('subagents')
+  const sessionQuery = ctx.get('sessionQuery')
+  const subagentsPresenter = createSubagentsPresenter({
+    slots: ctx.tuiSlots,
+    parentSessionId: agent.session.id,
+    invalidate: () => { ctx.tuiSlots.invalidate() },
+    ...subagents === undefined ? {} : { subagents },
+    ...sessionQuery === undefined ? {} : { query: sessionQuery },
+    interrupt: (childId, authorized) => work.interruptSubagent(childId, authorized),
+    // Subscribed only when the feature can actually be used: a profile without
+    // `ctx.subagents` has no catalog to refresh and no child to mark stale.
+    ...subagents === undefined ? {} : {
+      onLifecycle: listener => {
+        // `agent.ctx` is the parent-scoped carrier Harness routes lifecycle
+        // edges through. A test or an unusual composition may not have attached
+        // one, and a missing carrier means no scoped edge to observe.
+        const scoped = agent.ctx as typeof agent.ctx | undefined
+        if (scoped === undefined) return () => {}
+        const offStart = scoped.on('subagent/start', () => { listener() })
+        const offEnd = scoped.on('subagent/end', () => { listener() })
+        return () => { offStart(); offEnd() }
+      },
+      onSessionEvent: listener => ctx.on('session/event', session => { listener(String(session.id)) }),
+    },
+  })
+  scope.own(() => { subagentsPresenter.dispose() })
   // Reassigned once completion exists: a catalog change has to reach both the
   // frame and any menu already standing over it, and the menu is built below
   // out of this very catalog.
@@ -726,6 +758,7 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     cachePresenter.command,
     contextPresenter.command,
     turnsPresenter.command,
+    subagentsPresenter.command,
     {
       // Named for the key, unlike every other command here, because the key IS
       // the subject: the question a reader has is "what does enter do right
@@ -782,6 +815,9 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
         openSurface(ctx.tuiSlots, close => createWorkOverlay({
           snapshot: () => work.snapshot(),
           interrupt: item => work.interrupt(item),
+          // Offered exactly while the generic subagent seam is mounted, so a
+          // profile without it never advertises a drawer it cannot open.
+          ...subagents === undefined ? {} : { conversations: () => { subagentsPresenter.open() } },
           close,
           invalidate: () => { ctx.tuiSlots.invalidate() },
         }))

--- a/packages/dshline/src/attachment.ts
+++ b/packages/dshline/src/attachment.ts
@@ -281,8 +281,8 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
   // Durable subagent conversations are a SEPARATE presenter from active Work:
   // Work owns open lifecycle epochs keyed by `runId`, while a settled
   // continuable child is still a durable conversation. This presenter reads the
-  // generic subagent and session-query seams, and interruption is delegated to
-  // `work.interruptSubagent` so the terminal keeps one human interrupt path.
+  // generic subagent and session-query seams and inspects/continues; interrupt
+  // stays on `/work`, where an open epoch is the stronger premise.
   const subagents = ctx.get('subagents')
   const sessionQuery = ctx.get('sessionQuery')
   const subagentsPresenter = createSubagentsPresenter({
@@ -291,7 +291,6 @@ export async function attachSession(w: Window, outcome: AttachOutcome): Promise<
     invalidate: () => { ctx.tuiSlots.invalidate() },
     ...subagents === undefined ? {} : { subagents },
     ...sessionQuery === undefined ? {} : { query: sessionQuery },
-    interrupt: (childId, authorized) => work.interruptSubagent(childId, authorized),
     // Subscribed only when the feature can actually be used: a profile without
     // `ctx.subagents` has no catalog to refresh and no child to mark stale.
     ...subagents === undefined ? {} : {

--- a/packages/dshline/src/scroll.ts
+++ b/packages/dshline/src/scroll.ts
@@ -1,11 +1,55 @@
 /**
  * A bounded window over physical rendered rows.
  *
- * Rendering owns what a row means; this class owns only which contiguous rows
+ * Rendering owns what a row means; this module owns only which contiguous rows
  * are visible. Keeping those concerns apart lets modal documents, lists, and
  * future views share the same resize-safe position rules.
  * @module dshline/scroll
  */
+
+/** One cursor-following window over rendered rows. */
+export interface RowWindow {
+  /** The visible rows, at most the effective capacity. */
+  readonly rows: readonly string[]
+  /** How many rendered rows were scrolled past above the window. */
+  readonly offset: number
+  /** How many rendered rows remain below the window. */
+  readonly below: number
+}
+
+/**
+ * Window rendered rows so the cursor's row stays visible.
+ *
+ * This is ONE policy shared by the primary composer and the bounded subagent
+ * message overlay. It keeps the cursor's row in view and prefers to show what
+ * follows it, because a person typing or pasting works at the end: the window
+ * is pinned to the bottom until the cursor rises into it, then follows the
+ * cursor upward. Keeping it here is what makes the two editors agree without
+ * the renderer learning what a cursor is.
+ *
+ * `maximum` is the budget the current geometry grants and `cap` is the caller's
+ * own absolute ceiling; the effective window is the smaller of the two. A
+ * caller with only a geometry budget passes no `cap`. A capacity of zero still
+ * yields one row when there are rows to show, so a short terminal degrades to a
+ * single line rather than an empty body; callers that must draw nothing at a
+ * zero budget slice the result themselves.
+ * @param rows - every rendered row, in draw order.
+ * @param cursorRow - the cursor's row index within `rows`.
+ * @param maximum - most rows the current geometry can draw.
+ * @param cap - the caller's own absolute limit, or unlimited when omitted.
+ * @returns the visible slice and the counts scrolled past above and below it.
+ */
+export function cursorWindow(
+  rows: readonly string[],
+  cursorRow: number,
+  maximum: number,
+  cap: number = Number.POSITIVE_INFINITY,
+): RowWindow {
+  const visible = Math.max(1, Math.min(cap, maximum, rows.length))
+  if (rows.length <= visible) return { rows, offset: 0, below: 0 }
+  const offset = Math.min(rows.length - visible, Math.max(0, cursorRow - visible + 1))
+  return { rows: rows.slice(offset, offset + visible), offset, below: rows.length - offset - visible }
+}
 
 /** A scroll position over a sequence of rendered rows. */
 export class RowViewport {

--- a/packages/dshline/src/subagents/control.ts
+++ b/packages/dshline/src/subagents/control.ts
@@ -1,0 +1,101 @@
+/**
+ * The one Dshline adapter for human-authored subagent messages.
+ *
+ * A human terminal follow-up must go through Harness's browser/human prompt
+ * operation, `ctx.subagents.prompt`. That operation is not the same contract as
+ * `SubagentRuntime.sendMessage`: `sendMessage` takes an exact live `Agent`
+ * sender and stamps `agent-message` provenance, so calling it here would
+ * impersonate the parent Agent and record the human's words as the model's.
+ * `prompt` instead carries a durable parent/child address, a client-minted
+ * request identity, human `kind: 'user'` provenance, the Queue versus Steer
+ * choice, cold materialization, and the accepted `MessageId` receipt.
+ *
+ * This module builds exactly that request and maps its failure honestly. It
+ * owns no scheduling, authorization, or lifecycle: Harness accepts, rejects,
+ * cold-resumes, and schedules, and Dshline only reports which happened.
+ * @module dshline/subagents/control
+ */
+
+import { randomUUID } from 'node:crypto'
+import type { SessionId } from '@deepseek-ai/dsh-session'
+import type { SubagentPromptRequestId } from '@deepseek-ai/dsh-subagent'
+import type { HumanSubagentSeam } from './seam.ts'
+
+/**
+ * Which Harness scheduling a human message asks for.
+ *
+ * `queue` is an ordinary later turn; `steer` targets the nearest step and, for
+ * an idle or freshly cold-resumed child, starts a turn exactly as `queue`
+ * would. Both are Harness's own accepted values, and neither is inferred from
+ * anything Dshline observed about the child.
+ */
+export type HumanPromptDelivery = 'queue' | 'steer'
+
+/** The outcome of asking Harness to accept one human follow-up. */
+export type SubagentPromptOutcome =
+  /** Harness's child inbox accepted the message and returned its identity. */
+  | { readonly kind: 'accepted'; readonly messageId: string }
+  /** No human prompt operation is mounted in this profile. */
+  | { readonly kind: 'unavailable' }
+  /** Harness refused; the message is its own typed refusal. */
+  | { readonly kind: 'failed'; readonly message: string }
+
+/** One human follow-up addressed to a durable direct child. */
+export interface HumanPromptInput {
+  /** The attached session, which is the durable direct parent Harness authorizes. */
+  readonly parentSessionId: SessionId
+  /** The durable direct child the message is addressed to. */
+  readonly childId: SessionId
+  /** The typed message body. Text-only for this PR. */
+  readonly text: string
+  /** Harness's Queue or Steer scheduling. */
+  readonly delivery: HumanPromptDelivery
+}
+
+/**
+ * Deliver one human message through Harness's human prompt authority.
+ *
+ * The request identity is minted here because Harness persists it on the
+ * accepted message and treats it as caller-owned; a fresh id per submission is
+ * what makes an accepted receipt attributable to this exact keystroke.
+ * @param seam - the human-authoritative subagent operations, or undefined without one.
+ * @param input - the durable address, delivery, and message text.
+ * @param signal - caller cancellation, owning the call only until inbox acceptance.
+ * @returns the accepted receipt, the capability absence, or Harness's refusal.
+ */
+export async function deliverHumanPrompt(
+  seam: HumanSubagentSeam | undefined,
+  input: HumanPromptInput,
+  signal: AbortSignal,
+): Promise<SubagentPromptOutcome> {
+  if (seam === undefined) return { kind: 'unavailable' }
+  try {
+    const receipt = await seam.prompt({
+      requestId: randomUUID() as SubagentPromptRequestId,
+      parentSessionId: input.parentSessionId,
+      childSessionId: input.childId,
+      mode: 'continuable',
+      delivery: input.delivery,
+      content: [{ type: 'text', text: input.text }],
+    }, signal)
+    return { kind: 'accepted', messageId: String(receipt.messageId) }
+  } catch (error: unknown) {
+    return { kind: 'failed', message: humanReason(error) }
+  }
+}
+
+/**
+ * A short, safe account of a refused prompt.
+ *
+ * Harness's typed refusal code is kept when the error carries one, because
+ * `subagent/not-resumable` and `subagent/unauthorized` are actionable
+ * different facts; the message itself is untrusted text the composer escapes
+ * before drawing.
+ * @param error - the thrown value.
+ * @returns a one-line reason.
+ */
+function humanReason(error: unknown): string {
+  if (!(error instanceof Error)) return String(error)
+  const code = (error as { readonly code?: unknown }).code
+  return typeof code === 'string' && code !== '' ? `${code}: ${error.message}` : error.message
+}

--- a/packages/dshline/src/subagents/model.ts
+++ b/packages/dshline/src/subagents/model.ts
@@ -1,0 +1,214 @@
+/**
+ * Presentation-facing vocabulary for durable subagent conversations.
+ *
+ * Every fact here comes from Harness discovery (`SubagentListEntry`) or from a
+ * child's own durable session log. Nothing infers a state: a missing activity
+ * read is not completion, persistence residency is not "running", and
+ * resumability is exactly Harness's descriptor mode. The one identity this
+ * module keeps is the durable child session id, which survives the end of a
+ * lifecycle epoch — the whole reason a separate catalog exists beside Work's
+ * active-epoch projection.
+ *
+ * This is deliberately NOT part of `work/model.ts`. Work owns lifecycle
+ * authority (open epochs keyed by `runId`); this owns durable conversations
+ * keyed by child id, and merging them would make a settled child look like
+ * active work that blocks retiring the session.
+ * @module dshline/subagents/model
+ */
+
+import type { SubagentListEntry } from '@deepseek-ai/dsh-subagent'
+
+/**
+ * Durable session-store residency, in the wording Work already established.
+ *
+ * Harness `activity: 'running'` means the logical record is resident in the
+ * session store; `'inactive'` means it exists only in persistence. Neither is a
+ * claim that a model turn is executing, so the presentation never says
+ * "running" for either.
+ */
+export type SubagentResidency = 'resident' | 'stored'
+
+/** One durable direct child, from Harness discovery. */
+export interface SubagentChildRow {
+  /** Discriminant for the row union. */
+  readonly kind: 'child'
+  /** Durable child session id; stable across Activations. */
+  readonly id: string
+  /** Durable creation label, when the descriptor carried one. */
+  readonly label?: string
+  /** Harness's descriptor mode: a terminal one-shot run or a resumable conversation. */
+  readonly mode: 'one-shot' | 'continuable'
+  /** Durable session-store residency, never a model-turn claim. */
+  readonly residency: SubagentResidency
+  /** Whether a direct descendant has durable `origin: 'subagent'`. */
+  readonly hasChildren: boolean
+}
+
+/**
+ * One candidate Harness could not interpret, kept rather than dropped.
+ *
+ * A diagnostic is a first-class row so a corrupt or unreadable child degrades
+ * honestly instead of vanishing from the catalog.
+ */
+export interface SubagentDiagnosticRow {
+  /** Discriminant for the row union. */
+  readonly kind: 'diagnostic'
+  /** The candidate's session id. */
+  readonly id: string
+  /** Why Harness produced no child identity for it. */
+  readonly reason: 'corrupt' | 'unsupported' | 'unavailable'
+}
+
+/** One catalog row: a durable child or an honest diagnostic. */
+export type SubagentCatalogRow = SubagentChildRow | SubagentDiagnosticRow
+
+/**
+ * What the catalog can truthfully present.
+ *
+ * The absences are distinct on purpose: a missing service, an in-flight read,
+ * and a failed read are three different facts, and collapsing them into an
+ * empty list would report "no subagents" for a profile that has many.
+ */
+export type SubagentCatalogReading =
+  /** No `ctx.subagents` is mounted in this profile. */
+  | { readonly kind: 'unavailable' }
+  /** A discovery read is in flight. */
+  | { readonly kind: 'loading' }
+  /** Discovery failed; the message is Harness's or the transport's. */
+  | { readonly kind: 'failed'; readonly message: string }
+  /** Discovery answered, possibly with zero rows. */
+  | { readonly kind: 'ready'; readonly rows: readonly SubagentCatalogRow[] }
+
+/**
+ * Stable selection identity for one catalog row.
+ *
+ * The durable child id is the identity, never the live `runId`: a continuable
+ * child that settles and later resumes keeps one catalog row across both
+ * epochs, which is exactly what the active-epoch projection cannot do.
+ * @param row - the row to key.
+ * @returns a kind-scoped key stable across refresh and reordering.
+ */
+export function subagentRowKey(row: SubagentCatalogRow): string {
+  return `${row.kind}:${row.id}`
+}
+
+/**
+ * The leading name a row shows.
+ *
+ * Harness's durable label wins; a one-shot child may legitimately have none, in
+ * which case its durable id is the truthful name rather than an invented one.
+ * @param row - the row to name.
+ * @returns raw, untrusted label text (the overlay escapes it before drawing).
+ */
+export function subagentRowLabel(row: SubagentCatalogRow): string {
+  if (row.kind === 'diagnostic') return row.id
+  return row.label === undefined || row.label === '' ? row.id : row.label
+}
+
+/**
+ * Whether a row can open a conversation inspector.
+ *
+ * Only a resolved child has a durable session to read; a diagnostic has no
+ * identity to read, so it is listed but not openable.
+ * @param row - the row under the cursor.
+ * @returns whether Enter may open the inspector.
+ */
+export function subagentRowOpenable(row: SubagentCatalogRow): boolean {
+  return row.kind === 'child'
+}
+
+/**
+ * Whether a row may receive a human queue/steer follow-up.
+ *
+ * Two independent authorities must agree: Harness's descriptor must say
+ * `continuable`, and the human prompt operation must be mounted. A one-shot
+ * child is inspectable and read-only.
+ * @param row - the row under the cursor.
+ * @param promptAvailable - whether `ctx.subagents.prompt` is mounted.
+ * @returns whether the follow-up/steer actions are offered.
+ */
+export function subagentRowFollowUp(row: SubagentCatalogRow, promptAvailable: boolean): boolean {
+  return row.kind === 'child' && row.mode === 'continuable' && promptAvailable
+}
+
+/**
+ * Whether a row may be interrupted.
+ *
+ * Interrupt authority is continuable-only, exactly as Work's active rows
+ * already decide it. The actual authorization still belongs to Harness; this
+ * only decides whether the terminal offers the action.
+ * @param row - the row under the cursor.
+ * @returns whether the interrupt action is offered.
+ */
+export function subagentRowInterruptible(row: SubagentCatalogRow): boolean {
+  return row.kind === 'child' && row.mode === 'continuable'
+}
+
+/**
+ * The one-line durability facts a catalog row shows.
+ *
+ * Order is deliberate: mode is what makes the row actionable, residency is a
+ * store fact, and child presence is a lineage fact. No field is inferred.
+ * @param row - the child row.
+ * @returns whole segments, joined for display by the overlay.
+ */
+export function subagentChildFacts(row: SubagentChildRow): readonly string[] {
+  return [
+    row.mode,
+    row.residency,
+    ...row.hasChildren ? ['has children'] : [],
+  ]
+}
+
+/**
+ * The honest wording for one diagnostic reason.
+ *
+ * The three reasons are distinct Harness outcomes and must not collapse:
+ * `corrupt` is deterministic data damage, `unavailable` is transient and
+ * retried on the next listing, and `unsupported` is kept in the union for
+ * consumers that route on it.
+ * @param reason - Harness's diagnostic reason.
+ * @returns a short human phrase.
+ */
+export function diagnosticReasonWord(reason: SubagentDiagnosticRow['reason']): string {
+  switch (reason) {
+    case 'corrupt':
+      return 'unreadable record'
+    case 'unavailable':
+      return 'temporarily unreadable'
+    case 'unsupported':
+      return 'unsupported record'
+  }
+}
+
+/**
+ * Map Harness discovery entries into the catalog reading.
+ *
+ * The mapping only renames facts: `activity` becomes residency wording, and a
+ * diagnostic keeps its own reason. Order is Harness's (`createdAt`, ties on id)
+ * and is preserved so the listing is the authority on order.
+ * @param entries - Harness's discovery result.
+ * @returns a ready reading over the same rows.
+ */
+export function catalogReading(entries: readonly SubagentListEntry[]): SubagentCatalogReading {
+  return { kind: 'ready', rows: entries.map(catalogRow) }
+}
+
+/**
+ * Convert one Harness entry to a presentation row.
+ * @param entry - one discovery entry.
+ * @returns the child or diagnostic row.
+ */
+function catalogRow(entry: SubagentListEntry): SubagentCatalogRow {
+  if (entry.kind === 'diagnostic') {
+    return { kind: 'diagnostic', id: String(entry.id), reason: entry.reason }
+  }
+  return {
+    kind: 'child',
+    id: String(entry.id),
+    mode: entry.mode,
+    residency: entry.activity === 'running' ? 'resident' : 'stored',
+    hasChildren: entry.hasChildren,
+    ...entry.label === undefined || entry.label === '' ? {} : { label: entry.label },
+  }
+}

--- a/packages/dshline/src/subagents/model.ts
+++ b/packages/dshline/src/subagents/model.ts
@@ -132,19 +132,6 @@ export function subagentRowFollowUp(row: SubagentCatalogRow, promptAvailable: bo
 }
 
 /**
- * Whether a row may be interrupted.
- *
- * Interrupt authority is continuable-only, exactly as Work's active rows
- * already decide it. The actual authorization still belongs to Harness; this
- * only decides whether the terminal offers the action.
- * @param row - the row under the cursor.
- * @returns whether the interrupt action is offered.
- */
-export function subagentRowInterruptible(row: SubagentCatalogRow): boolean {
-  return row.kind === 'child' && row.mode === 'continuable'
-}
-
-/**
  * The one-line durability facts a catalog row shows.
  *
  * Order is deliberate: mode is what makes the row actionable, residency is a

--- a/packages/dshline/src/subagents/overlay.ts
+++ b/packages/dshline/src/subagents/overlay.ts
@@ -26,7 +26,7 @@ import {
   truncateToWidth,
 } from '@dshline/renderer'
 import { FocusRing } from '../focus.ts'
-import { RowViewport } from '../scroll.ts'
+import { cursorWindow, RowViewport } from '../scroll.ts'
 import type { TuiOverlay } from '../slots.ts'
 import { createBoundedSurface, SurfaceNotice } from '../surface.ts'
 import type { HumanPromptDelivery, SubagentPromptOutcome } from './control.ts'
@@ -63,6 +63,9 @@ export const CONVERSATION_NOTICE_MS = 4_000
 
 /** How long a composer's refusal notice remains readable. */
 const MESSAGE_NOTICE_MS = 6_000
+
+/** The gutter every message-composer row is drawn and moved with. */
+const COMPOSER_GUTTER = '❯ '
 
 /** Inputs the durable-child catalog surface needs from its presenter. */
 export interface SubagentCatalogOverlaySpec {
@@ -104,7 +107,11 @@ export function createSubagentCatalogOverlay(spec: SubagentCatalogOverlaySpec): 
     reading: spec.reading,
     title: () => 'Subagent conversations',
     compact: reading => catalogCompact(reading),
-    footer: () => '↑↓ select · ↵ inspect · r refresh · esc back',
+    // ASCII direction letters, not `↑↓`: those are East Asian Ambiguous width,
+    // and a border label containing them makes the bottom border one physical
+    // row taller than `displayWidth` models, which leaves a stray corner in
+    // scrollback on every redraw (the #202 failure, on the footer this time).
+    footer: () => '^v select · enter inspect · r refresh · esc back',
     body: (reading, width, capacity) => {
       const lines = catalogLines(reading, width)
       focus.update(lines.flatMap(line => line.key === undefined ? [] : [line.key]), true)
@@ -171,16 +178,12 @@ export interface SubagentConversationOverlaySpec {
   readonly followUp: boolean
   /** Whether a human steer is authorized. */
   readonly steer: boolean
-  /** Whether the child may be interrupted. */
-  readonly interruptible: boolean
   /** Read one older page if the child has one. */
   readonly loadOlder: () => void
   /** Re-read the newest page. */
   readonly refresh: () => void
   /** Open the message composer with this delivery. */
   readonly message: (delivery: HumanPromptDelivery) => void
-  /** Interrupt the addressed child through the shared Work adapter. */
-  readonly interrupt: () => void
   /** The presenter-owned outcome notice. */
   readonly notice: SurfaceNotice
   /** Remove this temporary surface. */
@@ -221,9 +224,6 @@ export function createSubagentConversationOverlay(spec: SubagentConversationOver
             return
           case 's':
             if (spec.steer) spec.message('steer')
-            return
-          case 'k':
-            if (spec.interruptible) spec.interrupt()
             return
           case 'r':
             spec.refresh()
@@ -298,15 +298,35 @@ export function createSubagentMessageOverlay(spec: SubagentMessageOverlaySpec): 
   const notice = new SurfaceNotice(MESSAGE_NOTICE_MS)
   let pending = false
   let closed = false
+  /**
+   * The inner width of the last paint. `↑`/`↓` move the cursor by the SAME
+   * wrapped layout the rows were drawn from, so the movement needs the width
+   * the body was rendered at; a key before the first paint has nothing to move
+   * against and is ignored.
+   */
+  let lastWidth = 0
   return createBoundedSurface<{ readonly pending: boolean }>({
     reading: () => ({ pending }),
     title: () => `${spec.delivery === 'queue' ? 'Follow-up' : 'Steer'} · ${spec.childLabel}`,
     compact: () => spec.delivery === 'queue' ? 'Follow-up' : 'Steer',
     notice,
     footer: () => 'enter send · esc cancel',
-    body: (_reading, width, capacity) => composerBody(composer, width, capacity, spec.delivery),
+    body: (_reading, width, capacity) => {
+      lastWidth = width
+      return composerBody(composer, width, capacity, spec.delivery)
+    },
     onKey: key => {
       if (pending) return
+      // Vertical motion is not the editor's `handle`: the input router owns it,
+      // and it must use the layout the rows were drawn from so `↑`/`↓` land on
+      // the row the caret was drawn on. The window then follows the cursor.
+      if (key.kind === 'key' && (key.name === 'up' || key.name === 'down') && lastWidth > 0) {
+        const moved = key.name === 'up'
+          ? composer.moveUp(lastWidth, () => COMPOSER_GUTTER)
+          : composer.moveDown(lastWidth, () => COMPOSER_GUTTER)
+        if (moved) spec.invalidate()
+        return
+      }
       const action = composer.handle(key)
       if (action.kind === 'changed') {
         spec.invalidate()
@@ -458,36 +478,49 @@ function conversationHeader(
 function conversationHelp(spec: SubagentConversationOverlaySpec, reading: SubagentTranscriptReading): string {
   const older = reading.kind === 'ready' && reading.hasOlder ? ['[ older'] : []
   return [
-    '↑↓ scroll',
+    // ASCII, for the same ambiguous-width reason as the catalog footer.
+    '^v scroll',
     ...older,
     ...spec.followUp ? ['m message'] : [],
     ...spec.steer ? ['s steer'] : [],
-    ...spec.interruptible ? ['k interrupt'] : [],
     'r refresh',
     'esc back',
   ].join(' · ')
 }
 
-/** The composer's bounded body: a delivery hint, then the live draft. */
+/**
+ * The composer's bounded body: a delivery hint, then the live draft around its
+ * cursor.
+ *
+ * The row WINDOW is the same cursor-following policy the primary composer uses
+ * ({@link cursorWindow}), so a long or multiline draft scrolls with the cursor
+ * instead of always showing its first lines. The hint and its blank are fixed
+ * decoration OUTSIDE that window, exactly as the composer's separator and
+ * borders sit outside its content window: under height pressure decoration is
+ * surrendered before the editable row, so at least the cursor's own draft row
+ * survives.
+ */
 function composerBody(
   composer: Composer,
   width: number,
   capacity: number,
   delivery: HumanPromptDelivery,
 ): string[] {
+  if (capacity <= 0) return []
   const hint = delivery === 'queue'
     ? 'Queued as the child’s next turn.'
     : 'Steers the nearest step; starts a turn when the child is idle.'
-  const layout = layoutComposer(composer, width, () => '❯ ')
-  const rows = layout.rows.map((row, index) => index === layout.cursorRow
-    ? blockCursor(row, layout.cursorColumn, width)
-    : row)
-  const body = [
-    paint(truncateToWidth(escapeControls(hint), Math.max(1, width)), 'muted'),
-    '',
-    ...rows.map(row => escapeControls(row)),
-  ]
-  return body.slice(0, Math.max(0, capacity))
+  const layout = layoutComposer(composer, width, () => COMPOSER_GUTTER)
+  const rows = layout.rows
+    .map((row, index) => index === layout.cursorRow
+      ? blockCursor(row, layout.cursorColumn, width)
+      : row)
+    .map(row => escapeControls(row))
+  const prefix = [paint(truncateToWidth(escapeControls(hint), Math.max(1, width)), 'muted'), '']
+  const prefixRows = Math.min(prefix.length, Math.max(0, capacity - 1))
+  const draftCapacity = Math.max(1, capacity - prefixRows)
+  const shown = cursorWindow(rows, layout.cursorRow, draftCapacity)
+  return [...prefix.slice(0, prefixRows), ...shown.rows]
 }
 
 /**

--- a/packages/dshline/src/subagents/overlay.ts
+++ b/packages/dshline/src/subagents/overlay.ts
@@ -1,0 +1,509 @@
+/**
+ * Bounded live-region presentation of durable subagent conversations.
+ *
+ * Three surfaces over the shared kernel, and the stack IS the navigation model:
+ * the catalog opens over `/work`, Enter pushes a conversation inspector over
+ * the catalog, and `m`/`s` push a small message composer over that. Escape pops
+ * exactly one level, so there is no "sometimes back" state anywhere. None of
+ * them writes the transcript: native scrollback stays the transcript, and the
+ * inspector draws only the bounded window it read.
+ *
+ * The composer is the renderer's own `Composer` instance, not a second editor:
+ * the same buffer, cursor model, undo semantics, and key handling the main
+ * input uses, rendered into this surface's bounded body with a block cursor
+ * because a live-region overlay cannot own the terminal caret.
+ * @module dshline/subagents/overlay
+ */
+
+import type { Role } from '@dshline/renderer'
+import {
+  chunkToWidth,
+  Composer,
+  displayWidth,
+  escapeControls,
+  layoutComposer,
+  paint,
+  truncateToWidth,
+} from '@dshline/renderer'
+import { FocusRing } from '../focus.ts'
+import { RowViewport } from '../scroll.ts'
+import type { TuiOverlay } from '../slots.ts'
+import { createBoundedSurface, SurfaceNotice } from '../surface.ts'
+import type { HumanPromptDelivery, SubagentPromptOutcome } from './control.ts'
+import type {
+  SubagentCatalogReading,
+  SubagentCatalogRow,
+  SubagentChildRow,
+} from './model.ts'
+import {
+  diagnosticReasonWord,
+  subagentChildFacts,
+  subagentRowKey,
+  subagentRowLabel,
+  subagentRowOpenable,
+} from './model.ts'
+import type { SubagentTranscriptReading } from './transcript.ts'
+import { transcriptRows } from './transcript.ts'
+
+/** Columns a catalog row spends on its focus gutter and mark. */
+const GUTTER_COLUMNS = 4
+
+/**
+ * Text width used when a keystroke must resolve rows before the next paint.
+ *
+ * Key handling needs row identities, never their pixels, and the terminal's
+ * real width belongs to `render`. A generous logical width keeps fitting from
+ * dropping a fact a narrower guess would remove, which could otherwise change
+ * what a key resolves to.
+ */
+const LOGICAL_WIDTH = 200
+
+/** How long a conversation's outcome notice remains readable. */
+export const CONVERSATION_NOTICE_MS = 4_000
+
+/** How long a composer's refusal notice remains readable. */
+const MESSAGE_NOTICE_MS = 6_000
+
+/** Inputs the durable-child catalog surface needs from its presenter. */
+export interface SubagentCatalogOverlaySpec {
+  /** The current discovery reading, fresh on every paint. */
+  readonly reading: () => SubagentCatalogReading
+  /** Open the conversation inspector for one durable child id. */
+  readonly inspect: (childId: string) => void
+  /** Re-run discovery. */
+  readonly refresh: () => void
+  /** Remove this temporary surface. */
+  readonly close: () => void
+  /** Redraw after a keystroke that changed selection. */
+  readonly invalidate: () => void
+}
+
+/** One catalog line, kept plain so it is painted exactly once. */
+interface CatalogLine {
+  /** Focus identity, present exactly when the row can be aimed at. */
+  readonly key?: string
+  /** The row's text, already escaped and fitted. */
+  readonly text: string
+  /** Role for the text when the row is not focused. */
+  readonly role: Role
+  /** The leading mark, already chosen from an authoritative fact. */
+  readonly mark?: string
+  /** Role for the mark alone. */
+  readonly markRole?: Role
+}
+
+/**
+ * Create the bounded durable-child catalog surface.
+ * @param spec - discovery reading, inspection opener, and surface controls.
+ * @returns a live-region overlay that never writes the transcript.
+ */
+export function createSubagentCatalogOverlay(spec: SubagentCatalogOverlaySpec): TuiOverlay {
+  const focus = new FocusRing()
+  const viewport = new RowViewport()
+  return createBoundedSurface<SubagentCatalogReading>({
+    reading: spec.reading,
+    title: () => 'Subagent conversations',
+    compact: reading => catalogCompact(reading),
+    footer: () => '↑↓ select · ↵ inspect · r refresh · esc back',
+    body: (reading, width, capacity) => {
+      const lines = catalogLines(reading, width)
+      focus.update(lines.flatMap(line => line.key === undefined ? [] : [line.key]), true)
+      viewport.update(lines.length, capacity)
+      const at = lines.findIndex(line => line.key !== undefined && line.key === focus.current)
+      if (at >= 0) {
+        if (at < viewport.start) viewport.move(at - viewport.start)
+        if (at >= viewport.end) viewport.move(at - viewport.end + 1)
+      }
+      return lines.slice(viewport.start, viewport.end).map(line => paintCatalogLine(line, focus.current))
+    },
+    onKey: (key, reading) => {
+      if (key.kind === 'text') {
+        if (key.text === 'r') spec.refresh()
+        return
+      }
+      if (key.kind !== 'key') return
+      // The focus ring must be built from the SAME lines the body draws,
+      // diagnostics included, or arrows would skip a row the reader can see.
+      const lines = catalogLines(reading, LOGICAL_WIDTH)
+      focus.update(lines.flatMap(line => line.key === undefined ? [] : [line.key]), key.name !== 'enter')
+      switch (key.name) {
+        case 'up':
+          focus.move(-1)
+          spec.invalidate()
+          return
+        case 'down':
+          focus.move(1)
+          spec.invalidate()
+          return
+        case 'home':
+        case 'ctrl-a':
+          focus.first()
+          viewport.first()
+          spec.invalidate()
+          return
+        case 'end':
+        case 'ctrl-e':
+          focus.last()
+          viewport.last()
+          spec.invalidate()
+          return
+        case 'enter': {
+          const row = readyRows(reading).find(candidate => subagentRowKey(candidate) === focus.current)
+          if (row !== undefined && subagentRowOpenable(row)) spec.inspect(row.id)
+          else spec.invalidate()
+          return
+        }
+        default:
+          return
+      }
+    },
+    close: spec.close,
+  })
+}
+
+/** Inputs the read-only conversation inspector needs from its presenter. */
+export interface SubagentConversationOverlaySpec {
+  /** The durable child being inspected, read fresh so a refresh updates its facts. */
+  readonly child: () => SubagentChildRow
+  /** The current transcript reading, fresh on every paint. */
+  readonly reading: () => SubagentTranscriptReading
+  /** Whether a human queue/steer follow-up is authorized. */
+  readonly followUp: boolean
+  /** Whether a human steer is authorized. */
+  readonly steer: boolean
+  /** Whether the child may be interrupted. */
+  readonly interruptible: boolean
+  /** Read one older page if the child has one. */
+  readonly loadOlder: () => void
+  /** Re-read the newest page. */
+  readonly refresh: () => void
+  /** Open the message composer with this delivery. */
+  readonly message: (delivery: HumanPromptDelivery) => void
+  /** Interrupt the addressed child through the shared Work adapter. */
+  readonly interrupt: () => void
+  /** The presenter-owned outcome notice. */
+  readonly notice: SurfaceNotice
+  /** Remove this temporary surface. */
+  readonly close: () => void
+  /** Redraw after a keystroke that scrolled or acted. */
+  readonly invalidate: () => void
+}
+
+/**
+ * Create the bounded read-only conversation inspector.
+ * @param spec - the addressed child, transcript reading, and surface controls.
+ * @returns a live-region overlay that never resumes the child or writes scrollback.
+ */
+export function createSubagentConversationOverlay(spec: SubagentConversationOverlaySpec): TuiOverlay {
+  const viewport = new RowViewport()
+  return createBoundedSurface<SubagentTranscriptReading>({
+    reading: spec.reading,
+    title: () => `Subagent · ${subagentRowLabel(spec.child())}`,
+    compact: () => `Subagent · ${subagentRowLabel(spec.child())}`,
+    notice: spec.notice,
+    body: (reading, width, capacity) => {
+      const header = conversationHeader(spec.child(), reading, width)
+      const remaining = Math.max(0, capacity - header.length)
+      const rows = transcriptRows(reading, width)
+      viewport.update(rows.length, remaining)
+      const end = Math.min(rows.length, viewport.start + remaining)
+      return [
+        ...header.slice(0, capacity),
+        ...remaining === 0 ? [] : rows.slice(viewport.start, end),
+      ]
+    },
+    footer: reading => conversationHelp(spec, reading),
+    onKey: key => {
+      if (key.kind === 'text') {
+        switch (key.text) {
+          case 'm':
+            if (spec.followUp) spec.message('queue')
+            return
+          case 's':
+            if (spec.steer) spec.message('steer')
+            return
+          case 'k':
+            if (spec.interruptible) spec.interrupt()
+            return
+          case 'r':
+            spec.refresh()
+            return
+          case '[':
+            spec.loadOlder()
+            return
+          default:
+            return
+        }
+      }
+      if (key.kind !== 'key') return
+      switch (key.name) {
+        case 'up':
+          viewport.move(-1)
+          spec.invalidate()
+          return
+        case 'down':
+          viewport.move(1)
+          spec.invalidate()
+          return
+        case 'home':
+        case 'ctrl-a':
+          viewport.first()
+          spec.invalidate()
+          return
+        case 'end':
+        case 'ctrl-e':
+          viewport.last()
+          spec.invalidate()
+          return
+        default:
+          return
+      }
+    },
+    close: spec.close,
+  })
+}
+
+/** Inputs the bounded message composer needs from its presenter. */
+export interface SubagentMessageOverlaySpec {
+  /** The addressed child's display name. */
+  readonly childLabel: string
+  /** Which Harness scheduling this message asks for. */
+  readonly delivery: HumanPromptDelivery
+  /** Deliver through Harness's human prompt authority. */
+  readonly submit: (
+    text: string,
+    signal: AbortSignal,
+  ) => Promise<SubagentPromptOutcome>
+  /** Called once with the accepted receipt, before the surface closes. */
+  readonly onAccepted: (messageId: string) => void
+  /** Remove this temporary surface. */
+  readonly close: () => void
+  /** Redraw after an edit or a submission edge. */
+  readonly invalidate: () => void
+}
+
+/**
+ * Create the bounded text composer for one human follow-up.
+ *
+ * The buffer is the renderer's `Composer`. On Enter the composer clears its own
+ * buffer, so this surface restores the submitted text while the call is in
+ * flight and only leaves it cleared once Harness accepted — a refusal keeps the
+ * draft and shows Harness's own reason.
+ * @param spec - the addressed child, delivery, submission, and surface controls.
+ * @returns a live-region overlay that never writes the transcript.
+ */
+export function createSubagentMessageOverlay(spec: SubagentMessageOverlaySpec): TuiOverlay {
+  const composer = new Composer()
+  const controller = new AbortController()
+  const notice = new SurfaceNotice(MESSAGE_NOTICE_MS)
+  let pending = false
+  let closed = false
+  return createBoundedSurface<{ readonly pending: boolean }>({
+    reading: () => ({ pending }),
+    title: () => `${spec.delivery === 'queue' ? 'Follow-up' : 'Steer'} · ${spec.childLabel}`,
+    compact: () => spec.delivery === 'queue' ? 'Follow-up' : 'Steer',
+    notice,
+    footer: () => 'enter send · esc cancel',
+    body: (_reading, width, capacity) => composerBody(composer, width, capacity, spec.delivery),
+    onKey: key => {
+      if (pending) return
+      const action = composer.handle(key)
+      if (action.kind === 'changed') {
+        spec.invalidate()
+        return
+      }
+      if (action.kind === 'ignored') return
+      const text = action.text
+      // `handle` already cleared the buffer. Restore it while Harness decides so
+      // the draft is visibly retained until acceptance, which is the only
+      // moment this surface may clear it.
+      composer.set(text)
+      pending = true
+      notice.show('Sending…')
+      spec.invalidate()
+      void spec.submit(text, controller.signal).then(outcome => {
+        if (closed) return
+        pending = false
+        switch (outcome.kind) {
+          case 'accepted':
+            composer.clear()
+            spec.onAccepted(outcome.messageId)
+            spec.close()
+            return
+          case 'unavailable':
+            notice.show('Subagent follow-up is not available in this profile.', true)
+            break
+          case 'failed':
+            notice.show(outcome.message, true)
+            break
+        }
+        spec.invalidate()
+      })
+    },
+    close: spec.close,
+    dispose: () => {
+      closed = true
+      controller.abort()
+    },
+  })
+}
+
+/** Render every catalog line for one reading. */
+function catalogLines(reading: SubagentCatalogReading, width: number): CatalogLine[] {
+  switch (reading.kind) {
+    case 'unavailable':
+      return [{ text: 'Subagent discovery is not installed in this profile.', role: 'muted' }]
+    case 'loading':
+      return [{ text: 'Listing subagent children…', role: 'muted' }]
+    case 'failed':
+      // The message is untrusted Harness/transport text: it can carry an ESC or
+      // OSC sequence and can wrap. Escape it before measuring and bound it to
+      // the row's own budget, exactly as the transcript and session panels do.
+      return [{
+        text: truncateToWidth(
+          escapeControls(`Discovery failed: ${reading.message}`),
+          Math.max(1, width - GUTTER_COLUMNS),
+        ),
+        role: 'error',
+      }]
+    case 'ready':
+      if (reading.rows.length === 0) {
+        return [{ text: 'No durable subagent children were discovered.', role: 'muted' }]
+      }
+      return reading.rows.map(row => catalogLine(row, width))
+  }
+}
+
+/** One catalog row as a plain line, with marks chosen from Harness facts. */
+function catalogLine(row: SubagentCatalogRow, width: number): CatalogLine {
+  if (row.kind === 'diagnostic') {
+    return {
+      key: subagentRowKey(row),
+      text: fitFacts(subagentRowLabel(row), [diagnosticReasonWord(row.reason)], width - GUTTER_COLUMNS),
+      role: 'warning',
+      mark: '!',
+      markRole: 'warning',
+    }
+  }
+  return {
+    key: subagentRowKey(row),
+    text: fitFacts(subagentRowLabel(row), subagentChildFacts(row), width - GUTTER_COLUMNS),
+    role: 'subdued',
+    // A filled mark reports a session-store residency, never execution; the
+    // colour stays neutral so the row cannot be read as a running spinner.
+    mark: row.residency === 'resident' ? '●' : '·',
+    markRole: 'subdued',
+  }
+}
+
+/** The rows of a ready reading, or none for any other reading. */
+function readyRows(reading: SubagentCatalogReading): readonly SubagentCatalogRow[] {
+  return reading.kind === 'ready' ? reading.rows : []
+}
+
+/** Paint one catalog line; the focused row replaces the mark gutter. */
+function paintCatalogLine(line: CatalogLine, focus: string | undefined): string {
+  const focused = line.key !== undefined && line.key === focus
+  if (focused) return paint(`❯ ${line.text}`, 'selection')
+  const body = line.mark === undefined
+    ? paint(line.text, line.role)
+    : `${paint(line.mark, line.markRole ?? line.role)} ${paint(line.text, line.role)}`
+  return `  ${body}`
+}
+
+/** Fit a name and its facts by dropping whole facts, never cutting one. */
+function fitFacts(name: string, facts: readonly string[], width: number): string {
+  const escaped = escapeControls(name)
+  const remaining = facts.map(fact => escapeControls(fact))
+  const render = (): string => [escaped, ...remaining].join(' · ')
+  while (remaining.length > 0 && displayWidth(render()) > width) remaining.pop()
+  return truncateToWidth(render(), Math.max(1, width))
+}
+
+/** The one-row geometry backstop for the catalog. */
+function catalogCompact(reading: SubagentCatalogReading): string {
+  switch (reading.kind) {
+    case 'unavailable':
+      return 'Subagents unavailable'
+    case 'loading':
+      return 'Loading subagents'
+    case 'failed':
+      return 'Subagent listing failed'
+    case 'ready':
+      return reading.rows.length === 0 ? 'No subagent children' : `Subagents ${String(reading.rows.length)}`
+  }
+}
+
+/** The fixed header rows every conversation inspector shows. */
+function conversationHeader(
+  child: SubagentChildRow,
+  reading: SubagentTranscriptReading,
+  width: number,
+): string[] {
+  const facts = subagentChildFacts(child).join(' · ')
+  return [
+    paint(truncateToWidth(escapeControls(subagentRowLabel(child)), Math.max(1, width)), 'overlay-title'),
+    paint(truncateToWidth(escapeControls(facts), Math.max(1, width)), 'muted'),
+    paint(truncateToWidth(`session  ${escapeControls(child.id)}`, Math.max(1, width)), 'subdued'),
+    // Staleness is a hint, never an action: a child event arrived after this
+    // window was read, and only the reader's explicit refresh re-reads it.
+    ...reading.kind === 'ready' && reading.stale
+      ? [paint(truncateToWidth('new events · r refresh', Math.max(1, width)), 'warning')]
+      : [],
+    '',
+  ]
+}
+
+/** The truthful help for the inspector and its current authority. */
+function conversationHelp(spec: SubagentConversationOverlaySpec, reading: SubagentTranscriptReading): string {
+  const older = reading.kind === 'ready' && reading.hasOlder ? ['[ older'] : []
+  return [
+    '↑↓ scroll',
+    ...older,
+    ...spec.followUp ? ['m message'] : [],
+    ...spec.steer ? ['s steer'] : [],
+    ...spec.interruptible ? ['k interrupt'] : [],
+    'r refresh',
+    'esc back',
+  ].join(' · ')
+}
+
+/** The composer's bounded body: a delivery hint, then the live draft. */
+function composerBody(
+  composer: Composer,
+  width: number,
+  capacity: number,
+  delivery: HumanPromptDelivery,
+): string[] {
+  const hint = delivery === 'queue'
+    ? 'Queued as the child’s next turn.'
+    : 'Steers the nearest step; starts a turn when the child is idle.'
+  const layout = layoutComposer(composer, width, () => '❯ ')
+  const rows = layout.rows.map((row, index) => index === layout.cursorRow
+    ? blockCursor(row, layout.cursorColumn, width)
+    : row)
+  const body = [
+    paint(truncateToWidth(escapeControls(hint), Math.max(1, width)), 'muted'),
+    '',
+    ...rows.map(row => escapeControls(row)),
+  ]
+  return body.slice(0, Math.max(0, capacity))
+}
+
+/**
+ * Draw a block caret at the composer's own cursor column.
+ *
+ * A live-region overlay cannot place the terminal caret, so the editor's
+ * placement is drawn into the row instead. The block is inserted before the
+ * character at the cursor and the row is re-clamped to its width, so the frame
+ * never gains a wrapped row from the caret itself.
+ * @param row - one laid-out composer row, gutter included.
+ * @param column - the cursor's display column on that row.
+ * @param width - display columns available.
+ * @returns the row with a block caret.
+ */
+function blockCursor(row: string, column: number, width: number): string {
+  const left = column <= 0 ? '' : (chunkToWidth(row, column)[0] ?? '')
+  const marked = `${left}█${row.slice(left.length)}`
+  return displayWidth(marked) <= width ? marked : truncateToWidth(marked, Math.max(1, width))
+}

--- a/packages/dshline/src/subagents/presenter.ts
+++ b/packages/dshline/src/subagents/presenter.ts
@@ -1,0 +1,322 @@
+/**
+ * The durable subagent-conversation presenter.
+ *
+ * This is the adapter layer between Harness authority and the terminal: it
+ * reads durable direct children from `ctx.subagents.listChildren`, reads one
+ * child's bounded session window from `ctx.sessionQuery`, and routes human
+ * follow-up/steer through the one human prompt operation Harness publishes.
+ * It owns no lifecycle, no scheduling, and no child conversation state — every
+ * paint re-reads the current reading, and neither a refresh nor a keystroke
+ * invents a row the authority did not publish.
+ *
+ * It is deliberately separate from `HarnessWork`. Work owns active lifecycle
+ * epochs keyed by `runId`, and a settled continuable child has no epoch while
+ * still being a durable conversation. Folding this into Work would also make
+ * `activeWorkCount` see a settled child, which gates retiring the session.
+ *
+ * Interruption is NOT implemented here: it is delegated to the one
+ * `HarnessWork.interruptSubagent` adapter so the terminal never grows a second
+ * human authorization path.
+ * @module dshline/subagents/presenter
+ */
+
+import type { SessionId } from '@deepseek-ai/dsh-session'
+import type { LocalCommand } from '../local-commands.ts'
+import type { TuiSlots } from '../slots.ts'
+import { openSurface, SurfaceNotice } from '../surface.ts'
+import type { WorkInterruptResult } from '../work/model.ts'
+import { deliverHumanPrompt, type HumanPromptDelivery } from './control.ts'
+import {
+  catalogReading,
+  subagentRowFollowUp,
+  subagentRowInterruptible,
+  subagentRowLabel,
+  type SubagentCatalogReading,
+  type SubagentChildRow,
+} from './model.ts'
+import {
+  CONVERSATION_NOTICE_MS,
+  createSubagentCatalogOverlay,
+  createSubagentConversationOverlay,
+  createSubagentMessageOverlay,
+} from './overlay.ts'
+import type { ChildSessionReads, HumanSubagentSeam } from './seam.ts'
+import {
+  initialTranscript,
+  readTranscriptOlder,
+  readTranscriptTail,
+  transcriptReading,
+  type TranscriptState,
+} from './transcript.ts'
+
+/** Narrow dependencies the subagent-conversation presenter needs. */
+export interface SubagentsPresenterDeps {
+  /** Live-region registry that owns the overlay stack. */
+  readonly slots: Pick<TuiSlots, 'pushOverlay'>
+  /** The attached session, which is the durable direct parent Harness authorizes. */
+  readonly parentSessionId: SessionId
+  /** Redraw after a read or action changes presentation state. */
+  readonly invalidate: () => void
+  /** Human-authoritative subagent operations, or undefined without `ctx.subagents`. */
+  readonly subagents?: HumanSubagentSeam
+  /** Bounded child-session reads, or undefined without `ctx.sessionQuery`. */
+  readonly query?: ChildSessionReads
+  /**
+   * Human interrupt, routed to the single `HarnessWork` adapter.
+   * @param childId - the durable direct child.
+   * @param authorized - whether Harness's descriptor mode authorizes interruption.
+   */
+  readonly interrupt: (childId: string, authorized: boolean) => WorkInterruptResult
+  /** Subscribe to parent-scoped subagent lifecycle edges. */
+  readonly onLifecycle?: (listener: () => void) => () => void
+  /**
+   * Subscribe to Harness session events, for a selected child's staleness hint.
+   * @param listener - receives the event's durable session id.
+   */
+  readonly onSessionEvent?: (listener: (sessionId: string) => void) => () => void
+}
+
+/** The subagent-conversation capability as one local command and entry point. */
+export interface SubagentsPresenter {
+  /** `/subagents` — browse durable direct children and inspect one. */
+  readonly command: LocalCommand
+  /** Open the catalog; Work's `c` key calls this. */
+  open(): void
+  /** Abort in-flight reads and release lifecycle subscriptions. */
+  dispose(): void
+}
+
+/** One open conversation inspector's presenter-owned state. */
+interface OpenConversation {
+  /** The durable child being inspected; refreshed when discovery re-lists it. */
+  child: SubagentChildRow
+  /** The currently loaded bounded transcript state. */
+  transcript: TranscriptState
+  /** Cancels this inspector's in-flight reads when it closes or navigates. */
+  readonly abort: AbortController
+  /**
+   * Identity of the newest read started for this inspector. A read that settles
+   * after a newer one started is discarded, so two quick refreshes (or a refresh
+   * racing a paging read) cannot publish an older window over a newer one.
+   */
+  readGeneration: number
+  /** The inspector's own outcome notice. */
+  readonly notice: SurfaceNotice
+}
+
+/**
+ * Build the durable subagent-conversation presenter.
+ * @param deps - narrow Harness seams, the parent address, and surface controls.
+ * @returns the presenter's local command and Work entry point.
+ */
+export function createSubagentsPresenter(deps: SubagentsPresenterDeps): SubagentsPresenter {
+  let catalog: SubagentCatalogReading = deps.subagents === undefined
+    ? { kind: 'unavailable' }
+    : { kind: 'loading' }
+  let catalogGeneration = 0
+  let catalogAbort: AbortController | undefined
+  let catalogOpen = false
+  let closeCatalog: (() => void) | undefined
+
+  let conversation: OpenConversation | undefined
+  let conversationAbort: AbortController | undefined
+
+  const disposers: (() => void)[] = []
+
+  /** Re-run durable discovery under a generation guard. */
+  const refreshCatalog = (): void => {
+    const seam = deps.subagents
+    if (seam === undefined) {
+      catalog = { kind: 'unavailable' }
+      deps.invalidate()
+      return
+    }
+    const generation = (catalogGeneration += 1)
+    catalogAbort?.abort()
+    const abort = new AbortController()
+    catalogAbort = abort
+    // The previous listing's rows are dropped rather than kept: an aging list
+    // beside a "loading" label would present stale facts as current ones.
+    catalog = { kind: 'loading' }
+    deps.invalidate()
+    void seam.listChildren(deps.parentSessionId, abort.signal).then(entries => {
+      if (generation !== catalogGeneration) return
+      catalog = catalogReading(entries)
+      // An open inspector keeps showing the freshest residency Harness published
+      // rather than the snapshot taken when it opened. Durable identity, mode,
+      // and label do not change, but residency can.
+      const open = conversation
+      if (open !== undefined && catalog.kind === 'ready') {
+        const fresh = catalog.rows.find(
+          (row): row is SubagentChildRow => row.kind === 'child' && row.id === open.child.id,
+        )
+        if (fresh !== undefined) open.child = fresh
+      }
+      deps.invalidate()
+    }).catch((error: unknown) => {
+      if (generation !== catalogGeneration) return
+      // Discovery failing is not "no children": the reading says so, and it
+      // never falls back to scanning or to another registry.
+      catalog = { kind: 'failed', message: reason(error) }
+      deps.invalidate()
+    })
+  }
+
+  /** Re-read the newest page of one open inspector. */
+  const reload = (state: OpenConversation): void => {
+    const query = deps.query
+    if (query === undefined) return
+    const generation = (state.readGeneration += 1)
+    void readTranscriptTail(query, state.child.id as SessionId, state.abort.signal).then(next => {
+      if (conversation !== state || state.readGeneration !== generation) return
+      state.transcript = next
+      deps.invalidate()
+    })
+  }
+
+  /** Append one older page, keeping the loaded window on a failed read. */
+  const loadOlder = (state: OpenConversation): void => {
+    const query = deps.query
+    if (query === undefined || state.transcript.kind !== 'ready' || !state.transcript.hasOlder) return
+    const generation = (state.readGeneration += 1)
+    void readTranscriptOlder(query, state.child.id as SessionId, state.transcript, state.abort.signal)
+      .then(next => {
+        if (conversation !== state || state.readGeneration !== generation) return
+        state.transcript = next
+        deps.invalidate()
+      })
+      .catch((error: unknown) => {
+        if (conversation !== state || state.readGeneration !== generation) return
+        state.notice.show(`Older events failed: ${reason(error)}`, true)
+        deps.invalidate()
+      })
+  }
+
+  /** Interrupt through the shared Work adapter and report its outcome. */
+  const interruptChild = (state: OpenConversation): void => {
+    const result = deps.interrupt(state.child.id, subagentRowInterruptible(state.child))
+    state.notice.show(result.message, result.kind === 'failed')
+    deps.invalidate()
+  }
+
+  /** Push the small message composer over one inspector. */
+  const openComposer = (state: OpenConversation, delivery: HumanPromptDelivery): void => {
+    openSurface(deps.slots, close => createSubagentMessageOverlay({
+      childLabel: subagentRowLabel(state.child),
+      delivery,
+      submit: (text, signal) => deliverHumanPrompt(deps.subagents, {
+        parentSessionId: deps.parentSessionId,
+        childId: state.child.id as SessionId,
+        text,
+        delivery,
+      }, signal),
+      onAccepted: () => {
+        // Harness accepted the message; the durable log is the only place the
+        // message may appear, so the receipt is a notice and never a row.
+        state.notice.show('Follow-up accepted')
+        deps.invalidate()
+      },
+      close,
+      invalidate: deps.invalidate,
+    }))
+  }
+
+  /** Push the read-only conversation inspector over the catalog. */
+  const openConversation = (childId: string): void => {
+    const row = catalog.kind === 'ready'
+      ? catalog.rows.find(candidate => candidate.kind === 'child' && candidate.id === childId)
+      : undefined
+    if (row === undefined || row.kind !== 'child') return
+    conversationAbort?.abort()
+    const state: OpenConversation = {
+      child: row,
+      transcript: initialTranscript(deps.query !== undefined),
+      abort: new AbortController(),
+      readGeneration: 0,
+      notice: new SurfaceNotice(CONVERSATION_NOTICE_MS),
+    }
+    conversation = state
+    conversationAbort = state.abort
+    if (deps.query !== undefined) reload(state)
+    openSurface(deps.slots, close => createSubagentConversationOverlay({
+      child: () => state.child,
+      reading: () => transcriptReading(state.transcript),
+      followUp: subagentRowFollowUp(row, deps.subagents !== undefined),
+      steer: subagentRowFollowUp(row, deps.subagents !== undefined),
+      interruptible: subagentRowInterruptible(row),
+      loadOlder: () => { loadOlder(state) },
+      refresh: () => { reload(state) },
+      message: delivery => { openComposer(state, delivery) },
+      interrupt: () => { interruptChild(state) },
+      notice: state.notice,
+      close: () => {
+        if (conversation === state) conversation = undefined
+        // Cancel this inspector's in-flight reads now, rather than waiting for
+        // the next open or teardown, so a late page never reaches a dead surface.
+        state.abort.abort()
+        close()
+      },
+      invalidate: deps.invalidate,
+    }))
+  }
+
+  /** Open the durable-child catalog, replacing any catalog already open. */
+  const open = (): void => {
+    closeCatalog?.()
+    catalogOpen = true
+    refreshCatalog()
+    closeCatalog = openSurface(deps.slots, close => createSubagentCatalogOverlay({
+      reading: () => catalog,
+      inspect: childId => { openConversation(childId) },
+      refresh: refreshCatalog,
+      close: () => {
+        catalogOpen = false
+        closeCatalog = undefined
+        close()
+      },
+      invalidate: deps.invalidate,
+    }))
+  }
+
+  if (deps.onLifecycle !== undefined) {
+    disposers.push(deps.onLifecycle(() => {
+      if (catalogOpen) refreshCatalog()
+    }))
+  }
+  if (deps.onSessionEvent !== undefined) {
+    disposers.push(deps.onSessionEvent(childId => {
+      const state = conversation
+      // A child event is only a staleness hint: it never mutates the transcript
+      // and never triggers a read, because Harness publishes no per-child
+      // transcript subscription and polling one would be a local state machine.
+      if (state === undefined || state.child.id !== childId || state.transcript.kind !== 'ready') return
+      state.transcript = { ...state.transcript, stale: true }
+      deps.invalidate()
+    }))
+  }
+
+  return {
+    command: {
+      name: 'subagents',
+      description: 'Browse durable subagent conversations and continue one',
+      execute: () => { open() },
+    },
+    open,
+    dispose(): void {
+      catalogGeneration += 1
+      catalogAbort?.abort()
+      conversationAbort?.abort()
+      conversation = undefined
+      for (const dispose of disposers.splice(0)) dispose()
+    },
+  }
+}
+
+/**
+ * A short, safe account of a read or discovery failure.
+ * @param error - the thrown value.
+ * @returns a message fit for a bounded row.
+ */
+function reason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/dshline/src/subagents/presenter.ts
+++ b/packages/dshline/src/subagents/presenter.ts
@@ -14,9 +14,11 @@
  * still being a durable conversation. Folding this into Work would also make
  * `activeWorkCount` see a settled child, which gates retiring the session.
  *
- * Interruption is NOT implemented here: it is delegated to the one
- * `HarnessWork.interruptSubagent` adapter so the terminal never grows a second
- * human authorization path.
+ * Interruption is deliberately NOT part of this presenter. `/work` owns the
+ * active lifecycle epoch and its existing human interrupt; a durable child's
+ * `listChildren().activity` is session-store residency, not proof that a turn
+ * is executing, so offering interrupt here could claim a cancellation Harness
+ * only accepted as a no-op. The durable view inspects and continues instead.
  * @module dshline/subagents/presenter
  */
 
@@ -24,12 +26,10 @@ import type { SessionId } from '@deepseek-ai/dsh-session'
 import type { LocalCommand } from '../local-commands.ts'
 import type { TuiSlots } from '../slots.ts'
 import { openSurface, SurfaceNotice } from '../surface.ts'
-import type { WorkInterruptResult } from '../work/model.ts'
 import { deliverHumanPrompt, type HumanPromptDelivery } from './control.ts'
 import {
   catalogReading,
   subagentRowFollowUp,
-  subagentRowInterruptible,
   subagentRowLabel,
   type SubagentCatalogReading,
   type SubagentChildRow,
@@ -61,12 +61,6 @@ export interface SubagentsPresenterDeps {
   readonly subagents?: HumanSubagentSeam
   /** Bounded child-session reads, or undefined without `ctx.sessionQuery`. */
   readonly query?: ChildSessionReads
-  /**
-   * Human interrupt, routed to the single `HarnessWork` adapter.
-   * @param childId - the durable direct child.
-   * @param authorized - whether Harness's descriptor mode authorizes interruption.
-   */
-  readonly interrupt: (childId: string, authorized: boolean) => WorkInterruptResult
   /** Subscribe to parent-scoped subagent lifecycle edges. */
   readonly onLifecycle?: (listener: () => void) => () => void
   /**
@@ -100,6 +94,13 @@ interface OpenConversation {
    * racing a paging read) cannot publish an older window over a newer one.
    */
   readGeneration: number
+  /**
+   * Count of selected-child session events seen. A read captures this before it
+   * starts and publishes `stale` from whether it still matches when the read
+   * settles, which is what keeps an event arriving MID-read from being lost when
+   * the read overwrites the flag with its own `stale:false`.
+   */
+  eventGeneration: number
   /** The inspector's own outcome notice. */
   readonly notice: SurfaceNotice
 }
@@ -167,22 +168,24 @@ export function createSubagentsPresenter(deps: SubagentsPresenterDeps): Subagent
     const query = deps.query
     if (query === undefined) return
     const generation = (state.readGeneration += 1)
+    const seen = state.eventGeneration
     void readTranscriptTail(query, state.child.id as SessionId, state.abort.signal).then(next => {
       if (conversation !== state || state.readGeneration !== generation) return
-      state.transcript = next
+      state.transcript = { ...next, stale: state.eventGeneration !== seen }
       deps.invalidate()
     })
   }
 
-  /** Append one older page, keeping the loaded window on a failed read. */
+  /** Replace the loaded window with one older page, keeping it on a failed read. */
   const loadOlder = (state: OpenConversation): void => {
     const query = deps.query
     if (query === undefined || state.transcript.kind !== 'ready' || !state.transcript.hasOlder) return
     const generation = (state.readGeneration += 1)
+    const seen = state.eventGeneration
     void readTranscriptOlder(query, state.child.id as SessionId, state.transcript, state.abort.signal)
       .then(next => {
         if (conversation !== state || state.readGeneration !== generation) return
-        state.transcript = next
+        state.transcript = { ...next, stale: state.eventGeneration !== seen }
         deps.invalidate()
       })
       .catch((error: unknown) => {
@@ -190,13 +193,6 @@ export function createSubagentsPresenter(deps: SubagentsPresenterDeps): Subagent
         state.notice.show(`Older events failed: ${reason(error)}`, true)
         deps.invalidate()
       })
-  }
-
-  /** Interrupt through the shared Work adapter and report its outcome. */
-  const interruptChild = (state: OpenConversation): void => {
-    const result = deps.interrupt(state.child.id, subagentRowInterruptible(state.child))
-    state.notice.show(result.message, result.kind === 'failed')
-    deps.invalidate()
   }
 
   /** Push the small message composer over one inspector. */
@@ -233,6 +229,7 @@ export function createSubagentsPresenter(deps: SubagentsPresenterDeps): Subagent
       transcript: initialTranscript(deps.query !== undefined),
       abort: new AbortController(),
       readGeneration: 0,
+      eventGeneration: 0,
       notice: new SurfaceNotice(CONVERSATION_NOTICE_MS),
     }
     conversation = state
@@ -243,11 +240,9 @@ export function createSubagentsPresenter(deps: SubagentsPresenterDeps): Subagent
       reading: () => transcriptReading(state.transcript),
       followUp: subagentRowFollowUp(row, deps.subagents !== undefined),
       steer: subagentRowFollowUp(row, deps.subagents !== undefined),
-      interruptible: subagentRowInterruptible(row),
       loadOlder: () => { loadOlder(state) },
       refresh: () => { reload(state) },
       message: delivery => { openComposer(state, delivery) },
-      interrupt: () => { interruptChild(state) },
       notice: state.notice,
       close: () => {
         if (conversation === state) conversation = undefined
@@ -286,11 +281,17 @@ export function createSubagentsPresenter(deps: SubagentsPresenterDeps): Subagent
   if (deps.onSessionEvent !== undefined) {
     disposers.push(deps.onSessionEvent(childId => {
       const state = conversation
+      if (state === undefined || state.child.id !== childId) return
       // A child event is only a staleness hint: it never mutates the transcript
       // and never triggers a read, because Harness publishes no per-child
       // transcript subscription and polling one would be a local state machine.
-      if (state === undefined || state.child.id !== childId || state.transcript.kind !== 'ready') return
-      state.transcript = { ...state.transcript, stale: true }
+      // The count advances for EVERY selected-child event, including one that
+      // arrives while the first read is still in flight; that read captured the
+      // count before it started and publishes `stale` from whether it still matches.
+      state.eventGeneration += 1
+      if (state.transcript.kind === 'ready') {
+        state.transcript = { ...state.transcript, stale: true }
+      }
       deps.invalidate()
     }))
   }

--- a/packages/dshline/src/subagents/seam.ts
+++ b/packages/dshline/src/subagents/seam.ts
@@ -10,9 +10,10 @@
  *
  * It is deliberately not a `Pick` of the whole runtime: `listDescendants` is
  * absent because this PR browses direct children only, and `interrupt` is
- * absent because human interruption already has one Dshline adapter
- * (`HarnessWork.interruptSubagent`) and a second call site would be a second
- * authorization path.
+ * absent because the durable view must not offer it — `listChildren().activity`
+ * is session-store residency, not proof a turn is executing, so a durable
+ * inspector cannot tell a real cancellation from Harness's accepted no-op.
+ * Interrupt stays on `/work`, where an open lifecycle epoch is the premise.
  *
  * The child-session read surface is likewise structural: only the two bounded
  * reads the inspector uses, never `readSession` (a whole-log read) and never a

--- a/packages/dshline/src/subagents/seam.ts
+++ b/packages/dshline/src/subagents/seam.ts
@@ -1,0 +1,59 @@
+/**
+ * The narrow Harness surfaces the subagent-conversation presenter consumes.
+ *
+ * This module exists to make the authority boundary a TYPE rather than a
+ * convention. `ctx.subagents` is a `SubagentRuntime`, which also publishes
+ * `sendMessage(sender: Agent, …)` — model-authored adjacent-Agent messaging,
+ * not a human path. Picking only the two operations a human terminal may call
+ * means a future edit that reaches for `sendMessage` fails `pnpm typecheck`
+ * instead of silently impersonating the parent Agent.
+ *
+ * It is deliberately not a `Pick` of the whole runtime: `listDescendants` is
+ * absent because this PR browses direct children only, and `interrupt` is
+ * absent because human interruption already has one Dshline adapter
+ * (`HarnessWork.interruptSubagent`) and a second call site would be a second
+ * authorization path.
+ *
+ * The child-session read surface is likewise structural: only the two bounded
+ * reads the inspector uses, never `readSession` (a whole-log read) and never a
+ * provider API.
+ * @module dshline/subagents/seam
+ */
+
+import type { SessionEventRecord } from '@deepseek-ai/dsh-session-query'
+import type { SessionEventReadRequest, SessionEventWindow } from '@deepseek-ai/dsh-session-query'
+import type { SessionId } from '@deepseek-ai/dsh-session'
+import type { SubagentRuntime } from '@deepseek-ai/dsh-subagent'
+
+/**
+ * The human-authoritative subset of `ctx.subagents` a terminal may call.
+ *
+ * `listChildren` is the durable direct-child discovery; `prompt` is Harness's
+ * browser/human control operation, which owns direct-parent authorization,
+ * continuable-child validation, Queue versus Steer scheduling, human
+ * provenance, cold materialization, and the accepted `MessageId` receipt.
+ */
+export type HumanSubagentSeam = Pick<SubagentRuntime, 'listChildren' | 'prompt'>
+
+/**
+ * The bounded session reads the conversation inspector performs.
+ *
+ * `listEvents` supplies the lightweight seq index that locates the tail page;
+ * `readEvent` supplies one bounded window of full event bodies around a target
+ * seq. Neither publishes an Agent or resumes the child.
+ */
+export interface ChildSessionReads {
+  /**
+   * List lightweight records for one session, in ascending seq order.
+   * @param sessionId - the durable child session to index.
+   * @returns the event metadata, without bodies.
+   */
+  listEvents(sessionId: SessionId): Promise<SessionEventRecord[]>
+  /**
+   * Read one target event plus a bounded raw-log window around it.
+   * @param request - the session, target seq, and window bounds.
+   * @param signal - optional cancellation.
+   * @returns the bounded window of full event bodies.
+   */
+  readEvent(request: SessionEventReadRequest, signal?: AbortSignal): Promise<SessionEventWindow>
+}

--- a/packages/dshline/src/subagents/transcript.ts
+++ b/packages/dshline/src/subagents/transcript.ts
@@ -1,0 +1,247 @@
+/**
+ * Bounded reads and rendering of one durable child's own session log.
+ *
+ * The inspector is a temporary live-region surface over Harness's own record,
+ * not a second transcript database. It keeps a lightweight seq index plus ONE
+ * bounded page of full event bodies, reads a further page only when the reader
+ * asks for older history, and renders each event with Harness's
+ * `extractSessionEventText` — the same presentation helper `/sessions` uses.
+ * Nothing here folds the log, and nothing resumes or publishes the child.
+ *
+ * The page size is a real tradeoff rather than a round number: Harness caps
+ * `readEvent` at 50 events per window, and a child turn is roughly six to ten
+ * raw events, so 24 spans about two or three turns of conversation while
+ * keeping the retained bodies small.
+ * @module dshline/subagents/transcript
+ */
+
+import type { SessionEvent, SessionId, SessionSeq } from '@deepseek-ai/dsh-session'
+import type { SessionEventRecord } from '@deepseek-ai/dsh-session-query'
+import { extractSessionEventText } from '@deepseek-ai/dsh-session-query'
+import { escapeControls, paint, truncateToWidth, wrapToWidth } from '@dshline/renderer'
+import { relativeAge } from '../sessions/model.ts'
+import type { ChildSessionReads } from './seam.ts'
+
+/**
+ * Full event bodies retained by one page read.
+ *
+ * Deliberately below Harness's 50-event window cap so a tail read of
+ * `before: TRANSCRIPT_PAGE - 1` plus its target never asks for more than the
+ * engine will serve.
+ */
+export const TRANSCRIPT_PAGE = 24
+
+/** Columns of indent under an event's metadata row. */
+const CONTEXT_INDENT = 2
+
+/**
+ * What the conversation inspector can truthfully show.
+ *
+ * `stale` is only a presentation hint that a child session event arrived after
+ * the window was read; the reader reloads on an explicit gesture, because
+ * Harness publishes no per-child transcript subscription and polling one would
+ * be a timer-backed state machine this frontend must not own.
+ */
+export type SubagentTranscriptReading =
+  | { readonly kind: 'unavailable' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'empty' }
+  | { readonly kind: 'failed'; readonly message: string }
+  | {
+    readonly kind: 'ready'
+    readonly events: readonly SessionEvent[]
+    readonly hasOlder: boolean
+    readonly stale: boolean
+  }
+
+/** The reader's retained state: the seq index plus one loaded window. */
+export interface TranscriptState {
+  /** Which reading this state resolves to. */
+  readonly kind: 'unavailable' | 'loading' | 'empty' | 'failed' | 'ready'
+  /** Harness's lightweight seq index for the whole child log. */
+  readonly index: readonly SessionEventRecord[]
+  /** The loaded window's full bodies, ascending by seq. */
+  readonly events: readonly SessionEvent[]
+  /** First seq of the loaded window, when one is loaded. */
+  readonly startSeq?: SessionSeq
+  /** Whether an older page exists before the loaded window. */
+  readonly hasOlder: boolean
+  /** Whether a child session event arrived since the window was read. */
+  readonly stale: boolean
+  /** Harness's or the transport's failure message, when the read failed. */
+  readonly message?: string
+}
+
+/**
+ * The state before any read has answered.
+ * @param available - whether the profile mounts a session-query read surface.
+ * @returns a loading state, or the honest capability absence.
+ */
+export function initialTranscript(available: boolean): TranscriptState {
+  return {
+    kind: available ? 'loading' : 'unavailable',
+    index: [],
+    events: [],
+    hasOlder: false,
+    stale: false,
+  }
+}
+
+/**
+ * Project the reader's state onto the small reading the overlay draws.
+ * @param state - the retained reader state.
+ * @returns the terminal-facing reading.
+ */
+export function transcriptReading(state: TranscriptState): SubagentTranscriptReading {
+  switch (state.kind) {
+    case 'unavailable':
+    case 'loading':
+    case 'empty':
+      return { kind: state.kind }
+    case 'failed':
+      return { kind: 'failed', message: state.message ?? 'The transcript could not be read.' }
+    case 'ready':
+      return { kind: 'ready', events: state.events, hasOlder: state.hasOlder, stale: state.stale }
+  }
+}
+
+/**
+ * Read the newest page of one child's durable log.
+ *
+ * Two reads, both on demand: `listEvents` supplies the seq index (and the tail
+ * seq a bounded window needs), and `readEvent` supplies the full bodies for the
+ * newest page. No Agent is loaded, no turn is started, and the child's own
+ * session log stays the only authority.
+ * @param query - the bounded child-session read surface.
+ * @param childId - the durable child session to read.
+ * @param signal - caller cancellation, observed before the state is published.
+ * @returns the newest page's state, or an honest failure state.
+ */
+export async function readTranscriptTail(
+  query: ChildSessionReads,
+  childId: SessionId,
+  signal?: AbortSignal,
+): Promise<TranscriptState> {
+  try {
+    const index = await query.listEvents(childId)
+    if (index.length === 0) return { kind: 'empty', index, events: [], hasOlder: false, stale: false }
+    const last = index[index.length - 1] as SessionEventRecord
+    const window = await query.readEvent(
+      { sessionId: childId, seq: last.seq, before: TRANSCRIPT_PAGE - 1, after: 0 },
+      signal,
+    )
+    return {
+      kind: 'ready',
+      index,
+      events: window.events,
+      startSeq: window.startSeq,
+      hasOlder: index.some(record => record.seq < window.startSeq),
+      stale: false,
+    }
+  } catch (error: unknown) {
+    return { kind: 'failed', index: [], events: [], hasOlder: false, stale: false, message: reason(error) }
+  }
+}
+
+/**
+ * Read one older page before the currently loaded window.
+ *
+ * The index from {@link readTranscriptTail} locates the record immediately
+ * before the window, so paging walks the log backwards without re-reading it.
+ * @param query - the bounded child-session read surface.
+ * @param childId - the durable child session being inspected.
+ * @param state - the currently loaded reader state.
+ * @param signal - caller cancellation.
+ * @returns the state with the older page prepended.
+ * @throws when the read fails; the caller keeps the loaded window and reports
+ *   the failure as a notice rather than discarding history it already has.
+ */
+export async function readTranscriptOlder(
+  query: ChildSessionReads,
+  childId: SessionId,
+  state: TranscriptState,
+  signal?: AbortSignal,
+): Promise<TranscriptState> {
+  const at = state.startSeq === undefined
+    ? -1
+    : state.index.findIndex(record => record.seq === state.startSeq)
+  if (at <= 0) return { ...state, hasOlder: false }
+  const previous = state.index[at - 1] as SessionEventRecord
+  const window = await query.readEvent(
+    { sessionId: childId, seq: previous.seq, before: TRANSCRIPT_PAGE - 1, after: 0 },
+    signal,
+  )
+  const older = window.events.filter(event => state.events.every(loaded => loaded.seq !== event.seq))
+  return {
+    ...state,
+    events: [...older, ...state.events],
+    startSeq: window.startSeq,
+    hasOlder: state.index.some(record => record.seq < window.startSeq),
+    stale: false,
+  }
+}
+
+/**
+ * Render the loaded window as bounded terminal rows.
+ *
+ * An event with no semantic text — a structural boundary or an unknown
+ * declaration-merged type — deliberately contributes only its metadata row,
+ * exactly as `/sessions` does, rather than a stringified payload.
+ * @param reading - the terminal-facing reading.
+ * @param width - display columns inside the frame.
+ * @returns one metadata row per event, plus wrapped body rows.
+ */
+export function transcriptRows(reading: SubagentTranscriptReading, width: number): string[] {
+  if (reading.kind !== 'ready') return absenceRows(reading, width)
+  if (reading.events.length === 0) return [mutedRow('This child has no recorded events.', width)]
+  const rows: string[] = []
+  const now = Date.now()
+  for (const event of reading.events) {
+    const meta = `${event.type} · seq ${String(event.seq)} · ${relativeAge(event.time, now)}`
+    rows.push(paint(truncateToWidth(escapeControls(meta), Math.max(1, width)), 'muted'))
+    const text = extractSessionEventText(event)
+    if (text === '') continue
+    for (const line of wrapToWidth(escapeControls(text), Math.max(1, width - CONTEXT_INDENT))) {
+      rows.push(line === '' ? '' : `${' '.repeat(CONTEXT_INDENT)}${paint(line, 'subdued')}`)
+    }
+  }
+  return rows
+}
+
+/**
+ * The one truthful row for a reading with no window.
+ * @param reading - an absence reading.
+ * @param width - display columns inside the frame.
+ * @returns the absence row.
+ */
+function absenceRows(reading: Exclude<SubagentTranscriptReading, { kind: 'ready' }>, width: number): string[] {
+  switch (reading.kind) {
+    case 'unavailable':
+      return [mutedRow('Session query is not installed in this profile.', width)]
+    case 'loading':
+      return [mutedRow('Reading this child’s conversation…', width)]
+    case 'empty':
+      return [mutedRow('This child has no recorded events.', width)]
+    case 'failed':
+      return [paint(truncateToWidth(`Transcript failed: ${escapeControls(reading.message)}`, Math.max(1, width)), 'error')]
+  }
+}
+
+/**
+ * A truncated, escaped muted row.
+ * @param text - untrusted or fixed message text.
+ * @param width - display columns inside the frame.
+ * @returns the finished row.
+ */
+function mutedRow(text: string, width: number): string {
+  return paint(truncateToWidth(escapeControls(text), Math.max(1, width)), 'muted')
+}
+
+/**
+ * A short, safe account of a read failure.
+ * @param error - the thrown value.
+ * @returns a message fit for a bounded row.
+ */
+function reason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/dshline/src/subagents/transcript.ts
+++ b/packages/dshline/src/subagents/transcript.ts
@@ -144,15 +144,20 @@ export async function readTranscriptTail(
 }
 
 /**
- * Read one older page before the currently loaded window.
+ * Read one older page, replacing the currently loaded window.
  *
  * The index from {@link readTranscriptTail} locates the record immediately
  * before the window, so paging walks the log backwards without re-reading it.
+ * The read REPLACES the window rather than prepending to it: the module's
+ * contract is one bounded page of full bodies, and an accumulating window would
+ * let `[` grow presenter state to the whole child log. `r` returns to the newest
+ * page. The new window `[previous - (TRANSCRIPT_PAGE - 1) .. previous]` is
+ * disjoint from the old one, so no de-duplication is needed.
  * @param query - the bounded child-session read surface.
  * @param childId - the durable child session being inspected.
- * @param state - the currently loaded reader state.
+ * @param state - the currently loaded reader state, whose page is replaced.
  * @param signal - caller cancellation.
- * @returns the state with the older page prepended.
+ * @returns the state with the older page loaded in place of the current one.
  * @throws when the read fails; the caller keeps the loaded window and reports
  *   the failure as a notice rather than discarding history it already has.
  */
@@ -171,10 +176,12 @@ export async function readTranscriptOlder(
     { sessionId: childId, seq: previous.seq, before: TRANSCRIPT_PAGE - 1, after: 0 },
     signal,
   )
-  const older = window.events.filter(event => state.events.every(loaded => loaded.seq !== event.seq))
+  // A window with no bodies is a local inconsistency, not a page to publish as
+  // the whole conversation; keep what is loaded and stop offering older.
+  if (window.events.length === 0) return { ...state, hasOlder: false }
   return {
     ...state,
-    events: [...older, ...state.events],
+    events: window.events,
     startSeq: window.startSeq,
     hasOlder: state.index.some(record => record.seq < window.startSeq),
     stale: false,

--- a/packages/dshline/src/views.ts
+++ b/packages/dshline/src/views.ts
@@ -28,6 +28,7 @@ import { CHROME_MIN_COLUMNS, chromeWidth, composerFrameWidth, rootFrame } from '
 import type { BusyEnter } from './delivery.ts'
 import { DEFAULT_BUSY_ENTER } from './delivery.ts'
 import type { TuiSlotView } from './slots.ts'
+import { cursorWindow } from './scroll.ts'
 import type { GoalReading } from './goals/model.ts'
 import type { PendingUserInput } from './steering.ts'
 
@@ -229,6 +230,10 @@ export function createComposerView(
 
   /**
    * The rows to draw, scrolled so the cursor's row is visible.
+   *
+   * The policy itself lives in {@link cursorWindow}, shared with the bounded
+   * subagent message overlay; this wrapper only supplies the composer's own
+   * fixed live-region cap on top of the budget `compose()` granted.
    * @param all - every wrapped row of the buffer.
    * @param row - the cursor's row within them.
    * @param maximum - most content rows the current live-region budget permits.
@@ -239,14 +244,8 @@ export function createComposerView(
     all: readonly string[],
     row: number,
     maximum = COMPOSER_ROWS,
-  ): { rows: readonly string[]; offset: number; below: number } => {
-    const visible = Math.max(1, Math.min(COMPOSER_ROWS, maximum))
-    if (all.length <= visible) return { rows: all, offset: 0, below: 0 }
-    // Keep the cursor's row in view, preferring to show what follows it: a person
-    // pasting or typing is working at the end.
-    const offset = Math.min(all.length - visible, Math.max(0, row - visible + 1))
-    return { rows: all.slice(offset, offset + visible), offset, below: all.length - offset - visible }
-  }
+  ): { rows: readonly string[]; offset: number; below: number } =>
+    cursorWindow(all, row, maximum, COMPOSER_ROWS)
 
   /**
    * The frame title, with an honest count of what the viewport hides.

--- a/packages/dshline/src/work/index.ts
+++ b/packages/dshline/src/work/index.ts
@@ -246,20 +246,35 @@ export class HarnessWork {
    * @param item - selected work item.
    */
   interrupt(item: JobWorkItem | SubagentWorkItem | WorkflowWorkItem): WorkInterruptResult {
-    const { agent, subagents } = this.capabilities
     // Job cancellation marks a record reported, changing model-delivery
     // semantics. `/work` observes jobs but must not recreate that control path.
     if (item.source === 'job') return { kind: 'unsupported', message: 'Jobs cannot be stopped from Work.' }
     // `ctx.workflowEngine` publishes `start()` alone: a run handle reaches only
     // its caller, so there is no authority here to cancel one from the terminal.
     if (item.source === 'workflow') return { kind: 'unsupported', message: 'Workflow runs cannot be stopped from Work.' }
+    return this.interruptSubagent(item.id, item.interruptible)
+  }
+
+  /**
+   * The ONE human interrupt adapter for an addressed durable direct child.
+   *
+   * Both `HarnessWork.interrupt` on an active epoch and the durable
+   * conversation inspector route here, so interruption keeps a single Dshline
+   * authorization point rather than two call sites that could drift.
+   * @param childId - durable child session id.
+   * @param authorized - the caller's decision that this child is interruptible;
+   *   only a continuable child's descriptor mode makes it true.
+   * @returns whether Harness accepted, rejected, or cannot interrupt the request.
+   */
+  interruptSubagent(childId: string, authorized: boolean): WorkInterruptResult {
+    const { agent, subagents } = this.capabilities
     try {
       // One-shot runs have no service-level interrupt operation. Pretending they
       // do would lie about a capability that only their holder owns.
-      if (subagents === undefined || !item.interruptible) {
+      if (subagents === undefined || !authorized) {
         return { kind: 'unsupported', message: 'This subagent cannot be interrupted here.' }
       }
-      subagents.interrupt(item.id as Parameters<SubagentRuntime['interrupt']>[0], {
+      subagents.interrupt(childId as Parameters<SubagentRuntime['interrupt']>[0], {
         kind: 'user', parentSessionId: agent.session.id,
       })
       this.capabilities.invalidate()

--- a/packages/dshline/src/work/index.ts
+++ b/packages/dshline/src/work/index.ts
@@ -246,35 +246,20 @@ export class HarnessWork {
    * @param item - selected work item.
    */
   interrupt(item: JobWorkItem | SubagentWorkItem | WorkflowWorkItem): WorkInterruptResult {
+    const { agent, subagents } = this.capabilities
     // Job cancellation marks a record reported, changing model-delivery
     // semantics. `/work` observes jobs but must not recreate that control path.
     if (item.source === 'job') return { kind: 'unsupported', message: 'Jobs cannot be stopped from Work.' }
     // `ctx.workflowEngine` publishes `start()` alone: a run handle reaches only
     // its caller, so there is no authority here to cancel one from the terminal.
     if (item.source === 'workflow') return { kind: 'unsupported', message: 'Workflow runs cannot be stopped from Work.' }
-    return this.interruptSubagent(item.id, item.interruptible)
-  }
-
-  /**
-   * The ONE human interrupt adapter for an addressed durable direct child.
-   *
-   * Both `HarnessWork.interrupt` on an active epoch and the durable
-   * conversation inspector route here, so interruption keeps a single Dshline
-   * authorization point rather than two call sites that could drift.
-   * @param childId - durable child session id.
-   * @param authorized - the caller's decision that this child is interruptible;
-   *   only a continuable child's descriptor mode makes it true.
-   * @returns whether Harness accepted, rejected, or cannot interrupt the request.
-   */
-  interruptSubagent(childId: string, authorized: boolean): WorkInterruptResult {
-    const { agent, subagents } = this.capabilities
     try {
       // One-shot runs have no service-level interrupt operation. Pretending they
       // do would lie about a capability that only their holder owns.
-      if (subagents === undefined || !authorized) {
+      if (subagents === undefined || !item.interruptible) {
         return { kind: 'unsupported', message: 'This subagent cannot be interrupted here.' }
       }
-      subagents.interrupt(childId as Parameters<SubagentRuntime['interrupt']>[0], {
+      subagents.interrupt(item.id as Parameters<SubagentRuntime['interrupt']>[0], {
         kind: 'user', parentSessionId: agent.session.id,
       })
       this.capabilities.invalidate()

--- a/packages/dshline/src/work/overlay.ts
+++ b/packages/dshline/src/work/overlay.ts
@@ -111,6 +111,13 @@ export interface WorkOverlaySpec {
   readonly snapshot: () => WorkSnapshot
   /** Ask Harness to interrupt one row where it exposes that authority. */
   readonly interrupt: (item: WorkItem) => WorkInterruptResult
+  /**
+   * Open the durable subagent-conversation catalog, when `ctx.subagents` is
+   * mounted. The catalog belongs to a separate presenter: Work hands off and
+   * keeps no durable conversation state of its own, and this is absent exactly
+   * when that authority is.
+   */
+  readonly conversations?: () => void
   /** Remove this overlay from the live region. */
   readonly close: () => void
   /** Redraw after selection, a result, or a timer tick. */
@@ -302,7 +309,7 @@ export function createWorkOverlay(spec: WorkOverlaySpec): TuiOverlay {
             '',
             ...built.slice(viewport.start, viewport.end).map(row => paintRow(row, frame().focus.current)),
           ],
-          footer: fitFooterHelp(stageHelp(frame().stage, aimed, subject()), footerBudget(columns)),
+          footer: fitFooterHelp(stageHelp(frame().stage, aimed, subject(), spec.conversations !== undefined), footerBudget(columns)),
         }),
       ]
       // The root frame wraps its content, including short-state text a caller may not
@@ -336,6 +343,13 @@ export function createWorkOverlay(spec: WorkOverlaySpec): TuiOverlay {
           notice = { text: result.message, failed: result.kind === 'failed', expiresAt: Date.now() + NOTICE_MS }
         }
         spec.invalidate()
+        return
+      }
+      // The durable conversation catalog lives in its own presenter. Work only
+      // hands the keyboard over: it keeps no child list, no transcript, and no
+      // message buffer of its own. The key exists exactly while the drawer does.
+      if (key.kind === 'text' && key.text === 'c' && spec.conversations !== undefined) {
+        spec.conversations()
         return
       }
       if (key.kind !== 'key') return
@@ -862,11 +876,17 @@ function fitSegments(name: string, segments: readonly RowSegment[], width: numbe
 }
 
 /** The help truthful for this stage, the focused row, and the current authority. */
-function stageHelp(stage: Stage, focused: StageRow | undefined, item: WorkItem | undefined): string {
+function stageHelp(
+  stage: Stage,
+  focused: StageRow | undefined,
+  item: WorkItem | undefined,
+  conversations: boolean,
+): string {
   const interrupt = item?.source === 'subagent' && item.interruptible ? ' · k interrupt' : ''
   const enter = focused?.open === undefined ? '' : ' · ↵ inspect'
+  const catalog = conversations ? ' · c conversations' : ''
   const exit = stage.kind === 'list' ? ' · esc close' : ' · esc back'
-  return `↑↓ select${enter}${interrupt}${exit}`
+  return `↑↓ select${enter}${interrupt}${catalog}${exit}`
 }
 
 /** Count the physical terminal rows the Screen will use for candidate lines. */

--- a/packages/dshline/tests/capability/subagents.probe.spec.ts
+++ b/packages/dshline/tests/capability/subagents.probe.spec.ts
@@ -52,6 +52,11 @@ describe('capability: subagents', () => {
     const ctx = new Context()
     try {
       await ctx.plugin(SubagentRuntime)
+      // The human prompt operation is a public instance method on the same
+      // service object, which is what lets a same-process terminal call it
+      // instead of the model-authored `sendMessage`. Asserted against the real
+      // runtime, not a fake.
+      expect(typeof ctx.subagents.prompt).toBe('function')
       const { provider, settle } = createProbeProvider()
       ctx.subagents.registerProvider(provider)
 

--- a/packages/dshline/tests/subagent-conversations-architecture.spec.ts
+++ b/packages/dshline/tests/subagent-conversations-architecture.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Architectural guards for the human subagent-conversation path.
+ *
+ * The load-bearing guarantee is the TYPE: `HumanSubagentSeam` is a `Pick` of
+ * `SubagentRuntime` with only `listChildren` and `prompt`, so a call to the
+ * model-authored `sendMessage` is a `pnpm typecheck` failure in `src`. These
+ * tests are the anti-cast backstop and the packaging check that the seam stays
+ * optional and provider-neutral.
+ *
+ * The scan is comment- and string-aware rather than a substring search, so a
+ * comment explaining why `sendMessage` is forbidden cannot fail the guard while
+ * a real call cannot hide behind one.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const root = fileURLToPath(new URL('../', import.meta.url))
+
+/** Every file under one production runtime directory, at any depth. */
+function runtimeFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = `${directory}/${entry.name}`
+    return entry.isDirectory() ? runtimeFiles(path) : [path]
+  })
+}
+
+/**
+ * Strip comments and string/template literals, keeping only code.
+ *
+ * A regex over raw text would flag the comments that explain this very rule and
+ * would miss a call whose receiver is spread across lines; a tiny scanner that
+ * respects lexical context flags the call and only the call. A template
+ * literal's `${…}` expressions are CODE, so they are copied back out rather than
+ * discarded with the literal text around them.
+ * @param source - one source file's text.
+ * @returns the same text with comments and literal contents removed.
+ */
+export function codeOnly(source: string): string {
+  let out = ''
+  let index = 0
+  while (index < source.length) {
+    const char = source[index]
+    const next = source[index + 1]
+    if (char === '/' && next === '/') {
+      while (index < source.length && source[index] !== '\n') index += 1
+      continue
+    }
+    if (char === '/' && next === '*') {
+      index += 2
+      while (index < source.length && !(source[index] === '*' && source[index + 1] === '/')) index += 1
+      index += 2
+      continue
+    }
+    if (char === '"' || char === '\'') {
+      const quote = char
+      index += 1
+      while (index < source.length) {
+        if (source[index] === '\\') {
+          index += 2
+          continue
+        }
+        if (source[index] === quote) {
+          index += 1
+          break
+        }
+        index += 1
+      }
+      out += '""'
+      continue
+    }
+    if (char === '`') {
+      index += 1
+      while (index < source.length) {
+        const inner = source[index]
+        if (inner === '\\') {
+          index += 2
+          continue
+        }
+        if (inner === '`') {
+          index += 1
+          break
+        }
+        if (inner === '$' && source[index + 1] === '{') {
+          let depth = 1
+          index += 2
+          const start = index
+          while (index < source.length && depth > 0) {
+            const inside = source[index]
+            if (inside === '\\') {
+              index += 2
+              continue
+            }
+            if (inside === '{') depth += 1
+            else if (inside === '}') depth -= 1
+            index += 1
+          }
+          out += ` ${source.slice(start, index - 1)} `
+          continue
+        }
+        index += 1
+      }
+      out += '""'
+      continue
+    }
+    out += char
+    index += 1
+  }
+  return out
+}
+
+/** Calls and symbols no human terminal path may reach. */
+const FORBIDDEN: readonly (readonly [string, RegExp])[] = [
+  ['SubagentRuntime.sendMessage access', /\.\s*sendMessage\b/],
+  ['private deliverSubagentPrompt symbol', /\bdeliverSubagentPrompt\b/],
+  ['host-only queueHostSubagentPrompt helper', /\bqueueHostSubagentPrompt\b/],
+  ['host-only steerHostSubagentPrompt helper', /\bsteerHostSubagentPrompt\b/],
+  ['provider-specific subagent import', /from\s+["'][^"']*@deepseek-ai\/dsh-subagent-[a-z-]+["']/],
+  ['dynamic provider-specific subagent import', /import\s*\(\s*["'][^"']*@deepseek-ai\/dsh-subagent-[a-z-]+["']/],
+]
+
+describe('architecture guard: the human subagent path', () => {
+  it('calls neither the model-authored sendMessage nor any private host symbol', () => {
+    const files = [...runtimeFiles(`${root}src`), ...runtimeFiles(`${root}bin`)]
+    const offenders: string[] = []
+    for (const file of files) {
+      const code = codeOnly(readFileSync(file, 'utf8'))
+      for (const [label, pattern] of FORBIDDEN) {
+        if (pattern.test(code)) offenders.push(`${file.slice(root.length)}: ${label}`)
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('sees a call in code but not one in a comment, string, or template text', () => {
+    expect(codeOnly('const x = seam.sendMessage(a, b)')).toContain('sendMessage')
+    expect(codeOnly('const x = `${seam.sendMessage(a, b)}`')).toContain('sendMessage')
+    expect(codeOnly('// seam.sendMessage(a, b)')).not.toContain('sendMessage')
+    expect(codeOnly("const s = 'seam.sendMessage(a, b)'")).not.toContain('sendMessage')
+  })
+
+  it('keeps the subagent seam optional and type-only in the published manifest', () => {
+    const manifest = JSON.parse(readFileSync(`${root}package.json`, 'utf8')) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+      peerDependencies?: Record<string, string>
+    }
+    // Optional per AGENTS rule 11: the runner needs the types to compile, but a
+    // profile that omits the plugin must not get an unmet-peer warning, so the
+    // types live in devDependencies and never in dependencies or peers.
+    expect(manifest.dependencies?.['@deepseek-ai/dsh-subagent']).toBeUndefined()
+    expect(manifest.devDependencies?.['@deepseek-ai/dsh-subagent']).toBeDefined()
+    expect(manifest.peerDependencies?.['@deepseek-ai/dsh-subagent']).toBeUndefined()
+  })
+
+  it('keeps the renderer free of every dependency', () => {
+    const manifest = JSON.parse(readFileSync(`${root}../renderer/package.json`, 'utf8')) as {
+      dependencies?: Record<string, string>
+      peerDependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    expect(manifest.dependencies ?? {}).toEqual({})
+    expect(manifest.peerDependencies ?? {}).toEqual({})
+  })
+})

--- a/packages/dshline/tests/subagent-conversations-frames.spec.ts
+++ b/packages/dshline/tests/subagent-conversations-frames.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Real-terminal frames for the subagent conversation inspector.
+ *
+ * The inspector is temporary live-region chrome: it must never rewrite a
+ * committed row, and repeated redraws must leave exactly one frame behind. A
+ * headless `@xterm/headless` terminal is the only place those two properties
+ * are visible, because the cursor moves rather than the whole screen being
+ * repainted.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { Screen, stripAnsi } from '@dshline/renderer'
+import type { Key } from '@dshline/renderer'
+import { createEmulator } from '../../../tests/emulator.ts'
+import { SurfaceNotice } from '../src/surface.ts'
+import { createSubagentCatalogOverlay, createSubagentConversationOverlay } from '../src/subagents/overlay.ts'
+import type { SubagentChildRow } from '../src/subagents/model.ts'
+import type { SubagentTranscriptReading } from '../src/subagents/transcript.ts'
+
+/** The child every frame test inspects. */
+const CHILD: SubagentChildRow = {
+  kind: 'child', id: 'child-1', mode: 'continuable', residency: 'resident', hasChildren: false, label: 'review',
+}
+
+/** A reading with enough rows to scroll. */
+function reading(): SubagentTranscriptReading {
+  return {
+    kind: 'ready',
+    hasOlder: false,
+    stale: false,
+    events: Array.from({ length: 12 }, (_, index) => ({
+      type: 'user/message',
+      seq: (index + 1) as never,
+      time: 1_700_000_000_000 + index,
+      data: { content: [{ type: 'text', text: `event number ${String(index + 1)}` }] },
+    })) as never,
+  }
+}
+
+/** Build the conversation inspector used by both frame tests. */
+function inspector(): ReturnType<typeof createSubagentConversationOverlay> {
+  return createSubagentConversationOverlay({
+    child: () => CHILD,
+    reading,
+    followUp: true,
+    steer: true,
+    interruptible: true,
+    loadOlder: () => {},
+    refresh: () => {},
+    message: () => {},
+    interrupt: () => {},
+    notice: new SurfaceNotice(1_000),
+    close: () => {},
+    invalidate: () => {},
+  })
+}
+
+/** A key keystroke. */
+function key(name: string): Key {
+  return { kind: 'key', name } as Key
+}
+
+describe('subagent conversation frames on a real terminal', () => {
+  it('never rewrites committed scrollback when it opens and closes', async () => {
+    const emulator = createEmulator(60, 12)
+    const screen = new Screen(emulator.target)
+    screen.commit(['committed transcript row'])
+    const before = await emulator.scrollback()
+
+    const overlay = inspector()
+    screen.setLive(overlay.render(60, 12))
+    overlay.handleKey(key('down'))
+    overlay.handleKey(key('down'))
+    screen.setLive(overlay.render(60, 12))
+    // Closing restores whatever was underneath; the committed row is untouched.
+    screen.setLive(['composer', 'status'])
+
+    const after = await emulator.scrollback()
+    expect(after.filter(row => row.includes('committed transcript row')))
+      .toEqual(before.filter(row => row.includes('committed transcript row')))
+    expect(after.join('\n')).not.toContain('Subagent')
+    expect(screen.height).toBeLessThanOrEqual(12)
+  })
+
+  it('leaves exactly one frame behind across repeated redraws', async () => {
+    const emulator = createEmulator(60, 12)
+    const screen = new Screen(emulator.target)
+    const overlay = inspector()
+    for (let step = 0; step < 10; step += 1) {
+      overlay.handleKey(key('down'))
+      screen.setLive(overlay.render(60, 12))
+    }
+    const history = await emulator.scrollback()
+    expect(history.filter(row => row.includes('╭─'))).toHaveLength(1)
+  })
+
+  it('draws the catalog as bounded live-region chrome', async () => {
+    const emulator = createEmulator(40, 8)
+    const screen = new Screen(emulator.target)
+    const overlay = createSubagentCatalogOverlay({
+      reading: () => ({
+        kind: 'ready',
+        rows: [{ kind: 'child', id: 'child-1', mode: 'continuable', residency: 'stored', hasChildren: false, label: 'review' }],
+      }),
+      inspect: () => {},
+      refresh: () => {},
+      close: () => {},
+      invalidate: () => {},
+    })
+    screen.setLive(overlay.render(40, 8))
+    screen.setLive(overlay.render(40, 8))
+    const visible = stripAnsi((await emulator.screen()).join('\n'))
+    expect(visible).toContain('Subagent conversations')
+    expect(visible).toContain('review')
+    expect(screen.height).toBeLessThanOrEqual(8)
+  })
+})

--- a/packages/dshline/tests/subagent-conversations-frames.spec.ts
+++ b/packages/dshline/tests/subagent-conversations-frames.spec.ts
@@ -125,18 +125,25 @@ const DIRECTIONAL_ARROWS = [0x2191, 0x2193] as const
 async function assertStableFrame(
   columns: number,
   overlay: { render(columns: number, rows?: number): readonly string[] },
+  mutate: () => void,
 ): Promise<void> {
   const emulator = createEmulator(columns, 12, { wideCodePoints: DIRECTIONAL_ARROWS })
   const screen = new Screen(emulator.target)
   const redraw = (): void => { screen.setLive(overlay.render(columns, 12)) }
-  // Identical redraws are the drift probe: a border the terminal wraps adds a
-  // physical row `Screen` does not erase, so each redraw leaves one behind.
   redraw()
   const before = await emulator.scrollback()
+  // Each redraw must render DIFFERENT content, or `Screen.setLive` recognizes an
+  // identical frame and returns without erasing — which would make the drift
+  // assertion below vacuous. The mutation keeps the frame's height unchanged, so
+  // a growing row count can only be a wrapped border left behind.
+  mutate()
   redraw()
+  mutate()
   redraw()
   const after = await emulator.scrollback()
-  expect(after).toEqual(before)
+  // No drift: a border the terminal wraps adds one physical row `Screen` never
+  // erases, so the held row count would grow on every redraw.
+  expect(after.length).toBe(before.length)
   // One current frame, not a previous one the erase missed.
   expect(after.filter(row => row.includes('╭─'))).toHaveLength(1)
   // Exactly one bottom border, ending in its right corner: a wrapped border
@@ -150,11 +157,17 @@ async function assertStableFrame(
 
 describe('subagent surfaces on a terminal that widens the directional arrows', () => {
   it('does not wrap the catalog footer or drift scrollback', async () => {
+    // Toggle a row's residency: the text changes (forcing a real redraw) but the
+    // row count does not.
+    let resident = true
     const overlay = createSubagentCatalogOverlay({
       reading: () => ({
         kind: 'ready',
         rows: [
-          { kind: 'child', id: 'a', mode: 'continuable', residency: 'resident', hasChildren: false, label: 'alpha' },
+          {
+            kind: 'child', id: 'a', mode: 'continuable',
+            residency: resident ? 'resident' : 'stored', hasChildren: false, label: 'alpha',
+          },
           { kind: 'child', id: 'b', mode: 'one-shot', residency: 'stored', hasChildren: false, label: 'beta' },
         ],
       }),
@@ -163,11 +176,26 @@ describe('subagent surfaces on a terminal that widens the directional arrows', (
       close: () => {},
       invalidate: () => {},
     })
-    await assertStableFrame(60, overlay)
+    await assertStableFrame(60, overlay, () => { resident = !resident })
   })
 
   it('does not wrap the inspector footer or drift scrollback', async () => {
-    await assertStableFrame(101, inspector())
+    let residency: 'resident' | 'stored' = 'resident'
+    const overlay = createSubagentConversationOverlay({
+      child: () => ({
+        kind: 'child', id: CHILD.id, mode: 'continuable', residency, hasChildren: false, label: CHILD.label,
+      }),
+      reading,
+      followUp: true,
+      steer: true,
+      loadOlder: () => {},
+      refresh: () => {},
+      message: () => {},
+      notice: new SurfaceNotice(1_000),
+      close: () => {},
+      invalidate: () => {},
+    })
+    await assertStableFrame(101, overlay, () => { residency = residency === 'resident' ? 'stored' : 'resident' })
   })
 
   it('does not wrap the message footer or drift scrollback', async () => {
@@ -179,6 +207,8 @@ describe('subagent surfaces on a terminal that widens the directional arrows', (
       close: () => {},
       invalidate: () => {},
     })
-    await assertStableFrame(60, overlay)
+    // One character per redraw changes the draft (a real redraw) without adding
+    // a row: the body starts at one draft row.
+    await assertStableFrame(60, overlay, () => { overlay.handleKey({ kind: 'text', text: 'x' } as Key) })
   })
 })

--- a/packages/dshline/tests/subagent-conversations-frames.spec.ts
+++ b/packages/dshline/tests/subagent-conversations-frames.spec.ts
@@ -13,7 +13,7 @@ import { Screen, stripAnsi } from '@dshline/renderer'
 import type { Key } from '@dshline/renderer'
 import { createEmulator } from '../../../tests/emulator.ts'
 import { SurfaceNotice } from '../src/surface.ts'
-import { createSubagentCatalogOverlay, createSubagentConversationOverlay } from '../src/subagents/overlay.ts'
+import { createSubagentCatalogOverlay, createSubagentConversationOverlay, createSubagentMessageOverlay } from '../src/subagents/overlay.ts'
 import type { SubagentChildRow } from '../src/subagents/model.ts'
 import type { SubagentTranscriptReading } from '../src/subagents/transcript.ts'
 
@@ -44,11 +44,9 @@ function inspector(): ReturnType<typeof createSubagentConversationOverlay> {
     reading,
     followUp: true,
     steer: true,
-    interruptible: true,
     loadOlder: () => {},
     refresh: () => {},
     message: () => {},
-    interrupt: () => {},
     notice: new SurfaceNotice(1_000),
     close: () => {},
     invalidate: () => {},
@@ -113,5 +111,74 @@ describe('subagent conversation frames on a real terminal', () => {
     expect(visible).toContain('Subagent conversations')
     expect(visible).toContain('review')
     expect(screen.height).toBeLessThanOrEqual(8)
+  })
+})
+
+/**
+ * The code points a terminal in an ambiguous-width mode can advance two cells
+ * for while Dshline measures one. The #202 bug was exactly this on the
+ * composer's top border; these surfaces must not reproduce it on the footer.
+ */
+const DIRECTIONAL_ARROWS = [0x2191, 0x2193] as const
+
+/** Assert one surface keeps a bounded, stable frame on the widening terminal. */
+async function assertStableFrame(
+  columns: number,
+  overlay: { render(columns: number, rows?: number): readonly string[] },
+): Promise<void> {
+  const emulator = createEmulator(columns, 12, { wideCodePoints: DIRECTIONAL_ARROWS })
+  const screen = new Screen(emulator.target)
+  const redraw = (): void => { screen.setLive(overlay.render(columns, 12)) }
+  // Identical redraws are the drift probe: a border the terminal wraps adds a
+  // physical row `Screen` does not erase, so each redraw leaves one behind.
+  redraw()
+  const before = await emulator.scrollback()
+  redraw()
+  redraw()
+  const after = await emulator.scrollback()
+  expect(after).toEqual(before)
+  // One current frame, not a previous one the erase missed.
+  expect(after.filter(row => row.includes('╭─'))).toHaveLength(1)
+  // Exactly one bottom border, ending in its right corner: a wrapped border
+  // would leave a second `╰` row behind.
+  const bottom = after.filter(row => row.includes('╰'))
+  expect(bottom).toHaveLength(1)
+  expect(bottom[0]!.trimEnd().endsWith('╯')).toBe(true)
+  expect(screen.height).toBeLessThanOrEqual(12)
+  emulator.dispose()
+}
+
+describe('subagent surfaces on a terminal that widens the directional arrows', () => {
+  it('does not wrap the catalog footer or drift scrollback', async () => {
+    const overlay = createSubagentCatalogOverlay({
+      reading: () => ({
+        kind: 'ready',
+        rows: [
+          { kind: 'child', id: 'a', mode: 'continuable', residency: 'resident', hasChildren: false, label: 'alpha' },
+          { kind: 'child', id: 'b', mode: 'one-shot', residency: 'stored', hasChildren: false, label: 'beta' },
+        ],
+      }),
+      inspect: () => {},
+      refresh: () => {},
+      close: () => {},
+      invalidate: () => {},
+    })
+    await assertStableFrame(60, overlay)
+  })
+
+  it('does not wrap the inspector footer or drift scrollback', async () => {
+    await assertStableFrame(101, inspector())
+  })
+
+  it('does not wrap the message footer or drift scrollback', async () => {
+    const overlay = createSubagentMessageOverlay({
+      childLabel: 'review',
+      delivery: 'queue',
+      submit: async () => ({ kind: 'accepted', messageId: 'm-1' }),
+      onAccepted: () => {},
+      close: () => {},
+      invalidate: () => {},
+    })
+    await assertStableFrame(60, overlay)
   })
 })

--- a/packages/dshline/tests/subagent-conversations.spec.ts
+++ b/packages/dshline/tests/subagent-conversations.spec.ts
@@ -1,6 +1,6 @@
 /**
  * Focused tests for the durable subagent-conversation catalog, inspector, and
- * human queue/steer/interrupt path.
+ * human queue/steer path.
  *
  * The authority boundary is the point: discovery is `listChildren`, inspection
  * is a bounded `listEvents`+`readEvent` read, and a human follow-up is
@@ -13,15 +13,15 @@ import type { Agent } from '@deepseek-ai/dsh-agent'
 import type { SessionEvent, SessionId, SessionSeq } from '@deepseek-ai/dsh-session'
 import type { SessionEventReadRequest, SessionEventRecord, SessionEventWindow } from '@deepseek-ai/dsh-session-query'
 import type { SubagentListEntry, SubagentPromptReceipt, SubagentPromptRequest } from '@deepseek-ai/dsh-subagent'
-import { stripAnsi } from '@dshline/renderer'
+import { BOX_CHROME_COLUMNS, stripAnsi } from '@dshline/renderer'
 import type { Key } from '@dshline/renderer'
+import { chromeWidth } from '../src/chrome.ts'
 import type { TuiOverlay } from '../src/slots.ts'
 import { physicalRows, SurfaceNotice } from '../src/surface.ts'
 import {
   catalogReading,
   diagnosticReasonWord,
   subagentRowFollowUp,
-  subagentRowInterruptible,
   subagentRowKey,
   subagentRowOpenable,
 } from '../src/subagents/model.ts'
@@ -31,7 +31,7 @@ import {
   createSubagentMessageOverlay,
 } from '../src/subagents/overlay.ts'
 import { createSubagentsPresenter, type SubagentsPresenterDeps } from '../src/subagents/presenter.ts'
-import { TRANSCRIPT_PAGE } from '../src/subagents/transcript.ts'
+import { readTranscriptOlder, readTranscriptTail, TRANSCRIPT_PAGE } from '../src/subagents/transcript.ts'
 import { HarnessWork } from '../src/work/index.ts'
 import { activeWorkCount } from '../src/work/model.ts'
 
@@ -209,15 +209,13 @@ describe('durable subagent discovery vocabulary', () => {
     })
     expect(subagentRowOpenable(row!)).toBe(true)
     expect(subagentRowFollowUp(row!, true)).toBe(true)
-    expect(subagentRowInterruptible(row!)).toBe(true)
   })
 
-  it('offers a one-shot child inspection but no follow-up or interrupt', () => {
+  it('offers a one-shot child inspection but no follow-up', () => {
     const reading = catalogReading([child('one', 'one-shot', 'inactive')])
     const row = reading.kind === 'ready' ? reading.rows[0] : undefined
     expect(subagentRowOpenable(row!)).toBe(true)
     expect(subagentRowFollowUp(row!, true)).toBe(false)
-    expect(subagentRowInterruptible(row!)).toBe(false)
   })
 
   it('reports the absence of the prompt seam rather than a one-shot mode', () => {
@@ -364,17 +362,15 @@ describe('subagent conversation catalog overlay', () => {
 
 describe('subagent conversation inspector overlay', () => {
   function inspector(overrides: Partial<Parameters<typeof createSubagentConversationOverlay>[0]> = {}) {
-    const calls = { older: 0, refresh: 0, message: [] as string[], interrupt: 0 }
+    const calls = { older: 0, refresh: 0, message: [] as string[] }
     const overlay = createSubagentConversationOverlay({
       child: () => ({ kind: 'child', id: 'c', mode: 'continuable', residency: 'resident', hasChildren: false, label: 'review' }),
       reading: () => ({ kind: 'ready', events: [message(1, 'the child said hello')], hasOlder: true, stale: false }),
       followUp: true,
       steer: true,
-      interruptible: true,
       loadOlder: () => { calls.older += 1 },
       refresh: () => { calls.refresh += 1 },
       message: delivery => { calls.message.push(delivery) },
-      interrupt: () => { calls.interrupt += 1 },
       notice: new SurfaceNotice(1_000),
       close: () => {},
       invalidate: () => {},
@@ -392,25 +388,22 @@ describe('subagent conversation inspector overlay', () => {
     expect(plain).toContain('the child said hello')
   })
 
-  it('routes m, s, k, [, and r to their presenters', () => {
+  it('routes m, s, [, and r to their presenters', () => {
     const { overlay, calls } = inspector()
     overlay.handleKey(text('m'))
     overlay.handleKey(text('s'))
-    overlay.handleKey(text('k'))
     overlay.handleKey(text('['))
     overlay.handleKey(text('r'))
     expect(calls.message).toEqual(['queue', 'steer'])
-    expect(calls.interrupt).toBe(1)
     expect(calls.older).toBe(1)
     expect(calls.refresh).toBe(1)
   })
 
-  it('offers no follow-up, steer, or interrupt for a one-shot child', () => {
+  it('offers no follow-up or steer for a one-shot child', () => {
     const { overlay, calls } = inspector({
       child: () => ({ kind: 'child', id: 'one', mode: 'one-shot', residency: 'stored', hasChildren: false }),
       followUp: false,
       steer: false,
-      interruptible: false,
     })
     const plain = stripAnsi(overlay.render(80, 24).join('\n'))
     expect(plain).not.toContain('m message')
@@ -418,9 +411,7 @@ describe('subagent conversation inspector overlay', () => {
     expect(plain).not.toContain('k interrupt')
     overlay.handleKey(text('m'))
     overlay.handleKey(text('s'))
-    overlay.handleKey(text('k'))
     expect(calls.message).toEqual([])
-    expect(calls.interrupt).toBe(0)
   })
 
   it('bounds every row at narrow and short geometries', () => {
@@ -512,6 +503,83 @@ describe('subagent message composer', () => {
     overlay.dispose?.()
     expect(signals[0]?.aborted).toBe(true)
   })
+
+  it('keeps the cursor row visible for a long multiline draft', () => {
+    const { overlay } = composer(async () => ({ kind: 'accepted', messageId: 'm-1' }))
+    const lines = Array.from({ length: 12 }, (_, index) => `line ${String(index).padStart(2, '0')}`)
+    overlay.handleKey({ kind: 'paste', text: lines.join('\n') } as Key)
+    const plain = stripAnsi(overlay.render(80, 8).join('\n'))
+    // The caret row — the end of the paste — is inside the window, and the
+    // window did not stay pinned to the draft's first line.
+    expect(plain).toContain('█')
+    expect(plain).toContain('line 11')
+    expect(plain).not.toContain('line 00')
+    expect(physicalRows(overlay.render(80, 8), 80).length).toBeLessThanOrEqual(8)
+  })
+
+  it('scrolls the draft window with the cursor on Up and back on Down', () => {
+    const { overlay } = composer(async () => ({ kind: 'accepted', messageId: 'm-1' }))
+    const lines = Array.from({ length: 12 }, (_, index) => `line ${String(index).padStart(2, '0')}`)
+    overlay.handleKey({ kind: 'paste', text: lines.join('\n') } as Key)
+    overlay.render(80, 8)
+    expect(stripAnsi(overlay.render(80, 8).join('\n'))).toContain('line 11')
+    for (let press = 0; press < 5; press += 1) overlay.handleKey(key('up'))
+    const up = stripAnsi(overlay.render(80, 8).join('\n'))
+    expect(up).not.toContain('line 11')
+    expect(up).toContain('line 06')
+    for (let press = 0; press < 5; press += 1) overlay.handleKey(key('down'))
+    expect(stripAnsi(overlay.render(80, 8).join('\n'))).toContain('line 11')
+  })
+
+  it('keeps the cursor visible when a row is exactly full, through wide content', () => {
+    const { overlay } = composer(async () => ({ kind: 'accepted', messageId: 'm-1' }))
+    // Establish the width the body renders at before moving/editing.
+    overlay.render(40, 8)
+    const firstRowText = 'a'.repeat(chromeWidth(40) - BOX_CHROME_COLUMNS - 2)
+    const draft = [
+      firstRowText,
+      '漢'.repeat(20),
+      '😀'.repeat(4),
+      'tail',
+    ].join('\n')
+    overlay.handleKey({ kind: 'paste', text: draft } as Key)
+    const plain = stripAnsi(overlay.render(40, 8).join('\n'))
+    expect(plain).toContain('tail')
+    expect(plain).toContain('█')
+    for (const rows of [4, 6, 8, 12]) {
+      expect(physicalRows(overlay.render(40, rows), 40).length).toBeLessThanOrEqual(rows)
+    }
+  })
+})
+
+describe('bounded transcript paging', () => {
+  /** A log far larger than the retained page. */
+  const LARGE = TRANSCRIPT_PAGE * 5
+
+  function seeded(): FakeSession {
+    const session = new FakeSession()
+    session.setLog('c', Array.from({ length: LARGE }, (_, index) => message(index + 1, `event ${String(index + 1).padStart(3, '0')}`)))
+    return session
+  }
+
+  it('retains at most one page of full event bodies while paging backward', async () => {
+    const session = seeded()
+    let state = await readTranscriptTail(session, 'c' as never)
+    expect(state.events.length).toBeLessThanOrEqual(TRANSCRIPT_PAGE)
+    expect(state.hasOlder).toBe(true)
+    let presses = 0
+    while (state.hasOlder && presses < LARGE) {
+      state = await readTranscriptOlder(session, 'c' as never, state)
+      expect(state.events.length).toBeLessThanOrEqual(TRANSCRIPT_PAGE)
+      const seqs = state.events.map(event => event.seq)
+      expect(new Set(seqs).size).toBe(seqs.length)
+      presses += 1
+    }
+    expect(state.hasOlder).toBe(false)
+    expect(state.events[0]?.seq).toBe(1)
+    // No full-log body read: every window asked for at most one page.
+    expect(session.readEventCalls.every(call => (call.request.before ?? 0) <= TRANSCRIPT_PAGE - 1)).toBe(true)
+  })
 })
 
 describe('subagent conversation presenter', () => {
@@ -519,7 +587,6 @@ describe('subagent conversation presenter', () => {
     const slots = testSlots()
     const subagents = new FakeSubagent()
     const session = new FakeSession()
-    const interrupts: { childId: string; authorized: boolean }[] = []
     let lifecycle: (() => void) | undefined
     let sessionEvent: ((sessionId: string) => void) | undefined
     const p = createSubagentsPresenter({
@@ -528,16 +595,12 @@ describe('subagent conversation presenter', () => {
       invalidate: () => {},
       subagents,
       query: session,
-      interrupt: (childId, authorized) => {
-        interrupts.push({ childId, authorized })
-        return { kind: 'requested', message: 'Interrupt requested.' }
-      },
       onLifecycle: listener => { lifecycle = listener; return () => {} },
       onSessionEvent: listener => { sessionEvent = listener; return () => {} },
       ...overrides,
     })
     return {
-      slots, subagents, session, interrupts, p,
+      slots, subagents, session, p,
       fireLifecycle: () => { lifecycle?.() },
       fireSessionEvent: (id: string) => { sessionEvent?.(id) },
     }
@@ -666,28 +729,21 @@ describe('subagent conversation presenter', () => {
     expect(session.readEventCalls.length).toBe(before)
   })
 
-  it('interrupts through the shared adapter with continuable authorization', async () => {
-    const { slots, subagents, session, interrupts, p } = mount()
-    subagents.setChildren([child('c', 'continuable', 'running')])
+  it('never offers interrupt from the durable inspector, even for a continuable child', async () => {
+    const { slots, subagents, session, p } = mount()
+    // A settled/stored continuable child is exactly the case residency cannot
+    // prove a live turn for, so no interrupt affordance may appear here.
+    subagents.setChildren([child('c', 'continuable', 'inactive')])
     session.setLog('c', [message(1, 'hello')])
     p.open()
     await flush()
     slots.top()?.handleKey(key('enter'))
     await flush()
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).not.toContain('interrupt')
+    const reads = session.readEventCalls.length
     slots.top()?.handleKey(text('k'))
-    expect(interrupts).toEqual([{ childId: 'c', authorized: true }])
-  })
-
-  it('offers no interrupt for a one-shot child', async () => {
-    const { slots, subagents, session, interrupts, p } = mount()
-    subagents.setChildren([child('one', 'one-shot', 'inactive')])
-    session.setLog('one', [message(1, 'hello')])
-    p.open()
-    await flush()
-    slots.top()?.handleKey(key('enter'))
-    await flush()
-    slots.top()?.handleKey(text('k'))
-    expect(interrupts).toEqual([])
+    expect(session.readEventCalls.length).toBe(reads)
+    expect(slots.overlays).toHaveLength(2)
   })
 
   it('degrades honestly when ctx.subagents is absent', async () => {
@@ -803,5 +859,115 @@ describe('subagent conversation presenter', () => {
     expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).not.toContain('m message')
     slots.top()?.handleKey(text('m'))
     expect(slots.overlays).toHaveLength(2)
+  })
+
+  it('marks a window stale when an event arrives during its first read', async () => {
+    const { slots, subagents, session, p, fireSessionEvent } = mount()
+    subagents.setChildren([child('c', 'continuable', 'inactive')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    session.holdReads()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    // The event lands while `transcript.kind` is still `loading`, which the old
+    // guard dropped outright.
+    fireSessionEvent('c')
+    session.releaseRead(0)
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).toContain('new events')
+    expect(session.readEventCalls.length).toBe(1)
+  })
+
+  it('marks a replaced older page stale when an event arrives during its read', async () => {
+    const { slots, subagents, session, p, fireSessionEvent } = mount()
+    subagents.setChildren([child('c', 'continuable', 'inactive')])
+    session.setLog('c', Array.from({ length: TRANSCRIPT_PAGE * 2 }, (_, index) => message(index + 1, `e${index + 1}`)))
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    session.holdReads()
+    slots.top()?.handleKey(text('['))
+    await flush()
+    fireSessionEvent('c')
+    session.releaseRead(0)
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).toContain('new events')
+  })
+
+  it('does not go stale for another child’s event', async () => {
+    const { slots, subagents, session, p, fireSessionEvent } = mount()
+    subagents.setChildren([child('c', 'continuable', 'inactive')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    fireSessionEvent('other')
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).not.toContain('new events')
+  })
+
+  it('clears stale after a refresh with no intervening child event', async () => {
+    const { slots, subagents, session, p, fireSessionEvent } = mount()
+    subagents.setChildren([child('c', 'continuable', 'inactive')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    fireSessionEvent('c')
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).toContain('new events')
+    slots.top()?.handleKey(text('r'))
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).not.toContain('new events')
+  })
+
+  it('replaces the rendered page rather than accumulating events', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([child('c', 'continuable', 'inactive')])
+    session.setLog('c', Array.from(
+      { length: TRANSCRIPT_PAGE * 2 },
+      (_, index) => message(index + 1, `event ${String(index + 1).padStart(3, '0')}`),
+    ))
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    const tail = stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')
+    expect(tail).toContain('event 025')
+    expect(tail).not.toContain('event 001')
+    slots.top()?.handleKey(text('['))
+    await flush()
+    const older = stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')
+    expect(older).toContain('event 001')
+    expect(older).not.toContain('event 025')
+  })
+})
+
+describe('subagent navigation chrome', () => {
+  it('uses width-stable ASCII rather than the ambiguous arrow glyphs', () => {
+    const catalog = createSubagentCatalogOverlay({
+      reading: () => catalogReading([child('c', 'continuable', 'running')]),
+      inspect: () => {},
+      refresh: () => {},
+      close: () => {},
+      invalidate: () => {},
+    })
+    const conversation = createSubagentConversationOverlay({
+      child: () => ({ kind: 'child', id: 'c', mode: 'continuable', residency: 'resident', hasChildren: false, label: 'review' }),
+      reading: () => ({ kind: 'ready', events: [message(1, 'x')], hasOlder: false, stale: false }),
+      followUp: true,
+      steer: true,
+      loadOlder: () => {},
+      refresh: () => {},
+      message: () => {},
+      notice: new SurfaceNotice(1_000),
+      close: () => {},
+      invalidate: () => {},
+    })
+    for (const overlay of [catalog, conversation]) {
+      expect(stripAnsi(overlay.render(80, 24).join('\n'))).not.toMatch(/[\u2190-\u21ff]/u)
+    }
   })
 })

--- a/packages/dshline/tests/subagent-conversations.spec.ts
+++ b/packages/dshline/tests/subagent-conversations.spec.ts
@@ -408,7 +408,6 @@ describe('subagent conversation inspector overlay', () => {
     const plain = stripAnsi(overlay.render(80, 24).join('\n'))
     expect(plain).not.toContain('m message')
     expect(plain).not.toContain('s steer')
-    expect(plain).not.toContain('k interrupt')
     overlay.handleKey(text('m'))
     overlay.handleKey(text('s'))
     expect(calls.message).toEqual([])

--- a/packages/dshline/tests/subagent-conversations.spec.ts
+++ b/packages/dshline/tests/subagent-conversations.spec.ts
@@ -1,0 +1,807 @@
+/**
+ * Focused tests for the durable subagent-conversation catalog, inspector, and
+ * human queue/steer/interrupt path.
+ *
+ * The authority boundary is the point: discovery is `listChildren`, inspection
+ * is a bounded `listEvents`+`readEvent` read, and a human follow-up is
+ * `ctx.subagents.prompt` — never the model-authored `sendMessage`. These tests
+ * fake only the Harness seams and drive the real presenter and overlays.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import type { SessionEvent, SessionId, SessionSeq } from '@deepseek-ai/dsh-session'
+import type { SessionEventReadRequest, SessionEventRecord, SessionEventWindow } from '@deepseek-ai/dsh-session-query'
+import type { SubagentListEntry, SubagentPromptReceipt, SubagentPromptRequest } from '@deepseek-ai/dsh-subagent'
+import { stripAnsi } from '@dshline/renderer'
+import type { Key } from '@dshline/renderer'
+import type { TuiOverlay } from '../src/slots.ts'
+import { physicalRows, SurfaceNotice } from '../src/surface.ts'
+import {
+  catalogReading,
+  diagnosticReasonWord,
+  subagentRowFollowUp,
+  subagentRowInterruptible,
+  subagentRowKey,
+  subagentRowOpenable,
+} from '../src/subagents/model.ts'
+import {
+  createSubagentCatalogOverlay,
+  createSubagentConversationOverlay,
+  createSubagentMessageOverlay,
+} from '../src/subagents/overlay.ts'
+import { createSubagentsPresenter, type SubagentsPresenterDeps } from '../src/subagents/presenter.ts'
+import { TRANSCRIPT_PAGE } from '../src/subagents/transcript.ts'
+import { HarnessWork } from '../src/work/index.ts'
+import { activeWorkCount } from '../src/work/model.ts'
+
+/** One durable direct-child discovery entry. */
+function child(
+  id: string,
+  mode: 'one-shot' | 'continuable',
+  activity: 'running' | 'inactive',
+  label = id,
+  hasChildren = false,
+): SubagentListEntry {
+  return { kind: 'child', id: id as never, mode, activity, label, hasChildren }
+}
+
+/** One uninterpretable discovery candidate. */
+function diagnostic(id: string, reason: 'corrupt' | 'unavailable' | 'unsupported'): SubagentListEntry {
+  return { kind: 'diagnostic', id: id as never, reason }
+}
+
+/** A semantic user-message event, enough for `extractSessionEventText`. */
+function message(seq: number, text: string): SessionEvent {
+  return {
+    type: 'user/message',
+    seq: seq as never,
+    time: 1_700_000_000_000 + seq,
+    data: { content: [{ type: 'text', text }] },
+  } as unknown as SessionEvent
+}
+
+/** Let the queued microtask chain settle. */
+function flush(): Promise<void> {
+  return new Promise(resolve => { setImmediate(resolve) })
+}
+
+/** A key keystroke. */
+function key(name: string): Key {
+  return { kind: 'key', name } as Key
+}
+
+/** A printable-text keystroke. */
+function text(value: string): Key {
+  return { kind: 'text', text: value }
+}
+
+/** A fake `listChildren`/`prompt` seam that records every call. */
+class FakeSubagent {
+  readonly listCalls: SessionId[] = []
+  readonly promptCalls: { request: SubagentPromptRequest; signal: AbortSignal }[] = []
+  private children: SubagentListEntry[] = []
+  private failure: unknown
+  private settle: ((receipt: SubagentPromptReceipt) => void) | undefined
+  private fail: ((error: unknown) => void) | undefined
+
+  setChildren(entries: readonly SubagentListEntry[]): void {
+    this.children = [...entries]
+  }
+
+  failList(error: unknown): void {
+    this.failure = error
+  }
+
+  accept(messageId = 'm-1'): void {
+    this.settle?.({ messageId: messageId as never })
+  }
+
+  listChildren(parentSessionId: SessionId): Promise<SubagentListEntry[]> {
+    this.listCalls.push(parentSessionId)
+    if (this.failure !== undefined) return Promise.reject(this.failure)
+    return Promise.resolve(this.children)
+  }
+
+  prompt(request: SubagentPromptRequest, signal: AbortSignal): Promise<SubagentPromptReceipt> {
+    this.promptCalls.push({ request, signal })
+    return new Promise<SubagentPromptReceipt>((resolve, reject) => {
+      this.settle = resolve
+      this.fail = reject
+    })
+  }
+
+  refuse(error: unknown): void {
+    this.fail?.(error)
+  }
+}
+
+/** A fake bounded session read surface over in-memory logs. */
+class FakeSession {
+  readonly listEventsCalls: SessionId[] = []
+  readonly readEventCalls: { request: SessionEventReadRequest; signal?: AbortSignal }[] = []
+  private readonly logs = new Map<string, SessionEvent[]>()
+  private held = false
+  private readonly pending: (() => void)[] = []
+
+  setLog(sessionId: string, events: readonly SessionEvent[]): void {
+    this.logs.set(sessionId, [...events])
+  }
+
+  /** Defer every subsequent `readEvent` until {@link releaseRead}. */
+  holdReads(): void {
+    this.held = true
+  }
+
+  /** Resolve one held `readEvent`, oldest first. */
+  releaseRead(index = 0): void {
+    this.pending.splice(index, 1)[0]?.()
+  }
+
+  listEvents(sessionId: SessionId): Promise<SessionEventRecord[]> {
+    this.listEventsCalls.push(sessionId)
+    return Promise.resolve(recordsFor(this.logs.get(String(sessionId)) ?? []))
+  }
+
+  readEvent(request: SessionEventReadRequest, signal?: AbortSignal): Promise<SessionEventWindow> {
+    this.readEventCalls.push({ request, ...signal === undefined ? {} : { signal } })
+    const window = this.windowFor(request)
+    if (!this.held) return Promise.resolve(window)
+    return new Promise<SessionEventWindow>(resolve => { this.pending.push(() => { resolve(window) }) })
+  }
+
+  private windowFor(request: SessionEventReadRequest): SessionEventWindow {
+    const log = this.logs.get(String(request.sessionId)) ?? []
+    const at = log.findIndex(event => event.seq === request.seq)
+    const start = Math.max(0, at - (request.before ?? 0))
+    const end = Math.min(log.length - 1, at + (request.after ?? 0))
+    const events = at < 0 ? [] : log.slice(start, end + 1)
+    return {
+      session: { id: request.sessionId } as SessionEventWindow['session'],
+      inheritedEventCount: 0 as never,
+      target: (at < 0 ? undefined : log[at]) as SessionEvent,
+      events,
+      startSeq: (events[0]?.seq ?? request.seq) as SessionSeq,
+      endSeq: (events[events.length - 1]?.seq ?? request.seq) as SessionSeq,
+    }
+  }
+}
+
+/** Build lightweight records the way Harness would. */
+function recordsFor(events: readonly SessionEvent[]): SessionEventRecord[] {
+  return events.map(event => ({
+    sessionId: 'child' as never,
+    seq: event.seq,
+    type: event.type,
+    time: event.time,
+    surface: 'current',
+  }) as SessionEventRecord)
+}
+
+/** An in-memory overlay stack with the real `pushOverlay` contract. */
+function testSlots(): {
+  overlays: TuiOverlay[]
+  pushOverlay(overlay: TuiOverlay): () => void
+  top(): TuiOverlay | undefined
+} {
+  const overlays: TuiOverlay[] = []
+  return {
+    overlays,
+    pushOverlay(overlay) {
+      overlays.push(overlay)
+      overlay.mounted?.()
+      return () => {
+        const at = overlays.indexOf(overlay)
+        if (at >= 0) overlays.splice(at, 1)
+        overlay.dispose?.()
+      }
+    },
+    top: () => overlays.at(-1),
+  }
+}
+
+describe('durable subagent discovery vocabulary', () => {
+  it('keeps a settled stored continuable child browsable and follow-up-capable', () => {
+    const reading = catalogReading([child('c', 'continuable', 'inactive')])
+    const row = reading.kind === 'ready' ? reading.rows[0] : undefined
+    expect(row).toEqual({
+      kind: 'child', id: 'c', mode: 'continuable', residency: 'stored', hasChildren: false, label: 'c',
+    })
+    expect(subagentRowOpenable(row!)).toBe(true)
+    expect(subagentRowFollowUp(row!, true)).toBe(true)
+    expect(subagentRowInterruptible(row!)).toBe(true)
+  })
+
+  it('offers a one-shot child inspection but no follow-up or interrupt', () => {
+    const reading = catalogReading([child('one', 'one-shot', 'inactive')])
+    const row = reading.kind === 'ready' ? reading.rows[0] : undefined
+    expect(subagentRowOpenable(row!)).toBe(true)
+    expect(subagentRowFollowUp(row!, true)).toBe(false)
+    expect(subagentRowInterruptible(row!)).toBe(false)
+  })
+
+  it('reports the absence of the prompt seam rather than a one-shot mode', () => {
+    const reading = catalogReading([child('c', 'continuable', 'running')])
+    const row = reading.kind === 'ready' ? reading.rows[0] : undefined
+    expect(subagentRowFollowUp(row!, false)).toBe(false)
+  })
+
+  it('keeps diagnostics distinct and honest instead of dropping them', () => {
+    const reading = catalogReading([diagnostic('broken', 'corrupt'), child('ok', 'continuable', 'running')])
+    const rows = reading.kind === 'ready' ? reading.rows : []
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toEqual({ kind: 'diagnostic', id: 'broken', reason: 'corrupt' })
+    expect(diagnosticReasonWord('corrupt')).not.toBe(diagnosticReasonWord('unavailable'))
+    expect(subagentRowOpenable(rows[0]!)).toBe(false)
+  })
+
+  it('keys selection by the durable child id, stable across reordering', () => {
+    const keysOf = (reading: ReturnType<typeof catalogReading>): string[] =>
+      reading.kind === 'ready' ? reading.rows.map(subagentRowKey) : []
+    expect(keysOf(catalogReading([
+      child('a', 'continuable', 'running'), child('b', 'continuable', 'inactive'),
+    ]))).toEqual(['child:a', 'child:b'])
+    expect(keysOf(catalogReading([
+      child('b', 'continuable', 'inactive'), child('a', 'continuable', 'running'),
+    ]))).toEqual(['child:b', 'child:a'])
+  })
+
+  it('does not count a settled durable child as active work', async () => {
+    const subagents = new FakeSubagent()
+    subagents.setChildren([child('settled', 'continuable', 'inactive')])
+    const agent = { session: { id: 'parent' } } as unknown as Agent
+    const work = new HarnessWork({ agent, subagents: subagents as never, invalidate: () => {} })
+    await flush()
+    expect(work.snapshot().subagents).toEqual([])
+    expect(activeWorkCount(work.snapshot())).toBe(0)
+    work.dispose()
+  })
+})
+
+describe('subagent conversation catalog overlay', () => {
+  it('renders durable facts, opens a child, and refreshes on request', () => {
+    const inspected: string[] = []
+    let refreshes = 0
+    const overlay = createSubagentCatalogOverlay({
+      reading: () => catalogReading([
+        child('c', 'continuable', 'inactive', 'review task', true),
+        diagnostic('broken', 'corrupt'),
+      ]),
+      inspect: id => { inspected.push(id) },
+      refresh: () => { refreshes += 1 },
+      close: () => {},
+      invalidate: () => {},
+    })
+    const plain = stripAnsi(overlay.render(80, 20).join('\n'))
+    expect(plain).toContain('review task')
+    expect(plain).toContain('continuable')
+    expect(plain).toContain('stored')
+    expect(plain).toContain('has children')
+    expect(plain).toContain('unreadable record')
+    overlay.handleKey(key('enter'))
+    expect(inspected).toEqual(['c'])
+    overlay.handleKey(text('r'))
+    expect(refreshes).toBe(1)
+  })
+
+  it('never opens a diagnostic row and follows selection by identity', () => {
+    const inspected: string[] = []
+    let rows: SubagentListEntry[] = [diagnostic('broken', 'corrupt'), child('ok', 'continuable', 'running')]
+    const overlay = createSubagentCatalogOverlay({
+      reading: () => catalogReading(rows),
+      inspect: id => { inspected.push(id) },
+      refresh: () => {},
+      close: () => {},
+      invalidate: () => {},
+    })
+    overlay.render(80, 20)
+    overlay.handleKey(key('enter'))
+    expect(inspected).toEqual([])
+    overlay.handleKey(key('down'))
+    // Reorder and re-render: the aim stays on `ok`, not on a screen position.
+    rows = [child('ok', 'continuable', 'running'), diagnostic('broken', 'corrupt')]
+    overlay.render(80, 20)
+    overlay.handleKey(key('enter'))
+    expect(inspected).toEqual(['ok'])
+  })
+
+  it('lets the cursor land on a diagnostic row without opening it', () => {
+    const inspected: string[] = []
+    const overlay = createSubagentCatalogOverlay({
+      reading: () => catalogReading([diagnostic('broken', 'unavailable'), child('ok', 'continuable', 'running')]),
+      inspect: id => { inspected.push(id) },
+      refresh: () => {},
+      close: () => {},
+      invalidate: () => {},
+    })
+    const plain = stripAnsi(overlay.render(80, 20).join('\n'))
+    expect(plain.split('\n').some(row => row.includes('❯') && row.includes('broken'))).toBe(true)
+    overlay.handleKey(key('enter'))
+    expect(inspected).toEqual([])
+  })
+
+  it('escapes a discovery failure message before drawing it', () => {
+    const overlay = createSubagentCatalogOverlay({
+      reading: () => ({ kind: 'failed', message: 'boom\u001b[2Jinjected' }),
+      inspect: () => {},
+      refresh: () => {},
+      close: () => {},
+      invalidate: () => {},
+    })
+    const plain = stripAnsi(overlay.render(80, 20).join('\n'))
+    expect(plain).toContain('^[')
+    expect(plain).not.toContain('\u001b')
+  })
+
+  it('bounds every row at narrow and short geometries', () => {
+    const overlay = createSubagentCatalogOverlay({
+      reading: () => catalogReading([child('c', 'continuable', 'running', 'a deliberately long 标签 label')]),
+      inspect: () => {},
+      refresh: () => {},
+      close: () => {},
+      invalidate: () => {},
+    })
+    for (const columns of [14, 18, 24, 30, 40, 60, 80]) {
+      for (const rows of [3, 5, 7, 8, 10, 12, 24]) {
+        expect(physicalRows(overlay.render(columns, rows), columns).length).toBeLessThanOrEqual(rows)
+      }
+    }
+  })
+
+  it('escapes control sequences in a child label', () => {
+    const overlay = createSubagentCatalogOverlay({
+      reading: () => catalogReading([child('c', 'continuable', 'running', 'bad\u001b[2Jlabel')]),
+      inspect: () => {},
+      refresh: () => {},
+      close: () => {},
+      invalidate: () => {},
+    })
+    const plain = stripAnsi(overlay.render(80, 20).join('\n'))
+    expect(plain).toContain('^[')
+    expect(plain).not.toContain('\u001b')
+  })
+})
+
+describe('subagent conversation inspector overlay', () => {
+  function inspector(overrides: Partial<Parameters<typeof createSubagentConversationOverlay>[0]> = {}) {
+    const calls = { older: 0, refresh: 0, message: [] as string[], interrupt: 0 }
+    const overlay = createSubagentConversationOverlay({
+      child: () => ({ kind: 'child', id: 'c', mode: 'continuable', residency: 'resident', hasChildren: false, label: 'review' }),
+      reading: () => ({ kind: 'ready', events: [message(1, 'the child said hello')], hasOlder: true, stale: false }),
+      followUp: true,
+      steer: true,
+      interruptible: true,
+      loadOlder: () => { calls.older += 1 },
+      refresh: () => { calls.refresh += 1 },
+      message: delivery => { calls.message.push(delivery) },
+      interrupt: () => { calls.interrupt += 1 },
+      notice: new SurfaceNotice(1_000),
+      close: () => {},
+      invalidate: () => {},
+      ...overrides,
+    })
+    return { overlay, calls }
+  }
+
+  it('shows durable facts and the loaded conversation window', () => {
+    const { overlay } = inspector()
+    const plain = stripAnsi(overlay.render(80, 24).join('\n'))
+    expect(plain).toContain('review')
+    expect(plain).toContain('continuable · resident')
+    expect(plain).toContain('session  c')
+    expect(plain).toContain('the child said hello')
+  })
+
+  it('routes m, s, k, [, and r to their presenters', () => {
+    const { overlay, calls } = inspector()
+    overlay.handleKey(text('m'))
+    overlay.handleKey(text('s'))
+    overlay.handleKey(text('k'))
+    overlay.handleKey(text('['))
+    overlay.handleKey(text('r'))
+    expect(calls.message).toEqual(['queue', 'steer'])
+    expect(calls.interrupt).toBe(1)
+    expect(calls.older).toBe(1)
+    expect(calls.refresh).toBe(1)
+  })
+
+  it('offers no follow-up, steer, or interrupt for a one-shot child', () => {
+    const { overlay, calls } = inspector({
+      child: () => ({ kind: 'child', id: 'one', mode: 'one-shot', residency: 'stored', hasChildren: false }),
+      followUp: false,
+      steer: false,
+      interruptible: false,
+    })
+    const plain = stripAnsi(overlay.render(80, 24).join('\n'))
+    expect(plain).not.toContain('m message')
+    expect(plain).not.toContain('s steer')
+    expect(plain).not.toContain('k interrupt')
+    overlay.handleKey(text('m'))
+    overlay.handleKey(text('s'))
+    overlay.handleKey(text('k'))
+    expect(calls.message).toEqual([])
+    expect(calls.interrupt).toBe(0)
+  })
+
+  it('bounds every row at narrow and short geometries', () => {
+    const { overlay } = inspector({
+      reading: () => ({
+        kind: 'ready',
+        events: [message(1, 'a very long conversation body that must wrap and never leak a row 标签')],
+        hasOlder: false,
+        stale: false,
+      }),
+    })
+    for (const columns of [14, 18, 24, 30, 40, 60, 80]) {
+      for (const rows of [3, 5, 7, 8, 10, 12, 24]) {
+        expect(physicalRows(overlay.render(columns, rows), columns).length).toBeLessThanOrEqual(rows)
+      }
+    }
+  })
+})
+
+describe('subagent message composer', () => {
+  function composer(
+    submit: (
+      value: string,
+      signal: AbortSignal,
+    ) => Promise<{ kind: 'accepted'; messageId: string } | { kind: 'failed'; message: string } | { kind: 'unavailable' }>,
+  ) {
+    const accepted: string[] = []
+    let closes = 0
+    const overlay = createSubagentMessageOverlay({
+      childLabel: 'review',
+      delivery: 'queue',
+      submit,
+      onAccepted: id => { accepted.push(id) },
+      close: () => { closes += 1 },
+      invalidate: () => {},
+    })
+    return { overlay, accepted, closes: () => closes }
+  }
+
+  it('edits through the renderer Composer and submits on Enter', async () => {
+    const requests: string[] = []
+    const { overlay } = composer(async value => {
+      requests.push(value)
+      return { kind: 'accepted', messageId: 'm-1' }
+    })
+    overlay.handleKey(text('h'))
+    overlay.handleKey(text('i'))
+    expect(stripAnsi(overlay.render(80, 12).join('\n'))).toContain('❯ hi')
+    overlay.handleKey(key('enter'))
+    await flush()
+    expect(requests).toEqual(['hi'])
+  })
+
+  it('keeps the draft until Harness accepts, then clears and closes', async () => {
+    let resolve: ((outcome: { kind: 'accepted'; messageId: string }) => void) | undefined
+    const { overlay, accepted, closes } = composer(() => new Promise(resolvePromise => { resolve = resolvePromise }))
+    overlay.handleKey(text('h'))
+    overlay.handleKey(text('i'))
+    overlay.handleKey(key('enter'))
+    expect(stripAnsi(overlay.render(80, 12).join('\n'))).toContain('❯ hi')
+    expect(closes()).toBe(0)
+    resolve?.({ kind: 'accepted', messageId: 'm-9' })
+    await flush()
+    expect(accepted).toEqual(['m-9'])
+    expect(closes()).toBe(1)
+  })
+
+  it('keeps the draft and shows Harness’s reason after a refusal', async () => {
+    const { overlay, closes } = composer(async () => ({
+      kind: 'failed', message: 'subagent/not-resumable: no continuation state',
+    }))
+    overlay.handleKey(text('h'))
+    overlay.handleKey(key('enter'))
+    await flush()
+    const plain = stripAnsi(overlay.render(80, 12).join('\n'))
+    expect(plain).toContain('not-resumable')
+    expect(plain).toContain('❯ h')
+    expect(closes()).toBe(0)
+  })
+
+  it('aborts an in-flight submission when the surface is disposed', () => {
+    const signals: AbortSignal[] = []
+    const { overlay } = composer((_value, signal) => {
+      signals.push(signal)
+      return new Promise(() => {})
+    })
+    overlay.handleKey(text('h'))
+    overlay.handleKey(key('enter'))
+    overlay.dispose?.()
+    expect(signals[0]?.aborted).toBe(true)
+  })
+})
+
+describe('subagent conversation presenter', () => {
+  function mount(overrides: Partial<SubagentsPresenterDeps> = {}) {
+    const slots = testSlots()
+    const subagents = new FakeSubagent()
+    const session = new FakeSession()
+    const interrupts: { childId: string; authorized: boolean }[] = []
+    let lifecycle: (() => void) | undefined
+    let sessionEvent: ((sessionId: string) => void) | undefined
+    const p = createSubagentsPresenter({
+      slots,
+      parentSessionId: 'parent' as never,
+      invalidate: () => {},
+      subagents,
+      query: session,
+      interrupt: (childId, authorized) => {
+        interrupts.push({ childId, authorized })
+        return { kind: 'requested', message: 'Interrupt requested.' }
+      },
+      onLifecycle: listener => { lifecycle = listener; return () => {} },
+      onSessionEvent: listener => { sessionEvent = listener; return () => {} },
+      ...overrides,
+    })
+    return {
+      slots, subagents, session, interrupts, p,
+      fireLifecycle: () => { lifecycle?.() },
+      fireSessionEvent: (id: string) => { sessionEvent?.(id) },
+    }
+  }
+
+  it('reads a child transcript only when the inspector opens', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    session.setLog('c', [message(1, 'hello'), message(2, 'again')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('down'))
+    slots.top()?.handleKey(key('up'))
+    expect(session.listEventsCalls).toEqual([])
+    expect(session.readEventCalls).toEqual([])
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    expect(session.listEventsCalls.map(String)).toEqual(['c'])
+    expect(session.readEventCalls).toHaveLength(1)
+    expect(session.readEventCalls[0]?.request.before).toBe(TRANSCRIPT_PAGE - 1)
+  })
+
+  it('aborts an inspector’s in-flight read when it closes', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    session.holdReads()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    const signal = session.readEventCalls[0]?.signal
+    expect(signal?.aborted).toBe(false)
+    slots.top()?.handleKey(key('escape'))
+    expect(signal?.aborted).toBe(true)
+  })
+
+  it('discards a transcript read that a newer refresh superseded', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    session.setLog('c', [message(1, 'old')])
+    p.open()
+    await flush()
+    session.holdReads()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    // The log grows, then a second refresh starts. The FIRST read (seq 1)
+    // settles last and must not overwrite the newer window.
+    session.setLog('c', [message(1, 'old'), message(2, 'new')])
+    slots.top()?.handleKey(text('r'))
+    await flush()
+    session.releaseRead(1)
+    await flush()
+    session.releaseRead(0)
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).toContain('new')
+  })
+
+  it('keeps a settled child listed after a lifecycle edge reloads discovery', async () => {
+    const { slots, subagents, p, fireLifecycle } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    p.open()
+    await flush()
+    subagents.setChildren([child('c', 'continuable', 'inactive')])
+    fireLifecycle()
+    await flush()
+    expect(stripAnsi(slots.overlays[0]?.render(80, 20).join('\n') ?? '')).toContain('stored')
+  })
+
+  it('queues a follow-up through the human prompt authority with the exact address', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running', 'review')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    slots.top()?.handleKey(text('m'))
+    slots.top()?.handleKey(text('h'))
+    slots.top()?.handleKey(text('i'))
+    slots.top()?.handleKey(key('enter'))
+    const call = subagents.promptCalls[0]
+    expect(call?.request).toMatchObject({
+      parentSessionId: 'parent',
+      childSessionId: 'c',
+      mode: 'continuable',
+      delivery: 'queue',
+      content: [{ type: 'text', text: 'hi' }],
+    })
+    expect(typeof call?.request.requestId).toBe('string')
+    expect(call?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('steers with delivery steer and never claims the child is running', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running', 'review')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).not.toContain('running')
+    slots.top()?.handleKey(text('s'))
+    slots.top()?.handleKey(text('h'))
+    slots.top()?.handleKey(key('enter'))
+    expect(subagents.promptCalls[0]?.request.delivery).toBe('steer')
+  })
+
+  it('shows an accepted receipt without inserting an optimistic row', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    const before = session.readEventCalls.length
+    slots.top()?.handleKey(text('m'))
+    slots.top()?.handleKey(text('z'))
+    slots.top()?.handleKey(key('enter'))
+    subagents.accept()
+    await flush()
+    const plain = stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')
+    expect(plain).toContain('Follow-up accepted')
+    expect(plain).not.toContain('z')
+    expect(session.readEventCalls.length).toBe(before)
+  })
+
+  it('interrupts through the shared adapter with continuable authorization', async () => {
+    const { slots, subagents, session, interrupts, p } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    slots.top()?.handleKey(text('k'))
+    expect(interrupts).toEqual([{ childId: 'c', authorized: true }])
+  })
+
+  it('offers no interrupt for a one-shot child', async () => {
+    const { slots, subagents, session, interrupts, p } = mount()
+    subagents.setChildren([child('one', 'one-shot', 'inactive')])
+    session.setLog('one', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    slots.top()?.handleKey(text('k'))
+    expect(interrupts).toEqual([])
+  })
+
+  it('degrades honestly when ctx.subagents is absent', async () => {
+    const { slots, p } = mount({ subagents: undefined })
+    p.open()
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 20).join('\n') ?? '')).toContain('not installed')
+  })
+
+  it('degrades honestly when ctx.sessionQuery is absent', async () => {
+    const { slots, subagents, p } = mount({ query: undefined })
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 20).join('\n') ?? '')).toContain('Session query is not installed')
+  })
+
+  it('performs no discovery or transcript read on a timer', async () => {
+    vi.useFakeTimers()
+    try {
+      const { subagents, session, p } = mount()
+      subagents.setChildren([child('c', 'continuable', 'running')])
+      session.setLog('c', [message(1, 'hello')])
+      p.open()
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(subagents.listCalls).toHaveLength(1)
+      expect(session.listEventsCalls).toEqual([])
+      expect(session.readEventCalls).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('records staleness on a selected child event without re-reading', async () => {
+    const { slots, subagents, session, p, fireSessionEvent } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    const reads = session.readEventCalls.length
+    const beforeStale = stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')
+    expect(beforeStale).not.toContain('new events')
+    fireSessionEvent('c')
+    fireSessionEvent('unrelated')
+    expect(session.readEventCalls.length).toBe(reads)
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).toContain('new events')
+  })
+
+  it('refreshes an open inspector’s residency facts after a discovery reload', async () => {
+    const { slots, subagents, session, p, fireLifecycle } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).toContain('resident')
+    subagents.setChildren([child('c', 'continuable', 'inactive')])
+    fireLifecycle()
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).toContain('stored')
+  })
+
+  it('degrades honestly when discovery rejects', async () => {
+    const { slots, subagents, p } = mount()
+    subagents.failList(new Error('projection registry unavailable'))
+    p.open()
+    await flush()
+    const plain = stripAnsi(slots.top()?.render(80, 20).join('\n') ?? '')
+    expect(plain).toContain('Discovery failed')
+    expect(plain).toContain('projection registry unavailable')
+  })
+
+  it('never opens a diagnostic row and reads nothing for it', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([diagnostic('broken', 'corrupt')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    expect(session.listEventsCalls).toEqual([])
+    expect(slots.overlays).toHaveLength(1)
+  })
+
+  it('pops exactly one surface per escape, back to the prior catalog', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([child('c', 'continuable', 'running')])
+    session.setLog('c', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    expect(slots.overlays).toHaveLength(2)
+    slots.top()?.handleKey(key('escape'))
+    expect(slots.overlays).toHaveLength(1)
+    expect(stripAnsi(slots.top()?.render(80, 20).join('\n') ?? '')).toContain('Subagent conversations')
+    slots.top()?.handleKey(key('escape'))
+    expect(slots.overlays).toHaveLength(0)
+  })
+
+  it('offers no follow-up composer for a one-shot child', async () => {
+    const { slots, subagents, session, p } = mount()
+    subagents.setChildren([child('one', 'one-shot', 'inactive')])
+    session.setLog('one', [message(1, 'hello')])
+    p.open()
+    await flush()
+    slots.top()?.handleKey(key('enter'))
+    await flush()
+    expect(stripAnsi(slots.top()?.render(80, 24).join('\n') ?? '')).not.toContain('m message')
+    slots.top()?.handleKey(text('m'))
+    expect(slots.overlays).toHaveLength(2)
+  })
+})

--- a/packages/dshline/tests/work.spec.ts
+++ b/packages/dshline/tests/work.spec.ts
@@ -481,6 +481,30 @@ describe('the Work live-region overlay', () => {
     expect(continuable.render(80, 12).map(stripAnsi).join('\n')).not.toContain('k stop')
   })
 
+  it('hands the durable conversation catalog off only when the seam is mounted', () => {
+    let opened = 0
+    const withCatalog = createWorkOverlay({
+      snapshot: () => ({ ...EMPTY, available: true, subagents: [subagentItem()] }),
+      interrupt: () => INTERRUPT_REQUESTED,
+      conversations: () => { opened += 1 },
+      close: () => {},
+      invalidate: () => {},
+    })
+    expect(withCatalog.render(80, 12).map(stripAnsi).join('\n')).toContain('c conversations')
+    withCatalog.handleKey({ kind: 'text', text: 'c' })
+    expect(opened).toBe(1)
+
+    const without = createWorkOverlay({
+      snapshot: () => ({ ...EMPTY, available: true, subagents: [subagentItem()] }),
+      interrupt: () => INTERRUPT_REQUESTED,
+      close: () => {},
+      invalidate: () => {},
+    })
+    expect(without.render(80, 12).map(stripAnsi).join('\n')).not.toContain('c conversations')
+    without.handleKey({ kind: 'text', text: 'c' })
+    expect(opened).toBe(1)
+  })
+
   it('opens a detail stage on Enter and returns with Esc and Esc close', () => {
     let closed = 0
     const snapshot: WorkSnapshot = { ...EMPTY, available: true, subagents: [subagentItem({ label: '审查 renderer', mode: 'continuable', hasChildren: true })], jobs: [] }


### PR DESCRIPTION
## What this adds

A user can find a durable subagent child of the attached session, inspect its conversation, and continue a continuable child through Harness — without `/work` pretending a settled child is active work.

- `/work` → `c` (or `/subagents`) opens a durable **direct-child catalog** from `ctx.subagents.listChildren`.
- Opening a child reads its own session log through `ctx.sessionQuery` (`listEvents` + a bounded `readEvent` window) and renders it with Harness's `extractSessionEventText`. The child is never resumed or published to inspect it.
- A continuable child gets `m` (human follow-up, `delivery: 'queue'`) and `s` (steer, `delivery: 'steer'`). A one-shot child is inspectable and read-only.

## Authority boundary

Harness owns capabilities, lifecycle, persistence, authorization, scheduling, and child conversations; Dshline owns terminal presentation.

| Fact/action | Authority | Dshline adapter | Presentation |
| --- | --- | --- | --- |
| child discovery | `ctx.subagents.listChildren` | `subagents/presenter.ts` (generation-guarded) | catalog overlay |
| transcript inspection | `ctx.sessionQuery.listEvents`/`readEvent` | `subagents/transcript.ts` (one bounded page) | conversation inspector |
| queue follow-up | `ctx.subagents.prompt(delivery:'queue')` | `subagents/control.ts` | message composer (renderer `Composer`) |
| steer | `ctx.subagents.prompt(delivery:'steer')` | same adapter | same composer |

`SubagentRuntime.sendMessage` is model-authored and is not used; `HumanSubagentSeam` is a `Pick` of `SubagentRuntime` with only `listChildren` and `prompt`, so a cast-free call to `sendMessage` is a `pnpm typecheck` failure. A comment/string-aware source scan and a dependency-boundary test backstop it.

**Interrupt is deliberately not part of the durable inspector.** `listChildren().activity` is session-store residency, not proof that a turn is executing, and Harness's `interrupt()` treats an absent or already-settled target as an accepted no-op — so offering the action here could print `Interrupt requested.` for a cancellation that never happened. Interrupt stays on `/work`, where an open lifecycle epoch is the stronger premise, through its existing adapter; this change no longer modifies `work/index.ts`.

## Bounds and behavior

- **Transcript** — paging older history REPLACES the loaded window, so presenter state holds at most one page (`TRANSCRIPT_PAGE = 24`) of full event bodies however far the reader pages back. The lightweight seq index is metadata, not bodies; `readSession` is never reachable through the seam. A regression pages through a log five times the page size and asserts the bound, no duplicates, correct `hasOlder`, and per-read window bounds.
- **Composer** — the child message overlay shares the primary composer's cursor-following window via a new internal `cursorWindow` helper (`scroll.ts`), so a long or multiline draft scrolls with the cursor; `↑`/`↓` move the buffer cursor through the layout the rows were drawn from.
- **Staleness** — an inspector-local event generation is captured before each read and re-applied when it settles, so an event that arrives mid-read (including during the first `loading` read) is preserved as `new events · r refresh` instead of being overwritten by the read's `stale:false`. The read-generation guard still discards a superseded read.
- **Chrome** — the new surfaces' footers use width-stable ASCII (`^v`, `enter`) rather than the East Asian Ambiguous `↑↓`/`↵`, whose terminal width can wrap the bottom border one physical row and leave a stray corner in scrollback.

## Controls

- **Queue** is an ordinary later turn; **steer** targets the nearest step and starts a turn when the child is idle — exactly Harness's `Agent.followup`/`Agent.steer`. The gesture picks the delivery; observed activity never does.
- One-shot and diagnostic children offer no actions; a diagnostic row is shown honestly rather than dropped.
- Profiles without `ctx.subagents` or `ctx.sessionQuery` boot; Work hides `c` and `/subagents` reports the absence honestly.

## Tests

New: `subagent-conversations.spec.ts` (discovery, on-demand reads, queue/steer, bounded paging, cursor-following composer, mid-read staleness, capability absence, no timer polling, no optimistic rows), `subagent-conversations-frames.spec.ts` (real `@xterm/headless`: committed scrollback unchanged, one frame, widened-arrow footer regression), `subagent-conversations-architecture.spec.ts` (seam/dependency guard), plus a Work `c` hand-off test and a real-runtime `prompt` assertion in the subagents capability probe.

Deliberate mistakes each failed the intended test and were restored: follow-up via `sendMessage`; settled child disappearing; one-shot follow-up; reads on selection movement; optimistic insertion; unescaped discovery error; missing read-generation guard; transcript accumulation; composer top-slice; and ambiguous-arrow footers.

Focused suites: 208 passed. Full suite: 3459 passed, 22 skipped. `pnpm build`, `pnpm typecheck`, `pnpm security`, `pnpm verify-docs` green.

## Known limits

- The adopted generation documents `prompt` as the browser control surface; it is a public in-process method (Harness's own tests call it directly) and requires a live parent Agent. If a future generation makes it private/Remote-only, Dshline should request a durable-parent-addressed human control seam upstream rather than use private symbols.
- `listChildren` is live-only without a persistence backend, so cold children are unreachable there — capability absence, not an error.
- Direct children only; starting new subagents and descendant navigation are out of scope (`hasChildren` is shown as a fact).
- Text-only follow-up; no image staging.
- Older Dshline surfaces (`/work`, sessions, tool output, and others) also use `↑↓` in footers and share the ambiguous-width exposure; fixing them is a separate follow-up, not this PR.

## Upstream note

Current Harness `master` is many commits ahead of the adopted target and includes production-code changes elsewhere. What is relevant here: the adopted `packages/subagent/subagent/src/index.ts` and the relevant `packages/session-query/**` implementation are byte-identical to current `master`, so there is no directional contract change in the seams this PR consumes. `HARNESS_TARGET` remains authoritative.
